### PR TITLE
Add "Documentation" link to site social icons

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -69,6 +69,7 @@ export default defineConfig({
 				baseUrl: 'https://github.com/kakao/actionbase/edit/main/website/',
 			},
 			social: [
+				{ icon: 'document', label: 'Documentation', href: '/introduction/' },
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/kakao/actionbase' },
 			],
 			head: [


### PR DESCRIPTION
This adds a "Documentation" link to the site social icons to provide a clear path back to the docs for users entering through the blog.

The `Docs | Blog` navigation option, which would be the ideal solution, was discussed in HiDeoo/starlight-blog#190 but confirmed as not applicable for now. The guidance and considerations shared there informed this approach.

This is the most reasonable option given the current constraints.

The screenshot below shows the added Documentation link.

<img width="200" height="42" alt="image" src="https://github.com/user-attachments/assets/700be4a5-1da4-40b7-865c-536a119cf918" />
