### PR TITLE
Set correct ownership for /app directory in standalone Dockerfile

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -35,6 +35,7 @@ ENV AB_SERVER_PORT=8080
 EXPOSE 8080
 
 # Switch to non-root user
+RUN chown -R actionbase:actionbase /app
 USER actionbase
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Fix file write permission issue in standalone Docker container that prevented CLI `load preset` command from working.
                                                                                                                                                                                                                                                                                                                                     
## Changes                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                     
- Add `chown -R actionbase:actionbase /app` before switching to non-root user                                                                                                                                                                                                                                                     
- This grants the `actionbase` user write permission to download preset files                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                     
 ## How to Test                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                     
```bash                                                                                                                                                                                                                                                                                                                           
docker run -it ghcr.io/kakao/actionbase:standalone                                                                                                                                                                                                                                                                                
actionbase> load preset likes
```

It was

```bash
actionbase> load preset likes
Downloading file from https://github.com/kakao/actionbase/releases/download/examples/likes.preset.yaml
Failed to write file
Failed to download preset file
(Took 1.0051 seconds)
```