### PR TITLE
Exempt Dependabot and GitHub Actions from CLA checks

### DIFF
--- a/.github/cla.yml
+++ b/.github/cla.yml
@@ -1,3 +1,0 @@
-exempt:
-  - dependabot[bot]
-  - github-actions[bot]


### PR DESCRIPTION
This reverts commit f47d805c51e90b2f09f5835b0b345e938135a066.

This was not the correct solution for the CLA issue.
The issue was resolved via the GitHub App configuration, as confirmed in #18.
