### PR TITLE
Add proxy mode support to standalone CLI entrypoint

### DIFF
--- a/docker/standalone/docker-entrypoint.sh
+++ b/docker/standalone/docker-entrypoint.sh
@@ -42,5 +42,5 @@ if [ $ELAPSED -ge $MAX_WAIT_SECONDS ]; then
     exit 1
 fi
 
-# Start CLI in foreground
-actionbase --host "${SERVER_URL}"
+# Start CLI in foreground with proxy mode
+actionbase --host "${SERVER_URL}" --proxy "$@"


### PR DESCRIPTION
## Summary

Add proxy mode support to standalone CLI entrypoint

See https://github.com/kakao/actionbase/pull/81#issuecomment-3772195394

## Changes

- Add `--proxy` flag to standalone CLI entrypoint

## How to Test

N/A



