### PR TITLE
Add .prettierignore to exclude build output

### DIFF
--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,0 +1,9 @@
+# Build output
+dist/
+.astro/
+
+# Dependencies
+node_modules/
+
+# Cache
+.cache/


### PR DESCRIPTION
## Summary

This PR addresses the concern raised in #47 about dist files being checked by Prettier after build.

## Changes

- Added `.prettierignore` file to exclude build output directories
- Excludes: `dist/`, `.astro/`, `node_modules/`, `.cache/`

## Testing

- Verified with `npm run format:check` - all checks pass
- Build output directories are now properly excluded from Prettier checks

## Related

- Related to #47