### PR TITLE
Introduce `.preset.yaml` in `load preset` command

### DIFF
--- a/cli/internal/command/load.go
+++ b/cli/internal/command/load.go
@@ -334,7 +334,7 @@ func (l *Load) loadPreset(filename, refs string) *model.Response {
 		return model.Fail("invalid preset filename")
 	}
 
-	cleanedFilename := filepath.Clean(filename)
+	cleanedFilename := filepath.Clean(filename) + ".preset.yaml"
 
 	var url string
 	if refs != "" {


### PR DESCRIPTION
## Summary
As discussed in #72, this added the `.preset.yaml` suffix to the `load preset` command.

Closes #72 

## Changes

- The `load preset <name>` command now downloads `<name>.preset.yaml`.

## How to Test
```shell
$ cd cli && make run

actionbase> load preset build-your-social-app
Downloading file from https://github.com/kakao/actionbase/releases/download/examples/build-your-social-app.preset.yaml
Successfully downloaded file
...
```


