### PR TITLE
Bump version to 0.2.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.kakao.actionbase
-version=0.0.1-SNAPSHOT
+version=0.2.0-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Following up #207, the initial snapshot version `0.0.1-SNAPSHOT` is bumped to `0.2.0-SNAPSHOT` for the next development cycle.