### PR TITLE
Document release workflow in RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,62 @@ Actionbase has been running in production internally at Kakao. The open-source r
 
 The `1.0.0` release will mark the point where external users can deploy Actionbase in production environments.
 
+## Release workflow
+
+Releases are automated via GitHub Actions. Development uses `-SNAPSHOT` suffixes.
+
+### Branch model
+
+```
+main:    A ─ B ─ C ─ D ─ E ─ ...          (0.3.0-SNAPSHOT)
+                 │
+          tag v0.2.0
+                 └── 0.2.x:  C ── F ──    (0.2.1-SNAPSHOT)
+                                   │
+                            tag v0.2.1
+```
+
+- `main` — active development, always `X.Y.0-SNAPSHOT`
+- `X.Y.x` — release branch, created automatically on minor release
+
+### Minor release
+
+Three manual steps, everything else is automatic.
+
+```
+1. [manual]    Actions → "Bump Version" → version: 0.2.0
+               → PR: "Bump version to 0.2.0"
+2. [manual]    Merge PR
+               → (auto) tag v0.2.0
+               → (auto) create 0.2.x branch (0.2.1-SNAPSHOT)
+               → (auto) PR: "Bump version to 0.3.0-SNAPSHOT"
+3. [manual]    Merge snapshot PR
+               → main is now 0.3.0-SNAPSHOT
+```
+
+### Patch release
+
+Two manual steps. Fixes go to `main` first, then cherry-pick to the release branch.
+
+```
+1. [manual]    Actions → "Bump Version" → version: 0.2.1, branch: 0.2.x
+               → PR: "Bump version to 0.2.1" (against 0.2.x)
+2. [manual]    Merge PR
+               → (auto) tag v0.2.1
+               → (auto) 0.2.x bumped to 0.2.2-SNAPSHOT
+```
+
+### Upstream-first
+
+Fixes go to `main` first, then cherry-pick to release branches.
+
+```
+✅  main → cherry-pick → 0.2.x
+❌  commit directly to 0.2.x only
+```
+
+Exception: when `main` has diverged significantly and cherry-pick is not feasible, apply directly to the release branch with a note in the commit message.
+
 ## Compatibility promise
 
 The following applies **after 1.0.0**:


### PR DESCRIPTION
## Summary

Add release workflow documentation to RELEASES.md covering the automated GitHub Actions flow.

Ref: #207

## Changes

Add "Release workflow" section with:
- **Branch model** — `main` + `X.Y.x` release branches
- **Minor release** — 3 manual steps (trigger, merge, merge snapshot PR)
- **Patch release** — 2 manual steps (trigger with branch, merge)
- **Upstream-first** — fixes go to main first, then cherry-pick

All consistent with the policy established in #207 and the workflows in #220 and #224.
