### PR TITLE
Make GitProperties optional for worktree environments

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/WebFilterConfig.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/WebFilterConfig.kt
@@ -17,7 +17,7 @@ import org.springframework.web.server.WebFilter
 @Configuration
 class WebFilterConfig(
     private val properties: GraphProperties,
-    private val gitProperties: GitProperties,
+    private val gitProperties: GitProperties?,
     private val buildProperties: BuildProperties,
 ) {
     @Bean("responseMetaFilter")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/filter/ResponseMetaFactory.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/filter/ResponseMetaFactory.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.info.GitProperties
 import org.springframework.http.HttpHeaders
 
 class ResponseMetaFactory(
-    private val gitProperties: GitProperties,
+    private val gitProperties: GitProperties?,
     private val buildProperties: BuildProperties,
 ) {
     companion object {
@@ -51,12 +51,12 @@ class ResponseMetaFactory(
         val baseVersion =
             listOf(
                 buildVersion,
-                gitProperties.shortCommitId ?: UNKNOWN,
-                gitProperties.branch ?: UNKNOWN,
+                gitProperties?.shortCommitId ?: UNKNOWN,
+                gitProperties?.branch ?: UNKNOWN,
             ).joinToString(":")
 
         // Check dirty state
-        val isDirty = gitProperties.get("dirty")?.toBooleanStrictOrNull() ?: false
+        val isDirty = gitProperties?.get("dirty")?.toBooleanStrictOrNull() ?: false
         return if (isDirty) "$baseVersion(dirty)" else baseVersion
     }
 }


### PR DESCRIPTION
## Summary

Make `GitProperties` optional to allow the application to start in git worktree environments where `generateGitProperties` Gradle task may fail.

## Changes

- `WebFilterConfig.kt`: Change `gitProperties: GitProperties` to `gitProperties: GitProperties?`
- `ResponseMetaFactory.kt`: Change to nullable and use safe call operators (`?.`)

## How to Test

```bash
# Build without generating git properties
./gradlew :server:build -x generateGitProperties

# Run server - should start without git metadata
./gradlew :server:bootRun -x generateGitProperties
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)