### PR TITLE
Initialize .gitignore with Java, Kotlin, Gradle, and Go rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ go.work.sum
 
 # Gradle (multi-module)
 .gradle/
+build/
 */build/
 !*/src/*/build/
 !gradle-wrapper.jar


### PR DESCRIPTION
Initialize the project’s .gitignore using consolidated templates from https://github.com/github/gitignore, combining the standard rules for:

- Java
- Kotlin
- Gradle
- Go
