### PR TITLE
Make V3 metadata CRUD tests self-contained and expand lifecycle coverage

### DIFF
--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -214,6 +214,65 @@ class AliasControllerTest : E2ETestBase() {
             shared = """
               deactivate: |
                 {"active": false}
+              reactivate: |
+                {"active": true}
+            """,
+            cases = """
+            - name: v3-alias-react-basic
+              create: |
+                {"alias": "v3-alias-react-basic", "table": "v3-alias-target-table", "comment": "test alias"}
+              expected: |
+                {"alias": "v3-alias-react-basic", "active": true}
+            - name: v3-alias-react-empty
+              create: |
+                {"alias": "v3-alias-react-empty", "table": "v3-alias-target-table", "comment": ""}
+              expected: |
+                {"alias": "v3-alias-react-empty", "active": true}
+            """,
+        )
+        fun `reactivate alias`(
+            name: String,
+            create: String,
+            deactivate: String,
+            reactivate: String,
+            expected: String,
+        ) {
+            // precondition: create + deactivate
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(deactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(reactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            shared = """
+              deactivate: |
+                {"active": false}
             """,
             cases = """
             - name: v3-alias-del-basic

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -113,6 +113,159 @@ class DatabaseControllerTest : E2ETestBase() {
                 .expectBody()
                 .json(expected)
         }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            shared = """
+              deactivate: |
+                {"active": false}
+            """,
+            cases = """
+            - name: v3-db-deact-basic
+              create: |
+                {"database": "v3-db-deact-basic", "comment": "test db"}
+              expected: |
+                {"database": "v3-db-deact-basic", "active": false}
+            - name: v3-db-deact-empty
+              create: |
+                {"database": "v3-db-deact-empty", "comment": ""}
+              expected: |
+                {"database": "v3-db-deact-empty", "active": false}
+            """,
+        )
+        fun `deactivate database`(
+            name: String,
+            create: String,
+            deactivate: String,
+            expected: String,
+        ) {
+            // precondition
+            client
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("/graph/v3/databases/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(deactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            shared = """
+              deactivate: |
+                {"active": false}
+              reactivate: |
+                {"active": true}
+            """,
+            cases = """
+            - name: v3-db-react-basic
+              create: |
+                {"database": "v3-db-react-basic", "comment": "test db"}
+              expected: |
+                {"database": "v3-db-react-basic", "active": true}
+            - name: v3-db-react-empty
+              create: |
+                {"database": "v3-db-react-empty", "comment": ""}
+              expected: |
+                {"database": "v3-db-react-empty", "active": true}
+            """,
+        )
+        fun `reactivate database`(
+            name: String,
+            create: String,
+            deactivate: String,
+            reactivate: String,
+            expected: String,
+        ) {
+            // precondition: create + deactivate
+            client
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("/graph/v3/databases/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(deactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("/graph/v3/databases/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(reactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            shared = """
+              deactivate: |
+                {"active": false}
+            """,
+            cases = """
+            - name: v3-db-del-basic
+              create: |
+                {"database": "v3-db-del-basic", "comment": "test db"}
+            - name: v3-db-del-empty
+              create: |
+                {"database": "v3-db-del-empty", "comment": ""}
+            """,
+        )
+        fun `delete database`(
+            name: String,
+            create: String,
+            deactivate: String,
+        ) {
+            // precondition: create + deactivate
+            client
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("/graph/v3/databases/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(deactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .delete()
+                .uri("/graph/v3/databases/$name")
+                .exchange()
+                .expectStatus()
+                .isNoContent
+        }
     }
 
     @Nested

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -377,6 +377,94 @@ class TableControllerTest : E2ETestBase() {
             shared = """
               deactivate: |
                 {"active": false}
+              reactivate: |
+                {"active": true}
+            """,
+            cases = """
+            - name: v3-edge-react
+              create: |
+                {
+                  "table": "v3-edge-react",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/v3_edge_react",
+                  "mode": "SYNC",
+                  "comment": "edge table"
+                }
+              expected: |
+                {"table": "v3-edge-react", "active": true}
+            - name: v3-multiedge-react
+              create: |
+                {
+                  "table": "v3-multiedge-react",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "long", "comment": "id"},
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/v3_multiedge_react",
+                  "mode": "SYNC",
+                  "comment": "multiedge table"
+                }
+              expected: |
+                {"table": "v3-multiedge-react", "active": true}
+            """,
+        )
+        fun `reactivate table`(
+            name: String,
+            create: String,
+            deactivate: String,
+            reactivate: String,
+            expected: String,
+        ) {
+            // precondition: create + deactivate
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(deactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(reactivate)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            shared = """
+              deactivate: |
+                {"active": false}
             """,
             cases = """
             - name: v3-edge-del


### PR DESCRIPTION
## Summary

Refactor V3 metadata CRUD tests to be fully self-contained by removing execution-order dependency (`@TestMethodOrder` + `@Order`) and embedding preconditions in each case via `@ObjectSource`.

Also expand lifecycle coverage by adding/clarifying deactivate, reactivate, and delete scenarios across database/table/alias metadata tests.

## What Changed

- Removed ordered execution from V3 metadata CRUD suites
- Added per-case preconditions (`create`, plus `deactivate`/`reactivate` where needed)
- Used `shared`/`cases` in `@ObjectSource` to reduce duplicated lifecycle payloads
- Added/completed deactivate, reactivate, and delete lifecycle tests in:
  - `DatabaseControllerTest`
  - `TableControllerTest`
  - `AliasControllerTest`

## Why

The previous ordered approach depended on cross-test state and execution sequence.
With `@ObjectSource` `shared`/`cases` support, each test now declares its own setup and assertion path, improving isolation, readability, and maintainability.

## Plan
Created by **claude code (opus 4.6)**

- [x] Step 1: Refactor `DatabaseControllerTest` — remove `@Order`, add self-contained preconditions
- [x] Step 2: Refactor `TableControllerTest` — remove `@Order`, add self-contained preconditions
- [x] Step 3: Refactor `AliasControllerTest` — remove `@Order`, add self-contained preconditions
- [x] Step 4: Expand lifecycle coverage (deactivate/reactivate/delete) where missing
- [x] Step 5: Review round 2 and record findings
- [x] Step 6: Re-run targeted verification tests for affected suites

## Progress
<!-- Each agent appends here. Do NOT remove previous entries. -->
- [x] Steps 1-4 — **claude code (opus 4.6)** (commit 418feaf)
- [x] Steps 5-6 — **opencode (gpt-5.3-codex)** (review comment: https://github.com/kakao/actionbase/pull/190#issuecomment-3858914715)