### PR TITLE
Invite feedback in GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We collaborate through [GitHub](https://github.com/kakao/actionbase):
 - **[Issues](https://github.com/kakao/actionbase/issues)**: Bug reports, feature requests, and concrete improvements
 - **[Pull Requests](https://github.com/kakao/actionbase/pulls)**: Code and documentation changes
 
-If you're unsure where something belongs or have a question, start with a Discussion.
+For questions, ideas, or feedback, join us on [Discussions](https://github.com/kakao/actionbase/discussions).
 
 Pull requests are reviewed collaboratively and merged by Maintainers.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Early open-source preparation phase. The first release focuses on introducing co
 
 We welcome contributions. See our [Contributing Guide](https://actionbase.io/community/contributing/).
 
-For questions, feedback, or discussion, join us on [GitHub Discussions](https://github.com/kakao/actionbase/discussions/).
+For questions, ideas, or feedback, join us on [GitHub Discussions](https://github.com/kakao/actionbase/discussions/).
 
 ## Learn More
 

--- a/website/src/content/docs/community/contributing.mdx
+++ b/website/src/content/docs/community/contributing.mdx
@@ -19,7 +19,7 @@ We collaborate through [GitHub](https://github.com/kakao/actionbase):
 - **[Issues](https://github.com/kakao/actionbase/issues)**: Bug reports, feature requests, and concrete improvements
 - **[Pull Requests](https://github.com/kakao/actionbase/pulls)**: Code and documentation changes
 
-If you're unsure where something belongs or have a question, start with a Discussion.
+For questions, ideas, or feedback, join us on [Discussions](https://github.com/kakao/actionbase/discussions).
 
 Pull requests are reviewed collaboratively and merged by Maintainers.
 


### PR DESCRIPTION
## Summary

Explicitly invite feedback in documentation to encourage community participation.

## Changes

-  Unified wording across README.md, CONTRIBUTING.md, and contributing.mdx

## How to Test

N/A

