### PR TITLE
Add HBase + Actionbase local development setup

### DIFF
--- a/dev/hbase/.gitignore
+++ b/dev/hbase/.gitignore
@@ -1,2 +1,1 @@
 data/
-logs/

--- a/dev/hbase/Dockerfile
+++ b/dev/hbase/Dockerfile
@@ -2,12 +2,12 @@
 FROM eclipse-temurin:21-jdk-jammy AS builder
 
 # HBase version
-ENV HBASE_VERSION=2.5.12
+ENV HBASE_VERSION=2.5.13
 
 # Download and prepare HBase
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget && \
-    wget -q https://mirror.kakao.com/apache/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz && \
+    wget -q https://dlcdn.apache.org/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz && \
     tar -xzf hbase-${HBASE_VERSION}-bin.tar.gz && \
     mv hbase-${HBASE_VERSION} /opt/hbase && \
     rm hbase-${HBASE_VERSION}-bin.tar.gz && \
@@ -23,11 +23,11 @@ RUN apt-get update && \
 FROM eclipse-temurin:21-jre-jammy
 
 LABEL maintainer="Actionbase Developers"
-LABEL version="2.5.12"
+LABEL version="2.5.13"
 LABEL description="HBase Standalone for Development"
 
 # Environment variables
-ENV HBASE_VERSION=2.5.12 \
+ENV HBASE_VERSION=2.5.13 \
     HBASE_HOME=/opt/hbase \
     PATH=/opt/hbase/bin:$PATH \
     JAVA_HOME=/opt/java/openjdk
@@ -53,10 +53,12 @@ RUN mkdir -p /data/hbase /data/zookeeper
 # Expose ports
 EXPOSE 16000 16010 16020 16030 2181 9090 9095
 
-# Startup script with SVE warning fix
+# Startup script (silent - logs go to /opt/hbase/logs/)
 COPY <<'EOF' /start-hbase.sh
 #!/bin/bash
 set -e
+
+exec > /opt/hbase/logs/startup.log 2>&1
 
 # Disable SVE warning (ARM architecture issue)
 export HBASE_OPTS="${HBASE_OPTS} -XX:UseSVE=0"
@@ -64,41 +66,19 @@ export HBASE_MASTER_OPTS="${HBASE_MASTER_OPTS} -XX:UseSVE=0"
 export HBASE_REGIONSERVER_OPTS="${HBASE_REGIONSERVER_OPTS} -XX:UseSVE=0"
 
 # Clean up stale ZooKeeper files
-if [ -d /data/zookeeper ]; then
-  rm -f /data/zookeeper/zookeeper_server.pid 2>/dev/null || true
-fi
-
-echo "Starting HBase"
-echo "Java Version:"
-java -version 2>&1 | grep -v "SVE" || true
+rm -f /data/zookeeper/zookeeper_server.pid 2>/dev/null || true
 
 ${HBASE_HOME}/bin/start-hbase.sh
 
-echo "HBase started successfully!"
-echo "Master Web UI: http://localhost:16010"
-echo "RegionServer Web UI: http://localhost:16030"
-
-# Wait for HBase to be ready
-echo "Waiting for HBase to be ready..."
 sleep 10
 
 # Create namespace and default table if they don't exist
-echo "Checking for namespace and table ab_local:ab_local_default..."
 ${HBASE_HOME}/bin/hbase shell <<'HBASE_SHELL'
-# Check if namespace exists, create if not
 namespaces = list_namespace.to_a
-if namespaces.include?('ab_local')
-  puts "Namespace ab_local already exists."
-else
-  puts "Creating namespace ab_local..."
+unless namespaces.include?('ab_local')
   create_namespace 'ab_local'
-  puts "Namespace ab_local created successfully!"
 end
-# Check if table exists, create if not
-if exists('ab_local:ab_local_default')
-  puts "Table ab_local:ab_local_default already exists."
-else
-  puts "Creating ab_local:ab_local_default table..."
+unless exists('ab_local:ab_local_default')
   create 'ab_local:ab_local_default', {
     NAME => 'f',
     BLOOMFILTER => 'ROW',
@@ -112,15 +92,12 @@ else
     BLOCKCACHE => 'true',
     BLOCKSIZE => 65536
   }
-  puts "Table ab_local:ab_local_default created successfully!"
 end
 exit
 HBASE_SHELL
 
