### PR TITLE
Add KakaoTalk - Friends story

### DIFF
--- a/website/src/content/docs/stories/kakaotalk-friends.mdx
+++ b/website/src/content/docs/stories/kakaotalk-friends.mdx
@@ -49,6 +49,7 @@ First, we set up the data flow. Debezium captured changes from MySQL shards and 
 ### Stage 2: Bulk Load
 
 For historical data, we:
+
 1. Dumped the MySQL tables
 2. Bulk-loaded into Actionbase
 3. Replayed the WAL to catch up with changes during the dump


### PR DESCRIPTION
## Summary

Add second story to the Stories section: KakaoTalk Friends integration.

This story demonstrates the CQRS view pattern—using Actionbase as a flexible query layer alongside an existing system, rather than replacing it.

## Changes

- Add `stories/kakaotalk-friends.mdx` documenting:
  - CDC integration via Debezium and Kafka
  - Bulk load with WAL replay
  - New query layer for get, scan, count, and reverse queries
  - Existing system (MySQL + HBase) remains unchanged

## How to Test

1. Run `cd website && npm run dev`
2. Navigate to Stories > KakaoTalk - Friends
3. Verify diagrams render correctly