### PR TITLE
Clarify test-generated docs and trust-based ownership

### DIFF
--- a/website/src/content/docs/stories/contracts.mdx
+++ b/website/src/content/docs/stories/contracts.mdx
@@ -98,11 +98,11 @@ Contracts evolve with service requirements. Each change increments the versionâ€
 
 Traditional contract testing (like Pact) focuses on API shapeâ€”request and response formats. Our contracts go deeper: they capture usage patterns, not just interfaces.
 
-|                    | Traditional          | Actionbase                 |
-| ------------------ | -------------------- | -------------------------- |
-| **Scope**          | API shape            | Usage patterns             |
-| **Docs**           | Separate             | Generated from tests       |
-| **Guarantees**     | Payload compatibility| Behavior compatibility     |
+|                | Traditional           | Actionbase             |
+| -------------- | --------------------- | ---------------------- |
+| **Scope**      | API shape             | Usage patterns         |
+| **Docs**       | Separate              | Generated from tests   |
+| **Guarantees** | Payload compatibility | Behavior compatibility |
 
 ## What We Learned
 


### PR DESCRIPTION
## Summary

Improve clarity in the Tests as Contracts story.

## Changes

- Clarify that tests generate documentation (not CI extracting it)
- Reframe test ownership as a trust-based choice, not risk ownership

## How to Test

1. Run `cd website && npm run dev`
2. Navigate to /stories/contracts/
3. Review updated wording