### PR TITLE
Exclude files and directories generated by AI tools.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,11 +57,25 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-.env
 .env.production
-
-# macOS-specific files
-.DS_Store
 
 # Local runtime artifacts
 .run/
+
+# AI Coding Assistants (any depth)
+
+## Claude Code
+**/.claude/*
+!**/.claude/
+!**/.claude/CLAUDE.md
+!**/.claude/README.md
+
+## OpenAI Codex
+**/.codex/
+**/.codex-cache/
+
+## Cursor
+**/.cursor/*
+!**/.cursor/
+!**/.cursor/rules/
+!**/.cursor/rules/**


### PR DESCRIPTION
This updates `.gitignore` to exclude files and directories generated by AI-assisted coding tools.

The change is limited to the following:

- Ignoring local artifacts produced by AI-assisted coding tools, including:
  - Claude Code
  - OpenAI Codex
  - Cursor
- Preserving explicitly documented configuration files where applicable.
- Removing redundant or duplicated ignore entries.

Whether AI-generated code should be accepted as project contributions is intentionally left for future discussion.

At this time, contributions are considered acceptable when the code is ultimately authored, reviewed, and approved by a human contributor, even if AI tools were used to assist during development.