### PR TITLE
Bind server to 0.0.0.0 for Docker port forwarding

### DIFF
--- a/cli/internal/httpserver/server.go
+++ b/cli/internal/httpserver/server.go
@@ -39,7 +39,7 @@ func Start(port string, ready chan<- error, handlerFunc http.HandlerFunc) error 
 		handler.ServeHTTP(w, r)
 	})
 
-	addr := "127.0.0.1:" + port
+	addr := "0.0.0.0:" + port
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -80,7 +80,7 @@ func StartGuide(cwd, name, apiHost, serverPort string) error {
 
 	address := "http://localhost:" + serverPort
 	if err := openBrowser(address); err != nil {
-		fmt.Println("failed to open browser automatically; open this URL manually:", address)
+		fmt.Println("Open this URL in your browser:", address)
 	}
 
 	fmt.Println("The guide is now being served")


### PR DESCRIPTION
## Summary

Fix CLI proxy server to be accessible from outside Docker container.

## Changes

- Change server bind address from `127.0.0.1` to `0.0.0.0`
- Improve browser open failure message (remove "failed" wording)

## How to Test

```bash
docker run -it --pull always -p 8080:8080 -p 9300:9300 ghcr.io/kakao/actionbase:standalone
```

Then run `guide start hands-on-social` and access http://localhost:9300 from host browser.