### PR TITLE
Download preset from release assets by default

### DIFF
--- a/cli/internal/command/load.go
+++ b/cli/internal/command/load.go
@@ -380,7 +380,7 @@ func (l *Load) loadPreset(presetName, refs string) *model.Response {
 	if refs != "" {
 		url = "https://raw.githubusercontent.com/kakao/actionbase/" + refs + "/examples/presets/" + filename
 	} else {
-		url = "https://raw.githubusercontent.com/kakao/actionbase/examples/presets/" + filename
+		url = "https://github.com/kakao/actionbase/releases/download/examples/" + filename
 	}
 
 	ok := util.Download(filename, url)


### PR DESCRIPTION
## Summary

As discussed in https://github.com/kakao/actionbase/issues/56#issuecomment-3767247758, this updates the `load` command to download preset data from release assets by default when the `refs` argument is omitted.

## Changes

- Download preset data from release assets by default

## How to Test

```shell
$ cd cli && make run

actionbase> load preset database_social
Downloading file from https://github.com/kakao/actionbase/releases/download/examples/database_social.txt
Successfully downloaded file
Database 'social' is created
(Took 0.4517 seconds)
```
