### PR TITLE
Upgrade gradle-git-properties for worktree support

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("actionbase.jib-conventions")
     `java-test-fixtures`
 
-    id("com.gorylenko.gradle-git-properties") version "2.4.2"
+    id("com.gorylenko.gradle-git-properties") version "2.5.5"
 }
 
 dependencyManagement {


### PR DESCRIPTION
## Summary

Upgrade gradle-git-properties plugin from 2.4.2 to 2.5.5 to fix `RepositoryNotFoundException` when building in git worktree environments.

## Changes

- Upgrade `com.gorylenko.gradle-git-properties` plugin: 2.4.2 → 2.5.5

## How to Test

1. Create a git worktree:
   ```bash
   git worktree add ../test-worktree -b test-branch
   cd ../test-worktree
   ```

2. Run the build:
   ```bash
   ./gradlew :server:generateGitProperties
   ```

3. Verify `BUILD SUCCESSFUL` (previously failed with `RepositoryNotFoundException`)

---

🤖 Generated with [Claude Code](https://claude.ai/code)