### PR TITLE
Add debug mode support to standalone CLI entrypoint

### DIFF
--- a/docker/standalone/docker-entrypoint.sh
+++ b/docker/standalone/docker-entrypoint.sh
@@ -42,5 +42,5 @@ if [ $ELAPSED -ge $MAX_WAIT_SECONDS ]; then
     exit 1
 fi
 
-# Start CLI in foreground with proxy mode
-actionbase --host "${SERVER_URL}" --proxy "$@"
+# Start CLI in foreground with proxy and debug mode
+actionbase --host "${SERVER_URL}" --proxy --debug "$@"


### PR DESCRIPTION
## Summary

Add debug mode support to standalone CLI entrypoint

Related to #85

## Changes

- Add `--debug` flag to standalone CLI entrypoint

## How to Test

N/A