### PR TITLE
Add CLI documentation

### DIFF
--- a/website/src/content/docs/operations/cli.mdx
+++ b/website/src/content/docs/operations/cli.mdx
@@ -25,6 +25,7 @@ The Actionbase CLI provides an interactive console for managing databases, table
     ```
 
     This is sufficient for exploring Actionbase and understanding its core capabilities.
+
   </TabItem>
   <TabItem label="Homebrew">
     ```bash
@@ -40,6 +41,7 @@ The Actionbase CLI provides an interactive console for managing databases, table
     ```
 
     The binary is created at `cli/bin/actionbase`.
+
   </TabItem>
 </Tabs>
 
@@ -50,7 +52,8 @@ actionbase [options]
 ```
 
 <Aside type="tip">
-When using Docker standalone (`ghcr.io/kakao/actionbase:standalone`), the CLI starts with `--debug --proxy` enabled by default.
+  When using Docker standalone (`ghcr.io/kakao/actionbase:standalone`), the CLI starts with `--debug
+  --proxy` enabled by default.
 </Aside>
 
 ### Startup Options
@@ -425,7 +428,8 @@ actionbase(likes:likes)> mutate --type INSERT --source Charlie --target Phone --
 <Aside type="tip">
   Actionbase requires client-issued timestamps for [event ordering](/design/mutation/#event-ordering). Even if events arrive out of order, Actionbase uses these timestamps to compute the correct final state.
 
-  Use `$NOW` as a placeholder for the current Unix timestamp in milliseconds. It works in both `--version` and `--properties` values.
+Use `$NOW` as a placeholder for the current Unix timestamp in milliseconds. It works in both `--version` and `--properties` values.
+
 </Aside>
 
 ## Utility Commands


### PR DESCRIPTION
## Summary

Add comprehensive CLI documentation to replace the placeholder page.

Closes #70

## Changes

- Add complete command reference for all 14 CLI commands
- Document startup options (`--host`, `--authKey`, `--debug`, `--plain`, `--proxy`, `--version`)
- Add installation section with Docker, Homebrew, and source build tabs
- Document context management (`context`, `use`, `debug`)
- Document metadata operations (`create`, `show`, `desc`)
- Document data operations (`get`, `scan`, `count`, `mutate`)
- Document utility commands (`load`, `guide`, `help`, `exit`)
- Add common workflows section (Quick Start, Data Operations, Interactive Learning)
- Add reference tables (direction values, mutation types, context requirements)
- Add Preview badge to indicate CLI is in active development

## How to Test

1. Run the documentation site locally:
   ```bash
   cd website
   npm install
   npm run dev
   ```
2. Navigate to http://localhost:4321/operations/cli/
3. Verify all sections render correctly
4. Check that the Preview badge appears in the sidebar

---

Generated with [Claude Code](https://claude.com/claude-code)