### PR TITLE
Remove EntityName from QueryEngine.getLabel() signature

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/QueryEngine.kt
@@ -2,7 +2,6 @@ package com.kakao.actionbase.engine
 
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.query.ActionbaseQuery
-import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.label.Label
 import com.kakao.actionbase.v2.engine.sql.DataFrame
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
@@ -22,7 +21,10 @@ interface QueryEngine {
         alias: String,
     ): TableBinding
 
-    fun getLabel(name: EntityName): Label
+    fun getLabel(
+        database: String,
+        alias: String,
+    ): Label
 
     fun singleStepQuery(scanFilter: ScanFilter): Mono<DataFrame>
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -69,8 +69,7 @@ class QueryService(
         filters: String? = null,
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgeCountPayload> {
-        val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         require(ranges == null) { "`ranges` is not yet supported in count query." }
         require(filters == null) { "`filters` is not yet supported in count query." }
@@ -129,8 +128,7 @@ class QueryService(
         filters: String? = null,
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
-        val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         require(label.entity.type == LabelType.MULTI_EDGE) {
             "get query with ids is only supported for multi-edge tables."
@@ -148,8 +146,7 @@ class QueryService(
         filters: String? = null,
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
-        val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         require(label is HBaseHashLabel) {
             "get query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."
@@ -186,7 +183,7 @@ class QueryService(
         features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> {
         val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         val indexFieldNames =
             label.entity.indices
@@ -265,8 +262,7 @@ class QueryService(
         limit: Int = ScanFilter.defaultLimit,
         offset: String? = null,
     ): Mono<DataFrameEdgePayload> {
-        val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         require(label is HBaseHashLabel) {
             "cache query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."
@@ -363,8 +359,7 @@ class QueryService(
         features: List<String> = emptyList(),
         ttl: Long? = null,
     ): Mono<DataFrameEdgeAggPayload> {
-        val name = EntityName(database, table)
-        val label = engine.getLabel(name)
+        val label = engine.getLabel(database, table)
 
         require(label is HBaseHashLabel) {
             "group query is only supported for HBaseHashLabel, but got ${label::class.java.simpleName}."

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
@@ -44,7 +44,10 @@ class V2BackedEngine(
         return label.tableBinding
     }
 
-    override fun getLabel(name: EntityName): Label = graph.getLabel(name)
+    override fun getLabel(
+        database: String,
+        alias: String,
+    ): Label = graph.getLabel(EntityName(database, alias))
 
     override fun singleStepQuery(scanFilter: ScanFilter): Mono<DataFrame> = graph.singleStepQuery(scanFilter)
 


### PR DESCRIPTION
## Summary

Replace `QueryEngine.getLabel(name: EntityName)` with `getLabel(database, alias)` to remove V2 `EntityName` dependency from the interface.

Partial fix for #231

## Changes

- `QueryEngine.getLabel(name: EntityName)` → `getLabel(database: String, alias: String)`
- `V2BackedEngine` creates `EntityName` internally
- `QueryService`: remove `EntityName` construction at 5 call sites (1 remains for `ScanFilter`)

## How to Test

```
./gradlew build
```