### PR TITLE
Add storage backend compatibility tests

### DIFF
--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/DatastoreCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/DatastoreCompatibilityTest.kt
@@ -1,0 +1,285 @@
+package com.kakao.actionbase.engine.datastore
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Abstract compatibility test for storage backends.
+ *
+ * Required operations: get, scan, put, delete, increment, batch, checkAndMutate.
+ *
+ * @see <a href="/website/src/content/docs/design/storage-backends.mdx">Storage Backends</a>
+ */
+abstract class DatastoreCompatibilityTest {
+    protected abstract fun createStore(): StorageOperations
+
+    protected open fun cleanup() {}
+
+    protected open fun supportsCheckAndMutate(): Boolean = true
+
+    protected open fun supportsScanLimit(): Boolean = true
+
+    private lateinit var store: StorageOperations
+
+    @BeforeEach fun setUp() {
+        store = createStore()
+    }
+
+    @AfterEach fun tearDown() {
+        cleanup()
+    }
+
+    @Nested
+    @DisplayName("get")
+    inner class GetTest {
+        @Test fun `returns value when key exists`() {
+            store.put(b("key"), b("value"))
+            assert(store.get(b("key"))?.contentEquals(b("value")) == true)
+        }
+
+        @Test fun `returns null when key not exists`() {
+            assert(store.get(b("missing")) == null)
+        }
+
+        @Test fun `getAll returns matching records`() {
+            store.put(b("k1"), b("v1"))
+            store.put(b("k2"), b("v2"))
+            assert(store.getAll(listOf(b("k1"), b("k2"))).size == 2)
+        }
+
+        @Test fun `getAll skips missing keys`() {
+            store.put(b("exists"), b("v"))
+            assert(store.getAll(listOf(b("exists"), b("missing"))).size == 1)
+        }
+    }
+
+    @Nested
+    @DisplayName("scan")
+    inner class ScanTest {
+        @BeforeEach fun setup() {
+            listOf("user:001:a", "user:001:b", "user:002:a", "post:001").forEach {
+                store.put(b(it), b("v"))
+            }
+        }
+
+        @Test fun `returns matching prefix`() {
+            val results = store.scan(b("user:001"), 100)
+            assert(results.size == 2)
+            assert(results.all { String(it.first).startsWith("user:001") })
+        }
+
+        @Test fun `returns empty for non-matching prefix`() {
+            assert(store.scan(b("nonexistent"), 100).isEmpty())
+        }
+
+        @Test fun `returns sorted keys`() {
+            val keys = store.scan(b("user:"), 100).map { String(it.first) }
+            assert(keys == keys.sorted())
+        }
+
+        @Test fun `respects limit`() {
+            assumeTrue(supportsScanLimit())
+            assert(store.scan(b("user:"), 2).size == 2)
+        }
+    }
+
+    @Nested
+    @DisplayName("put")
+    inner class PutTest {
+        @Test fun `stores value`() {
+            store.put(b("k"), b("v"))
+            assert(store.get(b("k"))?.contentEquals(b("v")) == true)
+        }
+
+        @Test fun `overwrites existing`() {
+            store.put(b("k"), b("old"))
+            store.put(b("k"), b("new"))
+            assert(String(store.get(b("k"))!!) == "new")
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class DeleteTest {
+        @Test fun `removes key`() {
+            store.put(b("k"), b("v"))
+            store.delete(b("k"))
+            assert(store.get(b("k")) == null)
+        }
+
+        @Test fun `silently succeeds for missing key`() {
+            store.delete(b("nonexistent"))
+        }
+    }
+
+    @Nested
+    @DisplayName("increment")
+    inner class IncrementTest {
+        @Test fun `creates counter if not exists`() {
+            assert(store.increment(b("cnt"), 10) == 10L)
+        }
+
+        @Test fun `updates existing counter`() {
+            store.put(b("cnt"), longToBytes(100))
+            assert(store.increment(b("cnt"), 50) == 150L)
+        }
+
+        @Test fun `decrements with negative delta`() {
+            store.put(b("cnt"), longToBytes(100))
+            assert(store.increment(b("cnt"), -30) == 70L)
+        }
+    }
+
+    @Nested
+    @DisplayName("batch")
+    inner class BatchTest {
+        @Test fun `executes puts`() {
+            store.batch(listOf(Mutation.Put(b("b1"), b("v1")), Mutation.Put(b("b2"), b("v2"))))
+            assert(store.getAll(listOf(b("b1"), b("b2"))).size == 2)
+        }
+
+        @Test fun `executes deletes`() {
+            store.put(b("d1"), b("v"))
+            store.put(b("d2"), b("v"))
+            store.batch(listOf(Mutation.Delete(b("d1")), Mutation.Delete(b("d2"))))
+            assert(store.getAll(listOf(b("d1"), b("d2"))).isEmpty())
+        }
+
+        @Test fun `executes increments`() {
+            store.batch(listOf(Mutation.Increment(b("c1"), 10), Mutation.Increment(b("c2"), 20)))
+            assert(bytesToLong(store.get(b("c1"))!!) == 10L)
+            assert(bytesToLong(store.get(b("c2"))!!) == 20L)
+        }
+
+        @Test fun `executes mixed mutations`() {
+            store.put(b("to-delete"), b("v"))
+            store.batch(
+                listOf(
+                    Mutation.Put(b("new"), b("v")),
+                    Mutation.Delete(b("to-delete")),
+                    Mutation.Increment(b("cnt"), 100),
+                ),
+            )
+            assert(store.get(b("new")) != null)
+            assert(store.get(b("to-delete")) == null)
+            assert(bytesToLong(store.get(b("cnt"))!!) == 100L)
+        }
+    }
+
+    @Nested
+    @DisplayName("checkAndMutate")
+    inner class CheckAndMutateTest {
+        @BeforeEach fun checkSupport() {
+            assumeTrue(supportsCheckAndMutate())
+        }
+
+        @Nested
+        @DisplayName("setIfNotExists")
+        inner class SetIfNotExistsTest {
+            @Test fun `succeeds when key not exists`() {
+                assert(store.setIfNotExists(b("lock"), b("owner")))
+                assert(store.get(b("lock"))?.contentEquals(b("owner")) == true)
+            }
+
+            @Test fun `fails when key exists`() {
+                store.put(b("lock"), b("existing"))
+                assert(!store.setIfNotExists(b("lock"), b("new")))
+                assert(String(store.get(b("lock"))!!) == "existing")
+            }
+        }
+
+        @Nested
+        @DisplayName("deleteIfEquals")
+        inner class DeleteIfEqualsTest {
+            @Test fun `succeeds when value matches`() {
+                store.put(b("lock"), b("owner"))
+                assert(store.deleteIfEquals(b("lock"), b("owner")))
+                assert(store.get(b("lock")) == null)
+            }
+
+            @Test fun `fails when value differs`() {
+                store.put(b("lock"), b("owner"))
+                assert(!store.deleteIfEquals(b("lock"), b("different")))
+                assert(store.get(b("lock")) != null)
+            }
+
+            @Test fun `fails when key not exists`() {
+                assert(!store.deleteIfEquals(b("missing"), b("v")))
+            }
+        }
+
+        @Nested
+        @DisplayName("concurrent")
+        inner class ConcurrentTest {
+            @Test fun `only one thread acquires lock`() {
+                val threads = 10
+                val acquired = AtomicInteger(0)
+                val latch = CountDownLatch(threads)
+                val executor = Executors.newFixedThreadPool(threads)
+
+                repeat(threads) { i ->
+                    executor.submit {
+                        try {
+                            if (store.setIfNotExists(b("lock"), b("owner-$i"))) {
+                                acquired.incrementAndGet()
+                            }
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                executor.shutdown()
+                assert(acquired.get() == 1) { "Expected 1 but got ${acquired.get()}" }
+            }
+
+            @Test fun `only owner releases lock`() {
+                store.put(b("lock"), b("owner-0"))
+                val threads = 10
+                val released = AtomicInteger(0)
+                val latch = CountDownLatch(threads)
+                val executor = Executors.newFixedThreadPool(threads)
+
+                repeat(threads) { i ->
+                    executor.submit {
+                        try {
+                            if (store.deleteIfEquals(b("lock"), b("owner-$i"))) {
+                                released.incrementAndGet()
+                            }
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                executor.shutdown()
+                assert(released.get() == 1) { "Expected 1 but got ${released.get()}" }
+            }
+        }
+    }
+
+    companion object {
+        fun b(s: String): ByteArray = s.toByteArray()
+
+        fun longToBytes(v: Long): ByteArray =
+            ByteBuffer
+                .allocate(8)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putLong(v)
+                .array()
+
+        fun bytesToLong(b: ByteArray): Long = ByteBuffer.wrap(b).order(ByteOrder.BIG_ENDIAN).long
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/HBaseDatastoreCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/HBaseDatastoreCompatibilityTest.kt
@@ -1,0 +1,140 @@
+package com.kakao.actionbase.engine.datastore
+
+import com.kakao.actionbase.test.hbase.HBaseTestingCluster
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseConnections
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+import org.apache.hadoop.hbase.NamespaceDescriptor
+import org.apache.hadoop.hbase.TableName
+import org.apache.hadoop.hbase.client.Admin
+import org.apache.hadoop.hbase.client.CheckAndMutate
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Get
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.Scan
+import org.apache.hadoop.hbase.client.Table
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder
+import org.apache.hadoop.hbase.filter.PrefixFilter
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * HBase compatibility test. Default: MockConnection. Set HBASE_MINI_CLUSTER=true for mini cluster.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HBaseDatastoreCompatibilityTest : DatastoreCompatibilityTest() {
+    private lateinit var table: Table
+    private val tableName = TableName.valueOf("test", "compatibility_test")
+    private val cf = "f".toByteArray()
+    private val useMiniCluster = System.getenv("HBASE_MINI_CLUSTER") == "true"
+
+    @BeforeAll
+    fun setUpHBase() {
+        val connection =
+            if (useMiniCluster) {
+                HBaseTestingCluster.startIfNeeded()
+                HBaseTestingCluster.connection.also { createTableIfNeeded(it.admin) }
+            } else {
+                HBaseConnections.getMockConnection("test")
+            }
+        table = connection.getTable(tableName)
+    }
+
+    @AfterAll
+    fun tearDownHBase() {
+        table.close()
+        if (useMiniCluster) HBaseTestingCluster.stopIfNeeded()
+    }
+
+    override fun createStore(): StorageOperations = HBaseOps(table, cf)
+
+    override fun supportsCheckAndMutate() = useMiniCluster
+
+    override fun supportsScanLimit() = useMiniCluster
+
+    override fun cleanup() {
+        table.getScanner(Scan()).use { s ->
+            s.map { Delete(it.row) }.takeIf { it.isNotEmpty() }?.let { table.delete(it) }
+        }
+    }
+
+    private fun createTableIfNeeded(admin: Admin) {
+        val ns = tableName.namespaceAsString
+        if (admin.listNamespaceDescriptors().none { it.name == ns }) {
+            admin.createNamespace(NamespaceDescriptor.create(ns).build())
+        }
+        if (!admin.tableExists(tableName)) {
+            admin.createTable(
+                TableDescriptorBuilder
+                    .newBuilder(tableName)
+                    .setColumnFamily(ColumnFamilyDescriptorBuilder.of(cf))
+                    .build(),
+            )
+        }
+    }
+
+    private class HBaseOps(
+        private val t: Table,
+        private val cf: ByteArray,
+    ) : StorageOperations {
+        private val q = "v".toByteArray()
+
+        override fun get(key: ByteArray) = t.get(Get(key).addColumn(cf, q)).getValue(cf, q)
+
+        override fun getAll(keys: List<ByteArray>) = t.get(keys.map { Get(it).addColumn(cf, q) }).mapNotNull { r -> r.getValue(cf, q)?.let { r.row to it } }
+
+        override fun scan(
+            prefix: ByteArray,
+            limit: Int,
+        ) = t
+            .getScanner(Scan().setFilter(PrefixFilter(prefix)).addColumn(cf, q).setLimit(limit))
+            .use { s -> s.mapNotNull { r -> r.getValue(cf, q)?.let { r.row to it } } }
+
+        override fun put(
+            key: ByteArray,
+            value: ByteArray,
+        ) {
+            t.put(Put(key).addColumn(cf, q, value))
+        }
+
+        override fun delete(key: ByteArray) {
+            t.delete(Delete(key))
+        }
+
+        override fun increment(
+            key: ByteArray,
+            delta: Long,
+        ) = ByteBuffer
+            .wrap(t.increment(Increment(key).addColumn(cf, q, delta)).getValue(cf, q))
+            .order(ByteOrder.BIG_ENDIAN)
+            .long
+
+        override fun batch(mutations: List<Mutation>) {
+            if (mutations.isEmpty()) return
+            val actions =
+                mutations.map { m ->
+                    when (m) {
+                        is Mutation.Put -> Put(m.key).addColumn(cf, q, m.value)
+                        is Mutation.Delete -> Delete(m.key)
+                        is Mutation.Increment -> Increment(m.key).addColumn(cf, q, m.delta)
+                    }
+                }
+            t.batch(actions, arrayOfNulls(actions.size))
+        }
+
+        override fun setIfNotExists(
+            key: ByteArray,
+            value: ByteArray,
+        ) = t.checkAndMutate(CheckAndMutate.newBuilder(key).ifNotExists(cf, q).build(Put(key).addColumn(cf, q, value))).isSuccess
+
+        override fun deleteIfEquals(
+            key: ByteArray,
+            expectedValue: ByteArray,
+        ) = t.checkAndMutate(CheckAndMutate.newBuilder(key).ifEquals(cf, q, expectedValue).build(Delete(key))).isSuccess
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/MemoryDatastoreCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/MemoryDatastoreCompatibilityTest.kt
@@ -1,0 +1,61 @@
+package com.kakao.actionbase.engine.datastore
+
+import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+
+/** Memory (ByteArrayStore) compatibility test. */
+class MemoryDatastoreCompatibilityTest : DatastoreCompatibilityTest() {
+    private lateinit var store: ByteArrayStore
+
+    override fun createStore(): StorageOperations {
+        store = ByteArrayStore()
+        return MemoryOps(store)
+    }
+
+    private class MemoryOps(
+        private val s: ByteArrayStore,
+    ) : StorageOperations {
+        override fun get(key: ByteArray) = s[key]
+
+        override fun getAll(keys: List<ByteArray>) = keys.mapNotNull { k -> s[k]?.let { k to it } }
+
+        override fun scan(
+            prefix: ByteArray,
+            limit: Int,
+        ) = s.prefixScan(prefix).take(limit).map { it.key to it.value }
+
+        override fun put(
+            key: ByteArray,
+            value: ByteArray,
+        ) {
+            s[key] = value
+        }
+
+        override fun delete(key: ByteArray) {
+            s.remove(key)
+        }
+
+        override fun increment(
+            key: ByteArray,
+            delta: Long,
+        ) = s.increment(key, delta)
+
+        override fun batch(mutations: List<Mutation>) =
+            mutations.forEach { m ->
+                when (m) {
+                    is Mutation.Put -> s[m.key] = m.value
+                    is Mutation.Delete -> s.remove(m.key)
+                    is Mutation.Increment -> s.increment(m.key, m.delta)
+                }
+            }
+
+        override fun setIfNotExists(
+            key: ByteArray,
+            value: ByteArray,
+        ) = s.checkAndSet(key, null, value)
+
+        override fun deleteIfEquals(
+            key: ByteArray,
+            expectedValue: ByteArray,
+        ) = s.checkAndSet(key, expectedValue, null)
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/StorageOperations.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/datastore/StorageOperations.kt
@@ -1,0 +1,57 @@
+package com.kakao.actionbase.engine.datastore
+
+/**
+ * Storage operations interface for compatibility testing.
+ *
+ * Defines the minimal operations required for Actionbase storage backends.
+ */
+interface StorageOperations {
+    fun get(key: ByteArray): ByteArray?
+
+    fun getAll(keys: List<ByteArray>): List<Pair<ByteArray, ByteArray>>
+
+    fun scan(
+        prefix: ByteArray,
+        limit: Int,
+    ): List<Pair<ByteArray, ByteArray>>
+
+    fun put(
+        key: ByteArray,
+        value: ByteArray,
+    )
+
+    fun delete(key: ByteArray)
+
+    fun increment(
+        key: ByteArray,
+        delta: Long,
+    ): Long
+
+    fun batch(mutations: List<Mutation>)
+
+    fun setIfNotExists(
+        key: ByteArray,
+        value: ByteArray,
+    ): Boolean
+
+    fun deleteIfEquals(
+        key: ByteArray,
+        expectedValue: ByteArray,
+    ): Boolean
+}
+
+sealed class Mutation {
+    class Put(
+        val key: ByteArray,
+        val value: ByteArray,
+    ) : Mutation()
+
+    class Delete(
+        val key: ByteArray,
+    ) : Mutation()
+
+    class Increment(
+        val key: ByteArray,
+        val delta: Long,
+    ) : Mutation()
+}


### PR DESCRIPTION
## Summary

Add comprehensive compatibility tests for storage backends to verify required operations as defined in the storage backends design doc.

## Changes

- `DatastoreCompatibilityTest`: Abstract base class with 24 test cases covering all required operations
- `MemoryDatastoreCompatibilityTest`: Tests in-memory ByteArrayStore implementation
- `HBaseDatastoreCompatibilityTest`: Tests HBase backend
  - Default: MockConnection (fast, no external dependencies)
  - Optional: Mini cluster with `HBASE_MINI_CLUSTER=true`
- `StorageOperations`: Extracted interface for potential reuse
- Concurrent tests for checkAndMutate atomicity verification (distributed locking)

### Test Coverage

| Operation | Tests |
|-----------|-------|
| get / getAll | 4 |
| scan | 4 |
| put | 2 |
| delete | 2 |
| increment | 3 |
| batch | 4 |
| setIfNotExists | 2 |
| deleteIfEquals | 3 |
| concurrent | 2 |

## How to Test

```bash
# Run with MockConnection (default, fast)
./gradlew :engine:test --tests "*DatastoreCompatibilityTest*"

# Run with HBase mini cluster (slower, full integration)
HBASE_MINI_CLUSTER=true ./gradlew :engine:test --tests "*HBaseDatastoreCompatibilityTest*"
```