### PR TITLE
Add root (/) endpoint with basic status response

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/RootController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/RootController.kt
@@ -1,31 +1,33 @@
 package com.kakao.actionbase.server.api
 
-import org.springframework.boot.info.BuildProperties
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RestController
-import reactor.core.publisher.Mono
 import java.time.Clock
 import java.time.Instant
 
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
 @RestController
 class RootController(
-    @Autowired(required = false) private val buildProperties: BuildProperties?
+    @Autowired(required = false) private val buildProperties: BuildProperties?,
 ) {
-
     @GetMapping("/")
     fun root(): Mono<ResponseEntity<Map<String, String>>> {
         val version = buildProperties?.version ?: "unknown"
         val timestamp = Instant.now(Clock.systemUTC()).toString()
-        
-        val response = mapOf(
-            "status" to "UP",
-            "message" to "Actionbase is running",
-            "version" to version,
-            "timestamp" to timestamp
-        )
-        
+
+        val response =
+            mapOf(
+                "status" to "UP",
+                "message" to "Actionbase is running",
+                "version" to version,
+                "timestamp" to timestamp,
+            )
+
         return Mono.just(ResponseEntity.ok(response))
     }
 }


### PR DESCRIPTION
- Fixes #25 
## Summary of Changes

### Added `RootController.kt`
- Added a new controller to handle `GET /` requests.
- Returns a lightweight JSON response containing:
  1. Service status
  2. Current version
  3. Timestamp
