### PR TITLE
Make Kerberos realm configurable in HBaseStorageBackend

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
@@ -68,6 +68,7 @@ class DefaultHBaseCluster private constructor(
     companion object {
         const val DEFAULT_HBASE_NAMESPACE = "default"
         const val DEFAULT_HBASE_CLUSTER_NAME = "__DEFAULT_HBASE_CLUSTER__"
+        const val LEGACY_DEFAULT_KERBEROS_REALM = "KAKAO.HADOOP"
 
         private val logger = LoggerFactory.getLogger(DefaultHBaseCluster::class.java)
 
@@ -85,6 +86,7 @@ class DefaultHBaseCluster private constructor(
          *
          * # for secure cluster
          *   kerberos.realm: e.g. EXAMPLE.COM (or env AB_KERBEROS_REALM)
+         *     - If missing, defaults to KAKAO.HADOOP for backward compatibility (deprecated)
          *   krb5ConfPath: /path/to/krb5.conf (or env AB_KRB5_CONF_PATH)
          *   keytabPath: e.g. /path/to/hadoop-cdl-write.keytab (or env AB_KEYTAB_PATH)
          *   principal: e.g. hadoop-cdl-write@EXAMPLE.COM (or env AB_PRINCIPAL)
@@ -125,11 +127,7 @@ class DefaultHBaseCluster private constructor(
                 val krb5ConfPath = krb5ConfPathOpt ?: throw IllegalStateException("Kerberos krb5.conf path is not set")
                 val principal = principalOpt ?: throw IllegalStateException("Kerberos principal is not set")
                 val keytabPath = keytabPathOpt ?: throw IllegalStateException("Kerberos keytab path is not set")
-                val kerberosRealm =
-                    properties["kerberos.realm"]
-                        ?: System.getenv("AB_KERBEROS_REALM")
-                        ?: throw IllegalStateException("Kerberos realm is not set for secure cluster")
-                require(kerberosRealm.isNotBlank()) { "Kerberos realm must not be blank" }
+                val kerberosRealm = resolveKerberosRealm(properties)
 
                 System.setProperty("java.security.krb5.conf", krb5ConfPath)
 
@@ -191,6 +189,25 @@ class DefaultHBaseCluster private constructor(
                     }.cache()
 
             initialize(connectionMono, namespace, config)
+        }
+
+        internal fun resolveKerberosRealm(
+            properties: Map<String, String>,
+            envKerberosRealm: String? = System.getenv("AB_KERBEROS_REALM"),
+        ): String {
+            val kerberosRealm = (properties["kerberos.realm"] ?: envKerberosRealm)?.trim()
+
+            if (kerberosRealm == null) {
+                logger.warn(
+                    "`kerberos.realm` is not set; falling back to legacy default realm `{}` for backward compatibility. This fallback is deprecated and will be removed in a future release.",
+                    LEGACY_DEFAULT_KERBEROS_REALM,
+                )
+                // TODO(ab#180): Remove legacy fallback and require explicit kerberos.realm after migration period.
+                return LEGACY_DEFAULT_KERBEROS_REALM
+            }
+
+            require(kerberosRealm.isNotEmpty()) { "Kerberos realm must not be blank" }
+            return kerberosRealm
         }
 
         fun initialize(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseClusterTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseClusterTest.kt
@@ -18,12 +18,35 @@ class DefaultHBaseClusterTest {
         )
 
     @Test
-    fun `missing kerberos realm should throw for secure cluster`() {
-        val exception =
-            assertThrows<IllegalStateException> {
-                DefaultHBaseCluster.initialize(secureBaseProperties)
-            }
-        assertEquals("Kerberos realm is not set for secure cluster", exception.message)
+    fun `missing kerberos realm should use legacy default for compatibility`() {
+        val kerberosRealm = DefaultHBaseCluster.resolveKerberosRealm(secureBaseProperties, null)
+
+        assertEquals(DefaultHBaseCluster.LEGACY_DEFAULT_KERBEROS_REALM, kerberosRealm)
+    }
+
+    @Test
+    fun `environment kerberos realm should be used when property is missing`() {
+        val kerberosRealm = DefaultHBaseCluster.resolveKerberosRealm(secureBaseProperties, "ENV.EXAMPLE.COM")
+
+        assertEquals("ENV.EXAMPLE.COM", kerberosRealm)
+    }
+
+    @Test
+    fun `property kerberos realm should override environment realm`() {
+        val properties = secureBaseProperties + ("kerberos.realm" to "PROP.EXAMPLE.COM")
+
+        val kerberosRealm = DefaultHBaseCluster.resolveKerberosRealm(properties, "ENV.EXAMPLE.COM")
+
+        assertEquals("PROP.EXAMPLE.COM", kerberosRealm)
+    }
+
+    @Test
+    fun `kerberos realm should be trimmed`() {
+        val properties = secureBaseProperties + ("kerberos.realm" to "  EXAMPLE.COM  ")
+
+        val kerberosRealm = DefaultHBaseCluster.resolveKerberosRealm(properties, null)
+
+        assertEquals("EXAMPLE.COM", kerberosRealm)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replace the hardcoded `@KAKAO.HADOOP` Kerberos realm in `DefaultHBaseCluster` with a configurable `kerberos.realm` property. This makes the project portable for environments with different Kerberos realms.

Closes #180

## Plan
Created by **claude code (opus 4.6)**

- [x] Step 1: Replace hardcoded `@KAKAO.HADOOP` with `kerberos.realm` property lookup in `DefaultHBaseCluster.initialize()`
- [x] Step 2: Add unit test for Kerberos realm configuration
- [x] Step 3: Update property documentation comment in `DefaultHBaseCluster`
- [x] Step 4: Add backward-compatible default realm (`KAKAO.HADOOP`) when `kerberos.realm` is missing, and mark fallback as deprecated/TODO — **opencode (gpt-5.3-codex)**

## Progress
<!-- Each agent appends here. Do NOT remove previous entries. -->
- [x] Step 1 — **claude code (opus 4.6)** (commit 4b9d78c)
- [x] Step 2 — **claude code (opus 4.6)** (commit 4b9d78c)
- [x] Step 3 — **claude code (opus 4.6)** (commit 4b9d78c)
- [x] Review Round 1 fixes — **claude code (opus 4.6)** (commit bddda26): env var fallback, blank validation, JUnit assertions
- [x] Step 4 — **opencode (gpt-5.3-codex)** (commit 23d6f34): legacy default fallback to `KAKAO.HADOOP` when realm is missing
- [x] Review Round 2 fixes — **opencode (gpt-5.3-codex)** (commit 23d6f34): deprecation warning/TODO, realm trimming, precedence and compatibility tests
