### PR TITLE
Add groups field to Label descriptors

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
@@ -1,0 +1,168 @@
+package com.kakao.actionbase.v2.core.metadata;
+
+import com.kakao.actionbase.v2.core.code.hbase.ValueUtils;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Group implements Serializable {
+
+  @JsonIgnore final int code;
+
+  @JsonProperty("group")
+  final String group;
+
+  @JsonProperty("type")
+  final GroupType type;
+
+  @JsonProperty("fields")
+  final List<Field> fields;
+
+  @JsonProperty("valueField")
+  final String valueField;
+
+  @JsonProperty("comment")
+  final String comment;
+
+  @JsonProperty("directionType")
+  final DirectionType directionType;
+
+  @JsonProperty("ttl")
+  final long ttl;
+
+  @JsonCreator
+  public Group(
+      @JsonProperty("group") String group,
+      @JsonProperty("type") GroupType type,
+      @JsonProperty("fields") List<Field> fields,
+      @JsonProperty("valueField") String valueField,
+      @JsonProperty("comment") String comment,
+      @JsonProperty("directionType") DirectionType directionType,
+      @JsonProperty("ttl") Long ttl) {
+    this.code = ValueUtils.stringHash(group);
+    this.group = group;
+    this.type = type;
+    this.fields = fields;
+    this.valueField = valueField != null ? valueField : "-";
+    this.comment = comment != null ? comment : "";
+    this.directionType = directionType != null ? directionType : DirectionType.BOTH;
+    this.ttl = ttl != null ? ttl : -1L;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public GroupType getType() {
+    return type;
+  }
+
+  public List<Field> getFields() {
+    return fields;
+  }
+
+  public String getValueField() {
+    return valueField;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public DirectionType getDirectionType() {
+    return directionType;
+  }
+
+  public long getTtl() {
+    return ttl;
+  }
+
+  public static class Field implements Serializable {
+
+    @JsonProperty("name")
+    final String name;
+
+    @JsonCreator
+    public Field(@JsonProperty("name") String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String toString() {
+      return "Field{" + "name='" + name + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Field) {
+        Field other = (Field) obj;
+        return name.equals(other.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "Group{"
+        + "code="
+        + code
+        + ", group='"
+        + group
+        + '\''
+        + ", type="
+        + type
+        + ", fields="
+        + fields
+        + ", valueField='"
+        + valueField
+        + '\''
+        + ", comment='"
+        + comment
+        + '\''
+        + ", directionType="
+        + directionType
+        + ", ttl="
+        + ttl
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Group) {
+      Group other = (Group) obj;
+      return code == other.code
+          && group.equals(other.group)
+          && type == other.type
+          && fields.equals(other.fields)
+          && valueField.equals(other.valueField)
+          && comment.equals(other.comment)
+          && directionType == other.directionType
+          && ttl == other.ttl;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code, group, type, fields, valueField, comment, directionType, ttl);
+  }
+}

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/GroupType.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/GroupType.java
@@ -1,0 +1,6 @@
+package com.kakao.actionbase.v2.core.metadata;
+
+public enum GroupType {
+  SUM,
+  COUNT,
+}

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/LabelDTO.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/LabelDTO.java
@@ -36,6 +36,9 @@ public class LabelDTO implements Serializable {
   @JsonProperty("indices")
   final List<Index> indices;
 
+  @JsonProperty("groups")
+  final List<Group> groups;
+
   @JsonProperty("event")
   final boolean event;
 
@@ -56,6 +59,7 @@ public class LabelDTO implements Serializable {
       @JsonProperty("dirType") DirectionType dirType,
       @JsonProperty("storage") String storage,
       @JsonProperty("indices") List<Index> indices,
+      @JsonProperty("groups") List<Group> groups,
       @JsonProperty("event") boolean event,
       @JsonProperty("readOnly") boolean readOnly,
       @JsonProperty("mode") MutationMode mode) {
@@ -66,6 +70,7 @@ public class LabelDTO implements Serializable {
     this.dirType = dirType;
     this.storage = storage;
     this.indices = indices;
+    this.groups = groups;
     this.event = event;
     this.readOnly = readOnly;
     this.mode = mode;
@@ -74,7 +79,8 @@ public class LabelDTO implements Serializable {
   }
 
   public LabelDTO copy(String name, String storage) {
-    return new LabelDTO(name, desc, type, schema, dirType, storage, indices, event, readOnly, mode);
+    return new LabelDTO(
+        name, desc, type, schema, dirType, storage, indices, groups, event, readOnly, mode);
   }
 
   public String getName() {
@@ -103,6 +109,10 @@ public class LabelDTO implements Serializable {
 
   public List<Index> getIndices() {
     return indices;
+  }
+
+  public List<Group> getGroups() {
+    return groups;
   }
 
   public boolean isEvent() {

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
@@ -34,6 +34,7 @@ public class LabelDTOTests {
                 new Index(
                     "created_at",
                     Collections.singletonList(new Index.Field("created_at", Order.DESC)))),
+            Collections.emptyList(),
             false,
             false,
             MutationMode.ASYNC);
@@ -41,7 +42,7 @@ public class LabelDTOTests {
     String jsonString = objectMapper.writeValueAsString(label);
 
     assertEquals(
-        "{\"name\":\"test.test\",\"desc\":\"desc\",\"type\":\"INDEXED\",\"schema\":{\"src\":{\"type\":\"LONG\",\"desc\":\"\"},\"tgt\":{\"type\":\"STRING\",\"desc\":\"\"},\"fields\":[{\"name\":\"created_at\",\"type\":\"LONG\",\"nullable\":false,\"desc\":\"\"}]},\"dirType\":\"BOTH\",\"storage\":\"test_storage\",\"indices\":[{\"name\":\"created_at\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}],\"desc\":\"\"}],\"event\":false,\"readOnly\":false,\"mode\":\"ASYNC\"}",
+        "{\"name\":\"test.test\",\"desc\":\"desc\",\"type\":\"INDEXED\",\"schema\":{\"src\":{\"type\":\"LONG\",\"desc\":\"\"},\"tgt\":{\"type\":\"STRING\",\"desc\":\"\"},\"fields\":[{\"name\":\"created_at\",\"type\":\"LONG\",\"nullable\":false,\"desc\":\"\"}]},\"dirType\":\"BOTH\",\"storage\":\"test_storage\",\"indices\":[{\"name\":\"created_at\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}],\"desc\":\"\"}],\"groups\":[],\"event\":false,\"readOnly\":false,\"mode\":\"ASYNC\"}",
         jsonString);
   }
 

--- a/core-java/src/main/java/com/kakao/actionbase/core/java/metadata/v2/LabelDescriptor.java
+++ b/core-java/src/main/java/com/kakao/actionbase/core/java/metadata/v2/LabelDescriptor.java
@@ -7,6 +7,7 @@ import com.kakao.actionbase.core.java.metadata.v3.EdgeTableDescriptor;
 import com.kakao.actionbase.core.java.metadata.v3.ImmutableEdgeTableDescriptor;
 import com.kakao.actionbase.core.java.metadata.v3.TableDescriptor;
 import com.kakao.actionbase.core.java.metadata.v3.common.DirectionType;
+import com.kakao.actionbase.core.metadata.common.Group;
 
 import java.util.List;
 
@@ -35,6 +36,8 @@ public interface LabelDescriptor extends Descriptor<TableDescriptor<?>> {
   String storage();
 
   List<Index> indices();
+
+  List<Group> groups();
 
   List<TopNCompositeKey> topNCompositeKeys();
 

--- a/core/src/main/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelDescriptor.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelDescriptor.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.core.v2.metadata
 
 import com.kakao.actionbase.core.metadata.common.DirectionType
+import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.v2.metadata.common.V2Identifier
 import com.kakao.actionbase.core.v2.metadata.common.V2Index
 import com.kakao.actionbase.core.v2.metadata.common.V2MutationMode
@@ -17,6 +18,7 @@ data class V2LabelDescriptor(
     val dirType: DirectionType,
     val storage: String,
     val indices: List<V2Index>,
+    val groups: List<Group>,
     val event: Boolean,
     val readOnly: Boolean,
     val mode: V2MutationMode,

--- a/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelSerializationTest.kt
@@ -84,6 +84,7 @@ class V2LabelSerializationTest {
                             desc = "Wish creation time descending index",
                         ),
                     ),
+                groups = emptyList(),
                 event = false,
                 readOnly = false,
                 mode = V2MutationMode.SYNC,
@@ -141,6 +142,7 @@ class V2LabelSerializationTest {
                   "desc": "Wish creation time descending index"
                 }
               ],
+              "groups": [],
               "event": false,
               "readOnly": false,
               "mode": "SYNC"
@@ -218,6 +220,7 @@ class V2LabelSerializationTest {
                   "desc": "Wish creation time descending index"
                 }
               ],
+              "groups": [],
               "event": false,
               "readOnly": false,
               "mode": "SYNC"
@@ -288,6 +291,7 @@ class V2LabelSerializationTest {
                             desc = "Wish creation time descending index",
                         ),
                     ),
+                groups = emptyList(),
                 event = false,
                 readOnly = false,
                 mode = V2MutationMode.SYNC,


### PR DESCRIPTION
## Summary

Add groups field to LabelDescriptor, V2LabelDescriptor, and LabelDTO to align schema with LabelCreatePayload and LabelUpdatePayload.

## Changes
- Add List<Group> groups() to LabelDescriptor (core-java)
- Add groups: List<Group> to V2LabelDescriptor (core)
- Add List<Group> groups to LabelDTO (codec-java)
- Create Group and GroupType classes for codec-java module
- Update related tests to include groups field

## How to Test
```bash
$ ./gradlew test
```

