### PR TITLE
Update security vulnerability reporting method

### DIFF
--- a/website/src/content/docs/community/contributing.mdx
+++ b/website/src/content/docs/community/contributing.mdx
@@ -23,7 +23,7 @@ When submitting a pull request, please sign the [CLA](https://cla-assistant.io/k
 
 ## Security
 
-Report security vulnerabilities to [mskim@apache.org](mailto:mskim@apache.org) instead of opening a public issue.
+Report security vulnerabilities through [GitHub Security Advisories](https://github.com/kakao/actionbase/security/advisories/new) instead of opening a public issue.
 
 ## Community standards
 


### PR DESCRIPTION
## Summary

Update the security vulnerability reporting method from email to GitHub Security Advisories.                                                                                                             

## Changes

- Changed security reporting link from email to GitHub Security Advisories                                                                                                              
  
## How to Test

- Visit the contributing documentation page and verify the security section links to GitHub Security Advisories