### PR TITLE
Add contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ For questions, ideas, or feedback, join us on [GitHub Discussions](https://githu
 * [Roadmap](ROADMAP.md)
 * [Actionbase at if(kakaoAI) 2024](https://www.youtube.com/watch?v=8-hVAFVHISE) (YouTube, Korean)
 
+## Contributors
+
+[![][contributors_img]][contributors]
+
 ## License
 
 This software is licensed under the [Apache 2 license](LICENSE).
@@ -132,3 +136,6 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
+
+[contributors]: https://github.com/kakao/actionbase/graphs/contributors
+[contributors_img]: https://contrib.rocks/image?repo=kakao/actionbase


### PR DESCRIPTION
## Summary

- Add Contributors section with contrib.rocks widget
- Display contributor avatars with link to GitHub contributors page
- Use markdown reference link style for cleaner README

## Test plan

- [x] Verify contrib.rocks image renders correctly on GitHub
- [x] Verify link to contributors page works