### PR TITLE
Ignore Claude Code config files for experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,10 @@ pnpm-debug.log*
 # AI Coding Assistants (any depth)
 
 ## Claude Code
-**/.claude/*
-!**/.claude/
-!**/.claude/CLAUDE.md
-!**/.claude/README.md
+# Currently ignored to allow testing from experiment branches (#91)
+# To test: git checkout exp/claude-code-setup -- .claude/ CLAUDE.md
+CLAUDE.md
+.claude/
 
 ## OpenAI Codex
 **/.codex/


### PR DESCRIPTION
## Summary

Ignore Claude Code configuration files to allow testing from experiment branches.

Preparation for #91

## Changes

- Ignore `CLAUDE.md` at root
- Ignore `.claude/` directory entirely

**Note**: Previously `.claude/CLAUDE.md` and `.claude/README.md` were allowed. Now the entire directory is ignored.

## How to Test

After merging, test Claude Code setup from experiment branch:

```bash
git checkout exp/claude-code-setup -- .claude/ CLAUDE.md
```

To get latest updates (the config is continuously evolving):

```bash
git fetch origin
git checkout origin/exp/claude-code-setup -- .claude/ CLAUDE.md
```