### PR TITLE
Add unified graph vision story

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -106,16 +106,16 @@ export default defineConfig({
           items: ['introduction', 'quick-start', 'faq', 'for-rdb-users', 'llms-txt'],
         },
         {
-          label: 'Project',
-          autogenerate: { directory: 'project' },
+          label: 'Stories',
+          autogenerate: { directory: 'stories' },
         },
         {
           label: 'Design',
           autogenerate: { directory: 'design' },
         },
         {
-          label: 'Internals',
-          autogenerate: { directory: 'internals' },
+          label: 'Guides',
+          autogenerate: { directory: 'guides' },
         },
         {
           label: 'Provisioning',
@@ -126,16 +126,16 @@ export default defineConfig({
           autogenerate: { directory: 'operations' },
         },
         {
-          label: 'Stories',
-          autogenerate: { directory: 'stories' },
-        },
-        {
-          label: 'Guides',
-          autogenerate: { directory: 'guides' },
+          label: 'Internals',
+          autogenerate: { directory: 'internals' },
         },
         {
           label: 'API References',
           autogenerate: { directory: 'api-references' },
+        },
+        {
+          label: 'Project',
+          autogenerate: { directory: 'project' },
         },
         {
           label: 'Community',

--- a/website/src/content/docs/stories/unified-graph.mdx
+++ b/website/src/content/docs/stories/unified-graph.mdx
@@ -42,6 +42,7 @@ Individual edges accumulate. What was once scattered across databases becomes a 
 ## The Problem
 
 Today, each feature queries its own slice:
+
 - "What did I wish for?"
 - "What did I view recently?"
 - "Who do I follow?"
@@ -91,10 +92,12 @@ With wide rows, all edges for one source fit in a single row as separate columns
 ### Why Both?
 
 Different roles:
+
 - `EdgeIndex` — maintains all edges. Narrow rows scale simply. Add nodes, done.
 - `EdgeCache` — keeps only top N edges for multi-hop efficiency.
 
 But wide rows can grow unbounded. A user with millions of edges creates a massive row. A **Pruner** solves this by:
+
 - Consuming CDC to detect changes
 - Keeping only top N edges per row (by index order)
 - Multi-hop queries only need top N anyway


### PR DESCRIPTION
## Summary

- Add unified graph vision story to the Stories section
- Document the multi-hop query problem ("What did my friends wish for?")
- Explain technical approach: `EdgeIndex` (narrow rows) + `EdgeCache` (wide rows) + Pruner
- Reference the original blog post vision

## Test plan

- [x] Verify website builds successfully
- [x] Review rendered content at `/stories/unified-graph/`
- [x] Check mermaid diagram renders correctly
- [x] Verify blog link works