### PR TITLE
Add release workflows for version bumping

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,53 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 0.2.0)'
+        required: true
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${{ inputs.version }}. Expected: X.Y.Z"
+            exit 1
+          fi
+
+      - name: Check current version is SNAPSHOT
+        run: |
+          current=$(grep '^version=' gradle.properties | cut -d= -f2)
+          if [[ "$current" != *-SNAPSHOT ]]; then
+            echo "::error::Current version ($current) is not a SNAPSHOT version"
+            exit 1
+          fi
+          echo "current_version=$current" >> $GITHUB_ENV
+
+      - name: Update gradle.properties
+        run: |
+          sed -i "s/^version=.*/version=${{ inputs.version }}/" gradle.properties
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release/v${{ inputs.version }}
+          commit-message: "Bump version to ${{ inputs.version }}"
+          title: "Bump version to ${{ inputs.version }}"
+          body: |
+            Bump version from `${{ env.current_version }}` to `${{ inputs.version }}` for release.
+
+            After merging, the following will happen automatically:
+            - Tag `v${{ inputs.version }}` will be created
+            - Release branch will be created
+            - Main will be bumped to the next SNAPSHOT version
+          labels: release

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -48,6 +48,6 @@ jobs:
 
             After merging, the following will happen automatically:
             - Tag `v${{ inputs.version }}` will be created
-            - Release branch will be created
-            - Main will be bumped to the next SNAPSHOT version
+            - Release branch will be created with the next patch SNAPSHOT
+            - A follow-up PR will be opened to bump main to the next minor SNAPSHOT
           labels: release

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,9 +18,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: ${{ inputs.version }}. Expected: X.Y.Z"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION. Expected: X.Y.Z"
             exit 1
           fi
 
@@ -34,8 +36,10 @@ jobs:
           echo "current_version=$current" >> $GITHUB_ENV
 
       - name: Update gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/^version=.*/version=${{ inputs.version }}/" gradle.properties
+          sed -i "s/^version=.*/version=$VERSION/" gradle.properties
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -50,6 +50,11 @@ jobs:
           git commit -m "Bump version to ${{ env.next_patch }}"
           git push origin "${{ env.release_branch }}"
 
+      - name: Prepare main for next SNAPSHOT
+        run: |
+          git checkout main
+          sed -i "s/^version=.*/version=${{ env.next_minor }}/" gradle.properties
+
       - name: Create PR to bump main to next SNAPSHOT
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,58 @@
+name: Post Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version
+        run: |
+          version=$(grep '^version=' gradle.properties | cut -d= -f2)
+          major=${version%%.*}
+          rest=${version#*.}
+          minor=${rest%%.*}
+          patch=${version##*.}
+
+          echo "version=$version" >> $GITHUB_ENV
+          echo "release_branch=${major}.${minor}.x" >> $GITHUB_ENV
+          echo "next_minor=${major}.$((minor + 1)).0-SNAPSHOT" >> $GITHUB_ENV
+          echo "next_patch=${major}.${minor}.$((patch + 1))-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Create tag
+        run: |
+          git tag "v${{ env.version }}"
+          git push origin "v${{ env.version }}"
+
+      - name: Create release branch
+        run: |
+          git checkout -b "${{ env.release_branch }}" "v${{ env.version }}"
+          sed -i "s/^version=.*/version=${{ env.next_patch }}/" gradle.properties
+          git add gradle.properties
+          git commit -m "Bump version to ${{ env.next_patch }}"
+          git push origin "${{ env.release_branch }}"
+
+      - name: Bump main to next SNAPSHOT
+        run: |
+          git checkout main
+          sed -i "s/^version=.*/version=${{ env.next_minor }}/" gradle.properties
+          git add gradle.properties
+          git commit -m "Bump version to ${{ env.next_minor }}"
+          git push origin main

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,10 +50,16 @@ jobs:
           git commit -m "Bump version to ${{ env.next_patch }}"
           git push origin "${{ env.release_branch }}"
 
-      - name: Bump main to next SNAPSHOT
-        run: |
-          git checkout main
-          sed -i "s/^version=.*/version=${{ env.next_minor }}/" gradle.properties
-          git add gradle.properties
-          git commit -m "Bump version to ${{ env.next_minor }}"
-          git push origin main
+      - name: Create PR to bump main to next SNAPSHOT
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bump-main/v${{ env.version }}
+          commit-message: "Bump version to ${{ env.next_minor }}"
+          title: "Bump version to ${{ env.next_minor }}"
+          body: |
+            Post-release version bump from `${{ env.version }}` to `${{ env.next_minor }}`.
+
+            Released:
+            - Tag `v${{ env.version }}` created
+            - Branch `${{ env.release_branch }}` created with `${{ env.next_patch }}`
+          labels: release


### PR DESCRIPTION
## Summary

Add automated release workflows for version bumping and post-release tasks.

### Bump Version (`bump-version.yml`)
- Manual trigger via `workflow_dispatch` with version input
- Validates version format and checks current version is SNAPSHOT
- Creates a PR to update `gradle.properties`

### Post Release (`post-release.yml`)
- Triggered automatically when a `release/v*` PR is merged to main
- Creates a version tag (e.g., `v0.2.0`)
- Creates a release branch (e.g., `0.2.x`) with the next patch SNAPSHOT
- Opens a follow-up PR to bump main to the next minor SNAPSHOT

### Flow

```
1. [manual]    Actions tab → "Bump Version" → enter version (e.g., 0.2.0)
               → PR #1: "Bump version to 0.2.0"
2. [manual]    Merge PR #1
               → (automatic) tag v0.2.0
               → (automatic) create 0.2.x branch (0.2.1-SNAPSHOT)
               → (automatic) PR #2: "Bump version to 0.3.0-SNAPSHOT"
3. [manual]    Merge PR #2
               → main is now 0.3.0-SNAPSHOT
```

## Test plan

- [x] Run "Bump Version" workflow manually and verify PR is created with correct version
- [x] Merge the PR and verify post-release creates tag, release branch, and follow-up PR
- [x] Merge the follow-up PR and verify main is bumped to the next SNAPSHOT
