### PR TITLE
Fix typo in V2MutationMode enum: IGRNORE → IGNORE

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/v2/metadata/common/V2MutationMode.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/v2/metadata/common/V2MutationMode.kt
@@ -3,5 +3,5 @@ package com.kakao.actionbase.core.v2.metadata.common
 enum class V2MutationMode {
     SYNC,
     ASYNC,
-    IGRNORE,
+    IGNORE,
 }


### PR DESCRIPTION
## Summary

Fix a typo in the `V2MutationMode` enum where `IGRNORE` should be `IGNORE`.

## Changes

- Rename `IGRNORE` to `IGNORE` in `V2MutationMode.kt`

## How to Test

```bash
./gradlew :core:test
```