### PR TITLE
Automatically label first-time contributor PRs

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a workflow that automatically labels PRs from first-time contributors.


## Changes

- Trigger on pull_request_target event with opened type

## How to Test

1. Create a PR from an account that has never contributed to this repository
2. Verify the `first-time contributor` label is automatically added