### PR TITLE
Introduce QueryEngine interface with getTableBinding()

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
@@ -1,17 +1,32 @@
 package com.kakao.actionbase.engine
 
 import com.kakao.actionbase.engine.binding.TableBinding
+import com.kakao.actionbase.engine.query.ActionbaseQuery
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.label.Label
+import com.kakao.actionbase.v2.engine.sql.DataFrame
+import com.kakao.actionbase.v2.engine.sql.ScanFilter
+
+import reactor.core.publisher.Mono
 
 /**
  * Query engine abstraction used by the V3 Query path.
- * Resolves table bindings without direct references to V2 internals (Graph, Label).
+ * Decouples QueryService from Graph by exposing only the operations it needs.
+ *
+ * Note: some methods still expose V2 types (Label, ScanFilter, DataFrame) —
+ * these will be abstracted in future iterations.
  */
 interface QueryEngine {
-    /**
-     * Resolves a table binding from a database/alias pair.
-     */
     fun getTableBinding(
         database: String,
         alias: String,
     ): TableBinding
+
+    fun getLabel(name: EntityName): Label
+
+    fun singleStepQuery(scanFilter: ScanFilter): Mono<DataFrame>
+
+    fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>>
+
+    val encoderPoolSize: Int
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
@@ -1,0 +1,17 @@
+package com.kakao.actionbase.engine
+
+import com.kakao.actionbase.engine.binding.TableBinding
+
+/**
+ * Query engine abstraction used by the V3 Query path.
+ * Resolves table bindings without direct references to V2 internals (Graph, Label).
+ */
+interface QueryEngine {
+    /**
+     * Resolves a table binding from a database/alias pair.
+     */
+    fun getTableBinding(
+        database: String,
+        alias: String,
+    ): TableBinding
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -15,12 +15,12 @@ import com.kakao.actionbase.core.edge.record.EdgeGroupRecord
 import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.storage.HBaseRecord
+import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.query.ActionbaseQuery
 import com.kakao.actionbase.v2.core.code.CryptoUtils
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.core.metadata.LabelType
-import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseHashLabel
 import com.kakao.actionbase.v2.engine.sql.DataFrame
@@ -33,9 +33,9 @@ import org.apache.hadoop.hbase.client.Get
 import reactor.core.publisher.Mono
 
 class QueryService(
-    private val graph: Graph,
+    private val engine: QueryEngine,
 ) {
-    private val byteArrayBufferPool = ByteArrayBufferPool.create(graph.encoderPoolSize, Constants.Codec.DEFAULT_BUFFER_SIZE)
+    private val byteArrayBufferPool = ByteArrayBufferPool.create(engine.encoderPoolSize, Constants.Codec.DEFAULT_BUFFER_SIZE)
 
     private val groupRecordMapper = EdgeGroupRecordMapper.create(byteArrayBufferPool)
     private val cacheRecordMapper = EdgeCacheRecordMapper.create(byteArrayBufferPool)
@@ -70,7 +70,7 @@ class QueryService(
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgeCountPayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         require(ranges == null) { "`ranges` is not yet supported in count query." }
         require(filters == null) { "`filters` is not yet supported in count query." }
@@ -130,7 +130,7 @@ class QueryService(
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         require(label.entity.type == LabelType.MULTI_EDGE) {
             "get query with ids is only supported for multi-edge tables."
@@ -149,7 +149,7 @@ class QueryService(
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         require(label is HBaseHashLabel) {
             "get query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."
@@ -186,7 +186,7 @@ class QueryService(
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         val indexFieldNames =
             label.entity.indices
@@ -244,7 +244,7 @@ class QueryService(
             } else {
                 DEFAULT_TOTAL_VALUE_MONO
             }
-        val dfMono = graph.singleStepQuery(scanFilter)
+        val dfMono = engine.singleStepQuery(scanFilter)
 
         return dfMono
             .zipWith(totalMono)
@@ -266,7 +266,7 @@ class QueryService(
         offset: String? = null,
     ): Mono<DataFrameEdgePayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         require(label is HBaseHashLabel) {
             "cache query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."
@@ -364,7 +364,7 @@ class QueryService(
         ttl: Long? = null,
     ): Mono<DataFrameEdgeAggPayload> {
         val name = EntityName(database, table)
-        val label = graph.getLabel(name)
+        val label = engine.getLabel(name)
 
         require(label is HBaseHashLabel) {
             "group query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."
@@ -466,7 +466,7 @@ class QueryService(
             }
     }
 
-    fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>> = graph.query(request)
+    fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>> = engine.query(request)
 
     private fun encodeAggRanges(
         values: List<Any>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
@@ -9,10 +9,14 @@ import com.kakao.actionbase.engine.MutationEngine
 import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.query.ActionbaseQuery
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.label.Label
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.label.nil.NilLabel
+import com.kakao.actionbase.v2.engine.sql.DataFrame
+import com.kakao.actionbase.v2.engine.sql.ScanFilter
 
 import reactor.core.publisher.Mono
 
@@ -39,6 +43,15 @@ class V2BackedEngine(
         }
         return label.tableBinding
     }
+
+    override fun getLabel(name: EntityName): Label = graph.getLabel(name)
+
+    override fun singleStepQuery(scanFilter: ScanFilter): Mono<DataFrame> = graph.singleStepQuery(scanFilter)
+
+    override fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>> = graph.query(request)
+
+    override val encoderPoolSize: Int
+        get() = graph.encoderPoolSize
 
     private val messaging = V2BackedMessageBinding(wal = graph.wal, cdc = graph.cdc)
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
@@ -6,6 +6,7 @@ import com.kakao.actionbase.core.edge.MutationEvent
 import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.MutationContext
 import com.kakao.actionbase.engine.MutationEngine
+import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
@@ -21,7 +22,8 @@ import reactor.core.publisher.Mono
  */
 class V2BackedEngine(
     private val graph: Graph,
-) : MutationEngine {
+) : MutationEngine,
+    QueryEngine {
     override fun getTableBinding(
         database: String,
         alias: String,

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
@@ -37,8 +37,9 @@ class EdgeCacheQuerySpec :
 
         beforeTest {
             graph = GraphFixtures.create()
-            mutationService = MutationService(V2BackedEngine(graph))
-            queryService = QueryService(graph)
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
         }
 
         afterTest {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
@@ -33,8 +33,9 @@ class MutationServiceSpec :
 
         beforeTest {
             graph = GraphFixtures.create()
-            mutationService = MutationService(V2BackedEngine(graph))
-            queryService = QueryService(graph)
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
         }
 
         afterTest {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
@@ -20,7 +20,7 @@ class QueryServiceSpec :
 
         beforeTest {
             graph = GraphFixtures.create()
-            queryService = QueryService(graph)
+            queryService = QueryService(V2BackedEngine(graph))
         }
 
         afterTest {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
@@ -93,8 +93,9 @@ class MultiEdgeSpec :
             cdc = graph.cdc as InMemoryCdc
             val request = mapper.readValue<LabelCreateRequest>(labelDefinition)
             graph.labelDdl.create(keyEdgeLabelName, request).block()
-            mutationService = MutationService(V2BackedEngine(graph))
-            queryService = QueryService(graph)
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
         }
 
         afterTest {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceAsyncSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceAsyncSpec.kt
@@ -172,8 +172,9 @@ class MutationServiceAsyncSpec :
 
             val request2 = mapper.readValue<LabelCreateRequest>(edgeDescriptor)
             graph.labelDdl.create(edgeTableName, request2).block()
-            mutationService = MutationService(V2BackedEngine(graph))
-            queryService = QueryService(graph)
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
         }
 
         afterTest {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceSystemAsyncSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceSystemAsyncSpec.kt
@@ -67,8 +67,9 @@ class MutationServiceSystemAsyncSpec :
             asyncEdgeTable = graph.getLabel(EntityName(database, asyncEdgeTableName))
             asyncMultiEdgeTable = graph.getLabel(EntityName(database, asyncMultiEdgeTableName))
 
-            mutationService = MutationService(V2BackedEngine(graph))
-            queryService = QueryService(graph)
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
         }
 
         afterTest {

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.configuration
 
 import com.kakao.actionbase.engine.MutationEngine
+import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.service.MutationService
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.server.client.kafka.SpringKafkaClientFactory
@@ -136,6 +137,9 @@ class GraphConfiguration {
 
     @Bean
     fun provideMutationEngine(graph: Graph): MutationEngine = V2BackedEngine(graph)
+
+    @Bean
+    fun provideQueryEngine(graph: Graph): QueryEngine = V2BackedEngine(graph)
 
     @Bean
     fun provideMutationService(engine: MutationEngine): MutationService = MutationService(engine)

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
@@ -1,7 +1,5 @@
 package com.kakao.actionbase.server.configuration
 
-import com.kakao.actionbase.engine.MutationEngine
-import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.service.MutationService
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.server.client.kafka.SpringKafkaClientFactory
@@ -133,14 +131,11 @@ class GraphConfiguration {
     fun provideLocalMetastoreInspector(graph: Graph): MetastoreInspector = MetastoreInspector.createLocal(graph)
 
     @Bean
-    fun provideQueryService(graph: Graph): QueryService = QueryService(graph)
+    fun provideV2BackedEngine(graph: Graph): V2BackedEngine = V2BackedEngine(graph)
 
     @Bean
-    fun provideMutationEngine(graph: Graph): MutationEngine = V2BackedEngine(graph)
+    fun provideQueryService(engine: V2BackedEngine): QueryService = QueryService(engine)
 
     @Bean
-    fun provideQueryEngine(graph: Graph): QueryEngine = V2BackedEngine(graph)
-
-    @Bean
-    fun provideMutationService(engine: MutationEngine): MutationService = MutationService(engine)
+    fun provideMutationService(engine: V2BackedEngine): MutationService = MutationService(engine)
 }


### PR DESCRIPTION
## Summary

Introduce `QueryEngine` interface mirroring `MutationEngine` pattern.

Partial fix for #231

## Changes

- Add `QueryEngine` interface with `getTableBinding()`
- Make `V2BackedEngine` implement `QueryEngine`
- Wire `QueryEngine` bean in `GraphConfiguration`

## How to Test

```
./gradlew build
```