-echo "Setup complete!"
-
 # Keep container running
-tail -f ${HBASE_HOME}/logs/* 2>/dev/null || tail -f /dev/null
+tail -f /dev/null
 EOF
 
 RUN chmod +x /start-hbase.sh

--- a/dev/hbase/Makefile
+++ b/dev/hbase/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all clean
+
+DC := $(shell docker compose version > /dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+
+all:
+	@mkdir -p data/hbase data/zookeeper data/logs
+	@trap '$(DC) down' EXIT; $(DC) run --rm --service-ports actionbase
+
+clean:
+	$(DC) down
+	rm -rf data/*

--- a/dev/hbase/README.md
+++ b/dev/hbase/README.md
@@ -1,0 +1,22 @@
+# HBase Development Environment
+
+```bash
+make          # Start HBase + Actionbase CLI (Ctrl+C to stop)
+make clean    # Remove all data
+```
+
+## URLs
+
+- http://localhost:16010 - HBase UI
+- http://localhost:8080 - Actionbase API
+
+## Logs
+
+```bash
+cat data/logs/startup.log       # HBase
+cat data/logs/actionbase.log    # Actionbase
+```
+
+## Config
+
+`conf/application-local.yaml` - Actionbase settings

--- a/dev/hbase/conf/application-local.yaml
+++ b/dev/hbase/conf/application-local.yaml
@@ -1,0 +1,24 @@
+actionbase:
+  tenant: ab-local
+  datastore:
+    type: hbase
+    configuration:
+      actionbase.hbase.namespace: ab_local
+      hbase.zookeeper.quorum: hbase:2181
+
+logging:
+  file:
+    name: /app/logs/actionbase.log
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      max-history: 5
+      total-size-cap: 50MB
+  level:
+    com.kakao.actionbase: DEBUG
+    org.springframework.web.reactive: DEBUG
+    org.springframework.http.server.reactive: DEBUG
+    reactor.netty.http.server: DEBUG
+  threshold:
+    console: OFF
+    file: DEBUG

--- a/dev/hbase/docker-compose.yml
+++ b/dev/hbase/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   hbase:
     build: .
-    image: hbase-actionbase-dev:2.5.12
+    image: hbase-actionbase-dev:2.5.13
     container_name: hbase-actionbase-dev
     hostname: hbase
     ports:
@@ -13,17 +13,39 @@ services:
     volumes:
       - ./data/hbase:/data/hbase
       - ./data/zookeeper:/data/zookeeper
-      - ./logs:/opt/hbase/logs
+      - ./data/logs:/opt/hbase/logs
     deploy:
       resources:
         limits:
           memory: 3g
         reservations:
           memory: 2g
-    restart: unless-stopped
+
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:16010"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      test:
+        [
+          "CMD-SHELL",
+          'echo "exists ''ab_local:ab_local_default''" | hbase shell 2>/dev/null | grep -q ''true''',
+        ]
+      interval: 10s
+      timeout: 30s
+      retries: 12
       start_period: 60s
+
+  actionbase:
+    image: ghcr.io/kakao/actionbase:standalone
+    container_name: actionbase
+    depends_on:
+      hbase:
+        condition: service_healthy
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - SPRING_CONFIG_ADDITIONAL-LOCATION=/app/config/
+      - AB_SERVER_HOST=0.0.0.0
+    volumes:
+      - ./conf/application-local.yaml:/app/config/application-local.yaml
+      - ./data/logs:/app/logs
+    ports:
+      - "8080:8080"
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary

Add complete local development setup for HBase + Actionbase with simple `make` command.

## Changes

- Add `Makefile` with `make` (start) and `make clean` (cleanup) commands
- Add `actionbase` service to docker-compose with health check dependency
- Update HBase to 2.5.13 and fix download URL (Apache CDN)
- Silent HBase startup - logs redirected to file only
- Add `conf/application-local.yaml` for Actionbase config with log rolling
- Improve health check to wait for table creation (not just Web UI)
- Add README with usage instructions

## How to Test

```bash
cd dev/hbase
make
# CLI starts interactively after HBase is ready
# Ctrl+C to stop both services
```

Check:
- http://localhost:16010 - HBase UI
- http://localhost:8080 - Actionbase API
- `localhost:2181` - HBase ZooKeeper
- `data/logs/` - all logs