### PR TITLE
Disable provenance for standalone image for buildx

### DIFF
--- a/.github/workflows/standalone-image.yml
+++ b/.github/workflows/standalone-image.yml
@@ -78,3 +78,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false


### PR DESCRIPTION
## Summary

-  Disable provenance attestation for standalone image buildx push.

## Changes

- Add provenance: false to standalone-image workflow

## How to Test

- Push tag standalone/* or run workflow manually.
