### PR TITLE
Add status filter to V3 metadata list APIs for inactive data discovery

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 import jakarta.validation.Valid
@@ -25,9 +26,10 @@ class AliasController(
     @GetMapping("/graph/v3/databases/{database}/aliases")
     fun listAliases(
         @PathVariable database: String,
+        @RequestParam(required = false, defaultValue = "ACTIVE") status: MetadataStatus,
     ): Mono<ResponseEntity<List<AliasDescriptor>>> =
         v3CompatService
-            .getAliases(V3NameValidator.validateDatabase(database))
+            .getAliases(V3NameValidator.validateDatabase(database), status)
             .map { ResponseEntity.ok(it) }
 
     @GetMapping("/graph/v3/databases/{database}/aliases/{alias}")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 import jakarta.validation.Valid
@@ -25,9 +26,11 @@ class DatabaseController(
     private val v3CompatService: V3CompatService,
 ) {
     @GetMapping("/graph/v3/databases")
-    fun listDatabases(): Mono<ResponseEntity<List<DatabaseDescriptor>>> =
+    fun listDatabases(
+        @RequestParam(required = false, defaultValue = "ACTIVE") status: MetadataStatus,
+    ): Mono<ResponseEntity<List<DatabaseDescriptor>>> =
         v3CompatService
-            .getDatabases()
+            .getDatabases(status)
             .map { ResponseEntity.ok(it) }
 
     @GetMapping("/graph/v3/databases/{database}")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatus.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatus.kt
@@ -1,0 +1,14 @@
+package com.kakao.actionbase.server.api.graph.v3.metadata
+
+enum class MetadataStatus {
+    ACTIVE,
+    INACTIVE,
+    ALL,
+    ;
+
+    fun matches(active: Boolean): Boolean = when (this) {
+        ACTIVE -> active
+        INACTIVE -> !active
+        ALL -> true
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatus.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatus.kt
@@ -6,9 +6,10 @@ enum class MetadataStatus {
     ALL,
     ;
 
-    fun matches(active: Boolean): Boolean = when (this) {
-        ACTIVE -> active
-        INACTIVE -> !active
-        ALL -> true
-    }
+    fun matches(active: Boolean): Boolean =
+        when (this) {
+            ACTIVE -> active
+            INACTIVE -> !active
+            ALL -> true
+        }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 import jakarta.validation.Valid
@@ -25,9 +26,10 @@ class TableController(
     @GetMapping("/graph/v3/databases/{database}/tables")
     fun listTables(
         @PathVariable database: String,
+        @RequestParam(required = false, defaultValue = "ACTIVE") status: MetadataStatus,
     ): Mono<ResponseEntity<List<TableDescriptor<*>>>> =
         v3CompatService
-            .getTables(V3NameValidator.validateDatabase(database))
+            .getTables(V3NameValidator.validateDatabase(database), status)
             .map { ResponseEntity.ok(it) }
 
     @GetMapping("/graph/v3/databases/{database}/tables/{table}")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -91,7 +91,10 @@ class V3CompatService(
             .getSingle(EntityName(database, table))
             .map { it.toV3TableDescriptor(tenant) }
 
-    fun getTables(database: String, status: MetadataStatus = MetadataStatus.ACTIVE): Mono<List<TableDescriptor<*>>> =
+    fun getTables(
+        database: String,
+        status: MetadataStatus = MetadataStatus.ACTIVE,
+    ): Mono<List<TableDescriptor<*>>> =
         graph.labelDdl
             .getAll(EntityName(database))
             .map { page ->
@@ -170,7 +173,10 @@ class V3CompatService(
             .getSingle(EntityName(database, alias))
             .map { it.toV3AliasDescriptor(tenant) }
 
-    fun getAliases(database: String, status: MetadataStatus = MetadataStatus.ACTIVE): Mono<List<AliasDescriptor>> =
+    fun getAliases(
+        database: String,
+        status: MetadataStatus = MetadataStatus.ACTIVE,
+    ): Mono<List<AliasDescriptor>> =
         graph.aliasDdl
             .getAll(EntityName(database))
             .map { page ->

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -41,12 +41,12 @@ class V3CompatService(
             .getSingle(EntityName.fromOrigin(database))
             .map { it.toV3DatabaseDescriptor(tenant) }
 
-    fun getDatabases(): Mono<List<DatabaseDescriptor>> =
+    fun getDatabases(status: MetadataStatus = MetadataStatus.ACTIVE): Mono<List<DatabaseDescriptor>> =
         graph.serviceDdl
             .getAll(EntityName.origin)
             .map { page ->
                 page.content
-                    .filter { it.active }
+                    .filter { status.matches(it.active) }
                     .map { it.toV3DatabaseDescriptor(tenant) }
             }
 
@@ -91,12 +91,12 @@ class V3CompatService(
             .getSingle(EntityName(database, table))
             .map { it.toV3TableDescriptor(tenant) }
 
-    fun getTables(database: String): Mono<List<TableDescriptor<*>>> =
+    fun getTables(database: String, status: MetadataStatus = MetadataStatus.ACTIVE): Mono<List<TableDescriptor<*>>> =
         graph.labelDdl
             .getAll(EntityName(database))
             .map { page ->
                 page.content
-                    .filter { it.active }
+                    .filter { status.matches(it.active) }
                     .map { it.toV3TableDescriptor(tenant) }
             }
 
@@ -170,12 +170,12 @@ class V3CompatService(
             .getSingle(EntityName(database, alias))
             .map { it.toV3AliasDescriptor(tenant) }
 
-    fun getAliases(database: String): Mono<List<AliasDescriptor>> =
+    fun getAliases(database: String, status: MetadataStatus = MetadataStatus.ACTIVE): Mono<List<AliasDescriptor>> =
         graph.aliasDdl
             .getAll(EntityName(database))
             .map { page ->
                 page.content
-                    .filter { it.active }
+                    .filter { status.matches(it.active) }
                     .map { it.toV3AliasDescriptor(tenant) }
             }
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -411,6 +411,16 @@ class AliasControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `lowercase status value returns 400`() {
+            client
+                .get()
+                .uri("$baseUri?status=active")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `get non-existent alias returns 404`() {
             client
                 .get()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -320,7 +320,96 @@ class AliasControllerTest : E2ETestBase() {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class StatusFilterTest {
+        private val aliasName = "v3-alias-status-filter"
+
+        @BeforeAll
+        fun setup() {
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"alias": "$aliasName", "table": "$table", "comment": "status filter test"}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$aliasName")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"active": false}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
+
+        @Test
+        fun `default status excludes inactive aliases`() {
+            client
+                .get()
+                .uri(baseUri)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.alias == '$aliasName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=ACTIVE excludes inactive aliases`() {
+            client
+                .get()
+                .uri("$baseUri?status=ACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.alias == '$aliasName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=INACTIVE returns only inactive aliases`() {
+            client
+                .get()
+                .uri("$baseUri?status=INACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.alias == '$aliasName')]")
+                .exists()
+        }
+
+        @Test
+        fun `status=ALL returns both active and inactive aliases`() {
+            client
+                .get()
+                .uri("$baseUri?status=ALL")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.alias == '$aliasName')]")
+                .exists()
+        }
+    }
+
+    @Nested
     inner class ValidationTest {
+        @Test
+        fun `invalid status value returns 400`() {
+            client
+                .get()
+                .uri("$baseUri?status=BOGUS")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
         @Test
         fun `get non-existent alias returns 404`() {
             client

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.server.test.E2ETestBase
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -269,7 +270,97 @@ class DatabaseControllerTest : E2ETestBase() {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class StatusFilterTest {
+        private val dbName = "v3-db-status-filter"
+
+        @BeforeAll
+        fun setup() {
+            // create and deactivate a database
+            client
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"database": "$dbName", "comment": "status filter test"}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("/graph/v3/databases/$dbName")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"active": false}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
+
+        @Test
+        fun `default status excludes inactive databases`() {
+            client
+                .get()
+                .uri("/graph/v3/databases")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.database == '$dbName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=ACTIVE excludes inactive databases`() {
+            client
+                .get()
+                .uri("/graph/v3/databases?status=ACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.database == '$dbName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=INACTIVE returns only inactive databases`() {
+            client
+                .get()
+                .uri("/graph/v3/databases?status=INACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.database == '$dbName')]")
+                .exists()
+        }
+
+        @Test
+        fun `status=ALL returns both active and inactive databases`() {
+            client
+                .get()
+                .uri("/graph/v3/databases?status=ALL")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.database == '$dbName')]")
+                .exists()
+        }
+    }
+
+    @Nested
     inner class ValidationTest {
+        @Test
+        fun `invalid status value returns 400`() {
+            client
+                .get()
+                .uri("/graph/v3/databases?status=BOGUS")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
         @Test
         fun `get non-existent database returns 404`() {
             client

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -362,6 +362,16 @@ class DatabaseControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `lowercase status value returns 400`() {
+            client
+                .get()
+                .uri("/graph/v3/databases?status=active")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `get non-existent database returns 404`() {
             client
                 .get()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatusTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatusTest.kt
@@ -1,0 +1,24 @@
+package com.kakao.actionbase.server.api.graph.v3.metadata
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MetadataStatusTest {
+    @Test
+    fun `ACTIVE matches only active entities`() {
+        assertThat(MetadataStatus.ACTIVE.matches(active = true)).isTrue()
+        assertThat(MetadataStatus.ACTIVE.matches(active = false)).isFalse()
+    }
+
+    @Test
+    fun `INACTIVE matches only inactive entities`() {
+        assertThat(MetadataStatus.INACTIVE.matches(active = true)).isFalse()
+        assertThat(MetadataStatus.INACTIVE.matches(active = false)).isTrue()
+    }
+
+    @Test
+    fun `ALL matches both active and inactive entities`() {
+        assertThat(MetadataStatus.ALL.matches(active = true)).isTrue()
+        assertThat(MetadataStatus.ALL.matches(active = false)).isTrue()
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -646,6 +646,16 @@ class TableControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `lowercase status value returns 400`() {
+            client
+                .get()
+                .uri("$baseUri?status=active")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `get non-existent table returns 404`() {
             client
                 .get()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -538,7 +538,113 @@ class TableControllerTest : E2ETestBase() {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class StatusFilterTest {
+        private val tableName = "v3-tbl-status-filter"
+
+        @BeforeAll
+        fun setup() {
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(
+                    """
+                    {
+                      "table": "$tableName",
+                      "schema": {
+                        "type": "EDGE",
+                        "source": {"type": "string", "comment": "src"},
+                        "target": {"type": "string", "comment": "tgt"},
+                        "properties": [],
+                        "direction": "OUT",
+                        "indexes": [],
+                        "groups": []
+                      },
+                      "storage": "datastore://test_namespace/v3_tbl_status_filter",
+                      "mode": "SYNC",
+                      "comment": "status filter test"
+                    }
+                    """.trimIndent(),
+                ).exchange()
+                .expectStatus()
+                .isOk
+
+            client
+                .put()
+                .uri("$baseUri/$tableName")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"active": false}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
+
+        @Test
+        fun `default status excludes inactive tables`() {
+            client
+                .get()
+                .uri(baseUri)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.table == '$tableName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=ACTIVE excludes inactive tables`() {
+            client
+                .get()
+                .uri("$baseUri?status=ACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.table == '$tableName')]")
+                .doesNotExist()
+        }
+
+        @Test
+        fun `status=INACTIVE returns only inactive tables`() {
+            client
+                .get()
+                .uri("$baseUri?status=INACTIVE")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.table == '$tableName')]")
+                .exists()
+        }
+
+        @Test
+        fun `status=ALL returns both active and inactive tables`() {
+            client
+                .get()
+                .uri("$baseUri?status=ALL")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$[?(@.table == '$tableName')]")
+                .exists()
+        }
+    }
+
+    @Nested
     inner class ValidationTest {
+        @Test
+        fun `invalid status value returns 400`() {
+            client
+                .get()
+                .uri("$baseUri?status=BOGUS")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
         @Test
         fun `get non-existent table returns 404`() {
             client


### PR DESCRIPTION
## Summary

Add `status` query parameter (`ACTIVE`/`INACTIVE`/`ALL`) to V3 metadata list endpoints, enabling discovery of inactive items for cleanup purposes.

Closes #212

## Changes

- Add `MetadataStatus` enum with `matches()` method for status-based filtering
- Add `@RequestParam status` (default: `ACTIVE`) to `DatabaseController`, `TableController`, `AliasController` list endpoints
- Replace hardcoded `.filter { it.active }` in `V3CompatService` with `status.matches(it.active)`
- Add E2E tests for status filtering (default, ACTIVE, INACTIVE, ALL) on all 3 endpoints
- Add unit tests for `MetadataStatus.matches()` logic
- Add validation tests for invalid status values (400 Bad Request)

## How to Test

```bash
# Default (backward compatible) — returns only active
GET /graph/v3/databases

# Explicit active filter
GET /graph/v3/databases?status=ACTIVE

# Inactive items only
GET /graph/v3/databases?status=INACTIVE

# All items regardless of status
GET /graph/v3/databases?status=ALL

# Invalid value returns 400
GET /graph/v3/databases?status=BOGUS
```

Same pattern applies to `/graph/v3/databases/{db}/tables` and `/graph/v3/databases/{db}/aliases`.

## Note

The original discussion in #212 used lowercase values (`active|inactive|all`), but this PR implements them as uppercase (`ACTIVE`/`INACTIVE`/`ALL`). This project's enum parameter binding is case-sensitive — the query parameter value must exactly match the enum constant name. Lowercase values (e.g. `?status=active`) return 400 Bad Request. If case-insensitive support is desired, a custom converter can be registered separately.