### PR TITLE
Bust contributors image cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ License for the specific language governing permissions and limitations under
 the License.
 
 [contributors]: https://github.com/kakao/actionbase/graphs/contributors
-[contributors_img]: https://contrib.rocks/image?repo=kakao/actionbase
+[contributors_img]: https://contrib.rocks/image?repo=kakao/actionbase&v=2


### PR DESCRIPTION
## Summary

Bust GitHub camo proxy cache for contributors image to show updated contributors list.

## Changes

- Add `&v=2` query parameter to contrib.rocks image URL

## How to Test

Check README contributors section shows 7 contributors after merge.