### PR TITLE
Support patch release workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release version (e.g., 0.2.0)'
         required: true
         type: string
+      branch:
+        description: 'Target branch (default: main, e.g., 0.2.x for patch release)'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   bump:
@@ -16,6 +21,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Validate version format
         env:
@@ -44,14 +51,15 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          base: ${{ inputs.branch }}
           branch: release/v${{ inputs.version }}
           commit-message: "Bump version to ${{ inputs.version }}"
           title: "Bump version to ${{ inputs.version }}"
           body: |
-            Bump version from `${{ env.current_version }}` to `${{ inputs.version }}` for release.
+            Bump version from `${{ env.current_version }}` to `${{ inputs.version }}`.
+            Target: `${{ inputs.branch }}`
 
             After merging, the following will happen automatically:
             - Tag `v${{ inputs.version }}` will be created
-            - Release branch will be created with the next patch SNAPSHOT
-            - A follow-up PR will be opened to bump main to the next minor SNAPSHOT
+            - Version will be bumped to the next SNAPSHOT
           labels: release

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,7 +3,9 @@ name: Post Release
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches:
+      - main
+      - '*.x'
 
 jobs:
   release:
@@ -31,8 +33,11 @@ jobs:
           rest=${version#*.}
           minor=${rest%%.*}
           patch=${version##*.}
+          base=${{ github.event.pull_request.base.ref }}
 
           echo "version=$version" >> $GITHUB_ENV
+          echo "base_branch=$base" >> $GITHUB_ENV
+          echo "is_patch=$([[ "$base" != "main" ]] && echo true || echo false)" >> $GITHUB_ENV
           echo "release_branch=${major}.${minor}.x" >> $GITHUB_ENV
           echo "next_minor=${major}.$((minor + 1)).0-SNAPSHOT" >> $GITHUB_ENV
           echo "next_patch=${major}.${minor}.$((patch + 1))-SNAPSHOT" >> $GITHUB_ENV
@@ -42,7 +47,8 @@ jobs:
           git tag "v${{ env.version }}"
           git push origin "v${{ env.version }}"
 
-      - name: Create release branch
+      - name: Create release branch (minor release only)
+        if: env.is_patch == 'false'
         run: |
           git checkout -b "${{ env.release_branch }}" "v${{ env.version }}"
           sed -i "s/^version=.*/version=${{ env.next_patch }}/" gradle.properties
@@ -50,12 +56,23 @@ jobs:
           git commit -m "Bump version to ${{ env.next_patch }}"
           git push origin "${{ env.release_branch }}"
 
-      - name: Prepare main for next SNAPSHOT
+      - name: Bump release branch (patch release only)
+        if: env.is_patch == 'true'
+        run: |
+          git checkout "${{ env.base_branch }}"
+          sed -i "s/^version=.*/version=${{ env.next_patch }}/" gradle.properties
+          git add gradle.properties
+          git commit -m "Bump version to ${{ env.next_patch }}"
+          git push origin "${{ env.base_branch }}"
+
+      - name: Prepare main for next SNAPSHOT (minor release only)
+        if: env.is_patch == 'false'
         run: |
           git checkout main
           sed -i "s/^version=.*/version=${{ env.next_minor }}/" gradle.properties
 
-      - name: Create PR to bump main to next SNAPSHOT
+      - name: Create PR to bump main (minor release only)
+        if: env.is_patch == 'false'
         uses: peter-evans/create-pull-request@v7
         with:
           branch: bump-main/v${{ env.version }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,62 @@ Actionbase has been running in production internally at Kakao. The open-source r
 
 The `1.0.0` release will mark the point where external users can deploy Actionbase in production environments.
 
+## Release workflow
+
+Releases are automated via GitHub Actions. Development uses `-SNAPSHOT` suffixes.
+
+### Branch model
+
+```
+main:    A ─ B ─ C ─ D ─ E ─ ...          (0.3.0-SNAPSHOT)
+                 │
+          tag v0.2.0
+                 └── 0.2.x:  C ── F ──    (0.2.1-SNAPSHOT)
+                                   │
+                            tag v0.2.1
+```
+
+- `main` — active development, always `X.Y.0-SNAPSHOT`
+- `X.Y.x` — release branch, created automatically on minor release
+
+### Minor release
+
+Three manual steps, everything else is automatic.
+
+```
+1. [manual]    Actions → "Bump Version" → version: 0.2.0
+               → PR: "Bump version to 0.2.0"
+2. [manual]    Merge PR
+               → (auto) tag v0.2.0
+               → (auto) create 0.2.x branch (0.2.1-SNAPSHOT)
+               → (auto) PR: "Bump version to 0.3.0-SNAPSHOT"
+3. [manual]    Merge snapshot PR
+               → main is now 0.3.0-SNAPSHOT
+```
+
+### Patch release
+
+Two manual steps. Fixes go to `main` first, then cherry-pick to the release branch.
+
+```
+1. [manual]    Actions → "Bump Version" → version: 0.2.1, branch: 0.2.x
+               → PR: "Bump version to 0.2.1" (against 0.2.x)
+2. [manual]    Merge PR
+               → (auto) tag v0.2.1
+               → (auto) 0.2.x bumped to 0.2.2-SNAPSHOT
+```
+
+### Upstream-first
+
+Fixes go to `main` first, then cherry-pick to release branches.
+
+```
+✅  main → cherry-pick → 0.2.x
+❌  commit directly to 0.2.x only
+```
+
+Exception: when `main` has diverged significantly and cherry-pick is not feasible, apply directly to the release branch with a note in the commit message.
+
 ## Compatibility promise
 
 The following applies **after 1.0.0**:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,62 +22,6 @@ Actionbase has been running in production internally at Kakao. The open-source r
 
 The `1.0.0` release will mark the point where external users can deploy Actionbase in production environments.
 
-## Release workflow
-
-Releases are automated via GitHub Actions. Development uses `-SNAPSHOT` suffixes.
-
-### Branch model
-
-```
-main:    A ─ B ─ C ─ D ─ E ─ ...          (0.3.0-SNAPSHOT)
-                 │
-          tag v0.2.0
-                 └── 0.2.x:  C ── F ──    (0.2.1-SNAPSHOT)
-                                   │
-                            tag v0.2.1
-```
-
-- `main` — active development, always `X.Y.0-SNAPSHOT`
-- `X.Y.x` — release branch, created automatically on minor release
-
-### Minor release
-
-Three manual steps, everything else is automatic.
-
-```
-1. [manual]    Actions → "Bump Version" → version: 0.2.0
-               → PR: "Bump version to 0.2.0"
-2. [manual]    Merge PR
-               → (auto) tag v0.2.0
-               → (auto) create 0.2.x branch (0.2.1-SNAPSHOT)
-               → (auto) PR: "Bump version to 0.3.0-SNAPSHOT"
-3. [manual]    Merge snapshot PR
-               → main is now 0.3.0-SNAPSHOT
-```
-
-### Patch release
-
-Two manual steps. Fixes go to `main` first, then cherry-pick to the release branch.
-
-```
-1. [manual]    Actions → "Bump Version" → version: 0.2.1, branch: 0.2.x
-               → PR: "Bump version to 0.2.1" (against 0.2.x)
-2. [manual]    Merge PR
-               → (auto) tag v0.2.1
-               → (auto) 0.2.x bumped to 0.2.2-SNAPSHOT
-```
-
-### Upstream-first
-
-Fixes go to `main` first, then cherry-pick to release branches.
-
-```
-✅  main → cherry-pick → 0.2.x
-❌  commit directly to 0.2.x only
-```
-
-Exception: when `main` has diverged significantly and cherry-pick is not feasible, apply directly to the release branch with a note in the commit message.
-
 ## Compatibility promise
 
 The following applies **after 1.0.0**:


### PR DESCRIPTION
## Summary

Support patch releases (e.g., 0.2.1) from release branches (e.g., 0.2.x).

## Changes

### bump-version.yml
- Add `branch` input (default: `main`, e.g., `0.2.x` for patch release)
- Checkout and create PR against the target branch

### post-release.yml
- Trigger on `*.x` branches in addition to `main`
- Detect minor vs patch release based on target branch
- Patch release: tag + bump release branch to next patch SNAPSHOT
- Minor release: tag + create release branch + bump main (unchanged)

### Flow

**Minor release** (unchanged):
```
1. [manual]    "Bump Version" → version: 0.3.0
2. [manual]    Merge PR to main
               → (automatic) tag, release branch, next SNAPSHOT PR
3. [manual]    Merge next SNAPSHOT PR
```

**Patch release** (new):
```
1. [manual]    "Bump Version" → version: 0.2.1, branch: 0.2.x
2. [manual]    Merge PR to 0.2.x
               → (automatic) tag v0.2.1
               → (automatic) 0.2.x bumped to 0.2.2-SNAPSHOT
```

## Test plan

- [ ] Run "Bump Version" with version: 0.2.1, branch: 0.2.x
- [ ] Verify PR is created against 0.2.x
- [ ] Merge and verify tag v0.2.1 + 0.2.x bumped to 0.2.2-SNAPSHOT
- [ ] Verify no main bump PR is created
