### PR TITLE
Expand language selector click area

### DIFF
--- a/website/src/components/LanguageSelect.astro
+++ b/website/src/components/LanguageSelect.astro
@@ -17,7 +17,7 @@ const links = Object.entries(locales).map(([key]) => {
 });
 ---
 
-<nav class="lang-select" aria-label="Language">
+<nav class="lang-select" aria-label="Language" onclick="event.stopPropagation()">
   <Icon name="translate" class="icon" />
   {links.map((l, i) => (
     <>
@@ -35,15 +35,22 @@ const links = Object.entries(locales).map(([key]) => {
   .lang-select {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0;
     font-size: var(--sl-text-xs);
     flex-shrink: 0;
+    padding: 0.5rem;
+    margin: -0.5rem;
   }
   .icon {
     color: var(--sl-color-gray-4);
+    margin-right: 0.25rem;
   }
   .sep {
     color: var(--sl-color-gray-5);
+  }
+  .current,
+  a {
+    padding: 0.25rem 0.375rem;
   }
   .current {
     color: var(--sl-color-white);


### PR DESCRIPTION
## Summary

Fix for #154 - clicking near the EN/KO text was triggering the mobile table of contents dropdown instead of navigating to the selected language.

## Changes

- Add `event.stopPropagation()` to prevent clicks from bubbling to the parent dropdown
- Increase padding on the nav container and links to expand the clickable area

## How to Test

1. `cd website && npm run dev`
2. Open on mobile (or narrow browser window)
3. Click near but not exactly on EN/KO text - should now correctly navigate instead of opening TOC dropdown