### PR TITLE
Minimal local run scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Local runtime artifacts
+.run/

--- a/bin/run_local.sh
+++ b/bin/run_local.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+PID=.run/actionbase.pid
+LOG=.run/logs/actionbase.log
+PORT=8080
+
+[ -f "$PID" ] && { echo "❌ failed: already running"; exit 1; }
+
+mkdir -p .run/logs
+
+./gradlew :server:bootRun > "$LOG" 2>&1 &
+echo $! > "$PID"
+
+until nc -z localhost $PORT; do sleep 1; done
+
+echo "✅ Actionbase server started on $PORT 🚀"
+echo "log: $LOG"
+echo "pid: $PID"

--- a/bin/stop_local.sh
+++ b/bin/stop_local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+PID=.run/actionbase.pid
+
+[ ! -f "$PID" ] && { echo "❌ failed: not running"; exit 1; }
+
+kill "$(cat "$PID")"
+rm "$PID"
+
+echo "✅ Actionbase server stopped"
+echo "pid: $PID"


### PR DESCRIPTION
Add minimal local run scripts for Actionbase.

- Ignore `.run/` in `.gitignore`
- Provide `run_local.sh` and `stop_local.sh`
- Prevent duplicate runs using a PID file
- Wait for port 8080 before reporting startup success
- Store logs and PID under `.run/`
- Keep output limited to success/failure, log path, and PID path

There is room for further improvement, but this keeps it minimal for now.