### PR TITLE
scope website deploy workflow to website and workflow changes

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+    paths:
+      - "website/**"
+      - "CNAME"
+      - ".github/workflows/deploy-website.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Restrict the website deployment workflow to run only when relevant files change.

- Trigger deployment only on changes under `website/**`
- Include `CNAME` updates
- Run when the deployment workflow itself is modified
- Keep deployment scoped to pushes on `main`

This reduces unnecessary CI runs and makes the deployment behavior clearer.