### PR TITLE
Fix trailing whitespace in DataFrame README

### DIFF
--- a/core-java/src/main/java/com/kakao/actionbase/core/java/dataframe/README.md
+++ b/core-java/src/main/java/com/kakao/actionbase/core/java/dataframe/README.md
@@ -106,4 +106,4 @@ DataFrame emptyDataFrame = DataFrameConverter.emptyDataFrame(YourModel.class, sc
 
 1. Row and DataFrame are immutable objects, so you must create a new instance when modification is needed.
 2. Be careful as exceptions may occur if schema and data types do not match.
-3. Pay attention to memory usage when processing large amounts of data. 
+3. Pay attention to memory usage when processing large amounts of data.


### PR DESCRIPTION
Remove trailing whitespace from line 109 in core-java/src/main/java/com/kakao/actionbase/core/java/dataframe/README.md. This improves code formatting consistency.