### PR TITLE
feat: handle NilLabel gracefully in v3 mutation API

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -27,7 +27,7 @@ class NilTableBinding(
         key: MutationKey,
         before: State,
         after: State,
-    ): Mono<MutationRecordsSummary> = Mono.just(MutationRecordsSummary(IDLE, 0, before, after))
+    ): Mono<MutationRecordsSummary> = Mono.just(MutationRecordsSummary(IDLE, 0, State.initial, State.initial))
 
     override fun handleMutationError(error: Throwable) {}
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -1,0 +1,37 @@
+package com.kakao.actionbase.v2.engine.v3
+
+import com.kakao.actionbase.core.edge.MutationKey
+import com.kakao.actionbase.core.metadata.common.ModelSchema
+import com.kakao.actionbase.core.state.State
+import com.kakao.actionbase.engine.binding.MutationRecordsSummary
+import com.kakao.actionbase.engine.binding.TableBinding
+import com.kakao.actionbase.engine.metadata.MutationMode
+
+import reactor.core.publisher.Mono
+
+class NilTableBinding(
+    descriptor: V3TableDescriptor,
+) : TableBinding {
+    override val table: String = descriptor.table
+    override val schema: ModelSchema = descriptor.schema
+    override val mutationMode: MutationMode = MutationMode.SYNC
+
+    override fun <T> withLock(
+        key: MutationKey,
+        action: () -> Mono<T>,
+    ): Mono<T> = action()
+
+    override fun read(key: MutationKey): Mono<State> = Mono.just(State.initial)
+
+    override fun write(
+        key: MutationKey,
+        before: State,
+        after: State,
+    ): Mono<MutationRecordsSummary> = Mono.just(MutationRecordsSummary(IDLE, 0, before, after))
+
+    override fun handleMutationError(error: Throwable) {}
+
+    private companion object {
+        const val IDLE = "IDLE"
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
@@ -11,6 +11,7 @@ import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
+import com.kakao.actionbase.v2.engine.label.nil.NilLabel
 
 import reactor.core.publisher.Mono
 
@@ -26,6 +27,9 @@ class V2BackedEngine(
         alias: String,
     ): TableBinding {
         val label = graph.getLabel(EntityName(database, alias))
+        if (label is NilLabel) {
+            return NilTableBinding(V3TableDescriptor.create(label.entity))
+        }
         if (label !is HBaseIndexedLabel) {
             throw UnsupportedOperationException(
                 "This Label (${label.entity.fullName}, ${label.javaClass}) is not indexed or not supported for edge mutation",

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.engine.util.runEvenIfCancelled
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.metadata.Metadata
 import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
 import com.kakao.actionbase.v2.engine.test.GraphFixtures
 
@@ -310,6 +311,35 @@ class MutationServiceSpec :
                           "context": {}
                         }
                         """.trimIndent().toDataFrameEdgePayload().toNormalizedString()
+                    actualObject.toNormalizedString() shouldBe expected
+                }.verifyComplete()
+        }
+
+        "NilLabel mutation should return IDLE" {
+            val database = Metadata.sysServiceName
+            val table = Metadata.sysNilLabelName
+            val insertRequest =
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 10, "source": "1000", "target": "9000"}}
+                  ]
+                }
+                """.trimIndent().toEdgeBulkMutationRequest()
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext { actualObject ->
+                    val expected =
+                        """
+                        {
+                          "results": [
+                            {"status": "IDLE", "source": "1000", "target": "9000", "count": 1}
+                          ]
+                        }
+                        """.trimIndent().toEdgeMutationResponse().toNormalizedString()
                     actualObject.toNormalizedString() shouldBe expected
                 }.verifyComplete()
         }


### PR DESCRIPTION
## Summary

Return IDLE status for NilLabel mutations in v3 API instead of throwing
UnsupportedOperationException, aligning with v2 behavior.

Closes #213

## Changes

- Add `NilTableBinding` implementing `TableBinding` with no-op IDLE behavior
- Modify `V2BackedEngine.getTableBinding()` to return `NilTableBinding` for NilLabel
- Add `NilLabel mutation should return IDLE` test in `MutationServiceSpec`

## How to Test

```bash
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.MutationServiceSpec"
```