### PR TITLE
Add `shared` fields and `cases` alias to @ObjectSource

### DIFF
--- a/core/src/test/kotlin/com/kakao/actionbase/test/ObjectSourceTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/test/ObjectSourceTest.kt
@@ -294,15 +294,15 @@ class ObjectSourceTest {
     }
 
     @Nested
-    inner class TestsAliasTest {
+    inner class CasesAliasTest {
         @ObjectSourceParameterizedTest
         @ObjectSource(
-            tests = """
+            cases = """
             - number: 42
               string: hello
             """,
         )
-        fun `tests parameter works as alias for value`(
+        fun `cases parameter works as alias for value`(
             number: Int,
             string: String,
         ) {
@@ -312,14 +312,14 @@ class ObjectSourceTest {
 
         @ObjectSourceParameterizedTest
         @ObjectSource(
-            tests = """
+            cases = """
             - number: 1
               string: first
             - number: 2
               string: second
             """,
         )
-        fun `tests parameter with multiple cases`(
+        fun `cases parameter with multiple cases`(
             number: Int,
             string: String,
         ) {
@@ -329,18 +329,18 @@ class ObjectSourceTest {
     }
 
     @Nested
-    inner class AllFieldsTest {
+    inner class SharedFieldsTest {
         @ObjectSourceParameterizedTest
         @ObjectSource(
-            all = """
+            shared = """
               shared: common-value
             """,
-            tests = """
+            cases = """
             - name: case1
             - name: case2
             """,
         )
-        fun `all fields are merged into every test case`(
+        fun `shared fields are merged into every test case`(
             shared: String,
             name: String,
         ) {
@@ -350,11 +350,11 @@ class ObjectSourceTest {
 
         @ObjectSourceParameterizedTest
         @ObjectSource(
-            all = """
+            shared = """
               setup: |
                 {"database": "test-db", "comment": "test"}
             """,
-            tests = """
+            cases = """
             - name: alias-basic
               update: |
                 {"comment": "updated"}
@@ -363,7 +363,7 @@ class ObjectSourceTest {
                 {"comment": ""}
             """,
         )
-        fun `all with JSON block scalars`(
+        fun `shared with JSON block scalars`(
             setup: String,
             name: String,
             update: String,
@@ -375,15 +375,15 @@ class ObjectSourceTest {
 
         @ObjectSourceParameterizedTest
         @ObjectSource(
-            all = """
+            shared = """
               base: default
             """,
-            tests = """
+            cases = """
             - base: overridden
               extra: value
             """,
         )
-        fun `per-case fields override all fields`(
+        fun `per-case fields override shared fields`(
             base: String,
             extra: String,
         ) {
@@ -414,11 +414,11 @@ class ObjectSourceTest {
             value = """
             - name: from-value
             """,
-            all = """
+            shared = """
               shared: via-value
             """,
         )
-        fun `all works with value parameter`(
+        fun `shared works with value parameter`(
             shared: String,
             name: String,
         ) {

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSource.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSource.kt
@@ -4,6 +4,6 @@ package com.kakao.actionbase.test.documentations.params
 @Target(AnnotationTarget.FUNCTION)
 annotation class ObjectSource(
     val value: String = "",
-    val tests: String = "",
-    val all: String = "",
+    val cases: String = "",
+    val shared: String = "",
 )

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceExtension.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceExtension.kt
@@ -18,18 +18,18 @@ class ObjectSourceExtension : TestTemplateInvocationContextProvider {
     override fun provideTestTemplateInvocationContexts(context: ExtensionContext): Stream<TestTemplateInvocationContext> {
         val annotation = context.requiredTestMethod.getAnnotation(ObjectSource::class.java)
 
-        require(annotation.value.isBlank() || annotation.tests.isBlank()) {
-            "@ObjectSource: specify either 'value' or 'tests', not both"
+        require(annotation.value.isBlank() || annotation.cases.isBlank()) {
+            "@ObjectSource: specify either 'value' or 'cases', not both"
         }
 
         val testData =
-            annotation.tests.ifBlank { annotation.value }.also {
-                require(it.isNotBlank()) { "@ObjectSource: 'value' or 'tests' must be provided" }
+            annotation.cases.ifBlank { annotation.value }.also {
+                require(it.isNotBlank()) { "@ObjectSource: 'value' or 'cases' must be provided" }
             }
         val testCases: List<Map<String, Any?>> = ObjectMappers.YAML.readValue(testData)
 
         val allFields: Map<String, Any?> =
-            if (annotation.all.isNotBlank()) ObjectMappers.YAML.readValue(annotation.all) else emptyMap()
+            if (annotation.shared.isNotBlank()) ObjectMappers.YAML.readValue(annotation.shared) else emptyMap()
 
         val mergedCases =
             if (allFields.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Add `shared` and `cases` parameters to `@ObjectSource` annotation, enabling shared fields that merge into every test case. This keeps YAML self-contained and eliminates duplication of common setup data across test cases.

Closes #185

## Plan

- [x] Add `shared` and `cases` parameters to `ObjectSource` annotation (backward compatible)
- [x] Update `ObjectSourceExtension` processor: resolve test data from `cases.ifBlank { value }`, parse and merge `shared` fields into every test case
- [x] Add tests for: `cases` alias, `shared` merge, `shared` + `cases` combined, backward compatibility
- [x] Update `testing-guide.md` with `shared`/`cases` usage examples (in root agent SSOT, not in this PR)