### PR TITLE
Exclude guides directory from linguistic analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 dev/** linguist-vendored
 website/** linguist-vendored
-
+guides/** linguist-vendored


### PR DESCRIPTION
As discussed in #3, we are updating `.gitattributes` to exclude the `guides` directory from linguistic analysis.