### PR TITLE
Support schema `caches` in V3 DDL API

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/LabelDdlService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/LabelDdlService.kt
@@ -126,6 +126,7 @@ data class LabelUpdateRequest(
     val indices: List<Index>?,
     val readOnly: Boolean?,
     val mode: MutationMode?,
+    val caches: List<Cache>?,
     override val audit: Audit = Audit.default,
 ) : DdlRequest {
     private fun toNotNullMap(): Map<String, Any> =
@@ -138,6 +139,7 @@ data class LabelUpdateRequest(
             schema?.let { put("schema", objectMapper.writeValueAsString(it)) }
             groups?.let { put("groups", objectMapper.writeValueAsString(it)) }
             indices?.let { put("indices", objectMapper.writeValueAsString(it)) }
+            caches?.let { put("caches", objectMapper.writeValueAsString(it)) }
         }
 
     override fun toEdge(name: EntityName): TraceEdge = name.toTraceEdge(props = toNotNullMap())

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metadata/LabelSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metadata/LabelSpec.kt
@@ -79,6 +79,7 @@ class LabelSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -107,6 +108,7 @@ class LabelSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -128,6 +130,7 @@ class LabelSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -183,6 +186,7 @@ class LabelSpec :
                     schema = schema,
                     groups = null,
                     indices = indices,
+                    caches = null,
                 )
 
             graph.labelDdl

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DdlServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DdlServiceSpec.kt
@@ -159,6 +159,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -200,6 +201,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -241,6 +243,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -285,6 +288,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -481,6 +485,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
 
             graph.labelDdl
@@ -653,6 +658,7 @@ class DdlServiceSpec :
                     schema = null,
                     groups = null,
                     indices = null,
+                    caches = null,
                 )
             graph.labelDdl
                 .update(labelName, labelUpdateRequest)
@@ -711,7 +717,17 @@ class DdlServiceSpec :
             graph.labelDdl
                 .update(
                     EntityName("test", "some_label"),
-                    LabelUpdateRequest(false, null, null, null, null, null, null, null),
+                    LabelUpdateRequest(
+                        active = false,
+                        desc = null,
+                        type = null,
+                        schema = null,
+                        groups = null,
+                        indices = null,
+                        readOnly = null,
+                        mode = null,
+                        caches = null,
+                    ),
                 ).test()
                 .assertNext { ddlResult ->
                     ddlResult.status shouldBe DdlStatus.Status.UPDATED
@@ -784,6 +800,7 @@ class DdlServiceSpec :
                         schema = newSchema,
                         groups = null,
                         indices = null,
+                        caches = null,
                     ),
                 ).test()
                 .assertNext { ddlResult ->
@@ -864,6 +881,7 @@ class DdlServiceSpec :
                         schema = newSchema,
                         groups = null,
                         indices = null,
+                        caches = null,
                     ),
                 ).test()
                 .assertNext { ddlResult ->
@@ -968,6 +986,7 @@ class DdlServiceSpec :
                         schema = null,
                         groups = null,
                         indices = newIndices,
+                        caches = null,
                     ),
                 ).test()
                 .assertNext { ddlResult ->
@@ -1066,6 +1085,7 @@ class DdlServiceSpec :
                         schema = newSchema,
                         groups = null,
                         indices = null,
+                        caches = null,
                     ),
                 ).test()
                 .verifyError(IllegalArgumentException::class.java)
@@ -1180,6 +1200,7 @@ class DdlServiceSpec :
                         schema = null,
                         groups = null,
                         indices = null,
+                        caches = null,
                     )
 
                 graph.labelDdl
@@ -1199,6 +1220,7 @@ class DdlServiceSpec :
                         schema = null,
                         groups = null,
                         indices = null,
+                        caches = null,
                     )
 
                 graph.labelDdl

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -3,6 +3,7 @@ package com.kakao.actionbase.server.api.graph.v3.metadata
 import com.kakao.actionbase.v2.core.code.Index as V2Index
 import com.kakao.actionbase.v2.core.types.Field as V2Field
 
+import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.metadata.common.MutationMode
@@ -61,6 +62,14 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.groups
                 is ModelSchema.MultiEdge -> it.groups
+            }
+        }
+
+    fun toV2Caches(): List<Cache>? =
+        schema?.let {
+            when (it) {
+                is ModelSchema.Edge -> it.caches
+                is ModelSchema.MultiEdge -> it.caches
             }
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -153,6 +153,7 @@ class V3CompatService(
                 indices = request.toV2Indices(),
                 readOnly = null,
                 mode = request.mode?.toV2MutationMode(),
+                caches = request.toV2Caches(),
             )
         return graph.labelDdl
             .update(EntityName(database, table), v2Request)

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
@@ -15,6 +15,7 @@ import com.kakao.actionbase.v2.core.types.Field as V2Field
 import com.kakao.actionbase.core.metadata.AliasDescriptor
 import com.kakao.actionbase.core.metadata.DatabaseDescriptor
 import com.kakao.actionbase.core.metadata.TableDescriptor
+import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.IndexField
 import com.kakao.actionbase.core.metadata.common.ModelSchema
@@ -56,7 +57,7 @@ object V3MetadataConverter {
             tenant = tenant,
             database = name.service,
             table = name.nameNotNull,
-            schema = schema.toV3ModelSchemaEdge(dirType.toV3DirectionType(), indices, groups),
+            schema = schema.toV3ModelSchemaEdge(dirType.toV3DirectionType(), indices, groups, caches),
             mode = mode.toV3MutationMode(),
             storage = storage,
             active = active,
@@ -68,7 +69,7 @@ object V3MetadataConverter {
             tenant = tenant,
             database = name.service,
             table = name.nameNotNull,
-            schema = schema.toV3ModelSchemaMultiEdge(dirType.toV3DirectionType(), indices, groups),
+            schema = schema.toV3ModelSchemaMultiEdge(dirType.toV3DirectionType(), indices, groups, caches),
             mode = mode.toV3MutationMode(),
             storage = storage,
             active = active,
@@ -180,6 +181,7 @@ object V3MetadataConverter {
         direction: V3DirectionType,
         indices: List<V2Index>,
         groups: List<Group>,
+        caches: List<Cache>,
     ): ModelSchema.Edge =
         ModelSchema.Edge(
             source =
@@ -196,12 +198,14 @@ object V3MetadataConverter {
             direction = direction,
             indexes = indices.map { it.toV3Index() },
             groups = groups,
+            caches = caches,
         )
 
     fun EdgeSchema.toV3ModelSchemaMultiEdge(
         direction: V3DirectionType,
         indices: List<V2Index>,
         groups: List<Group>,
+        caches: List<Cache>,
     ): ModelSchema.MultiEdge {
         val idField =
             fields.find { it.name == "_id" }
@@ -226,6 +230,7 @@ object V3MetadataConverter {
             direction = direction,
             indexes = indices.map { it.toV3Index() },
             groups = groups,
+            caches = caches,
         )
     }
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -634,6 +634,193 @@ class TableControllerTest : E2ETestBase() {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CacheTest {
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - name: v3-edge-cache-crud
+              create: |
+                {
+                  "table": "v3-edge-cache-crud",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "long", "comment": "user"},
+                    "target": {"type": "long", "comment": "item"},
+                    "properties": [
+                      {"name": "score", "type": "int", "comment": "score", "nullable": true}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": [],
+                    "caches": [
+                      {
+                        "cache": "top_items",
+                        "fields": [{"field": "score", "order": "DESC"}],
+                        "limit": 50,
+                        "comment": "top 50 items"
+                      }
+                    ]
+                  },
+                  "storage": "datastore://test_namespace/v3_edge_cache_crud",
+                  "mode": "SYNC",
+                  "comment": "edge table with cache"
+                }
+              expected: |
+                {
+                  "type": "edge",
+                  "table": "v3-edge-cache-crud",
+                  "schema": {
+                    "type": "edge",
+                    "caches": [
+                      {
+                        "cache": "top_items",
+                        "fields": [{"field": "score", "order": "DESC"}],
+                        "limit": 50,
+                        "comment": "top 50 items"
+                      }
+                    ]
+                  },
+                  "active": true
+                }
+            """,
+        )
+        fun `create table preserves caches on response and get`(
+            name: String,
+            create: String,
+            expected: String,
+        ) {
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+
+            client
+                .get()
+                .uri("$baseUri/$name")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - name: v3-edge-cache-upd
+              create: |
+                {
+                  "table": "v3-edge-cache-upd",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "long", "comment": "user"},
+                    "target": {"type": "long", "comment": "item"},
+                    "properties": [
+                      {"name": "score", "type": "int", "comment": "score", "nullable": true}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": [],
+                    "caches": [
+                      {
+                        "cache": "old_cache",
+                        "fields": [{"field": "score", "order": "ASC"}],
+                        "limit": 10,
+                        "comment": "old"
+                      }
+                    ]
+                  },
+                  "storage": "datastore://test_namespace/v3_edge_cache_upd",
+                  "mode": "SYNC",
+                  "comment": "edge table"
+                }
+              update: |
+                {
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "long", "comment": "user"},
+                    "target": {"type": "long", "comment": "item"},
+                    "properties": [
+                      {"name": "score", "type": "int", "comment": "score", "nullable": true}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": [],
+                    "caches": [
+                      {
+                        "cache": "new_cache",
+                        "fields": [{"field": "score", "order": "DESC"}],
+                        "limit": 100,
+                        "comment": "new"
+                      }
+                    ]
+                  }
+                }
+              expected: |
+                {
+                  "table": "v3-edge-cache-upd",
+                  "schema": {
+                    "caches": [
+                      {
+                        "cache": "new_cache",
+                        "fields": [{"field": "score", "order": "DESC"}],
+                        "limit": 100,
+                        "comment": "new"
+                      }
+                    ]
+                  },
+                  "active": true
+                }
+            """,
+        )
+        fun `update table changes caches and reflects on get`(
+            name: String,
+            create: String,
+            update: String,
+            expected: String,
+        ) {
+            // precondition: create with initial cache
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(create)
+                .exchange()
+                .expectStatus()
+                .isOk
+
+            // update cache
+            client
+                .put()
+                .uri("$baseUri/$name")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(update)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+
+            // verify persistence via get
+            client
+                .get()
+                .uri("$baseUri/$name")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .json(expected)
+        }
+    }
+
+    @Nested
     inner class ValidationTest {
         @Test
         fun `invalid status value returns 400`() {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -9,7 +9,9 @@ import com.kakao.actionbase.v2.core.metadata.MutationMode as V2MutationMode
 import com.kakao.actionbase.core.metadata.AliasDescriptor
 import com.kakao.actionbase.core.metadata.DatabaseDescriptor
 import com.kakao.actionbase.core.metadata.TableDescriptor
+import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.core.metadata.common.DirectionType
+import com.kakao.actionbase.core.metadata.common.IndexField
 import com.kakao.actionbase.core.metadata.common.MutationMode
 import com.kakao.actionbase.core.types.PrimitiveType
 import com.kakao.actionbase.server.api.graph.v3.metadata.V3MetadataConverter.toV2AliasEntity
@@ -270,6 +272,135 @@ class V3MetadataConverterTest {
             assertThat(schema.indexes[0].index).isEqualTo("idx1")
             assertThat(schema.indexes[0].fields[0].field).isEqualTo("score")
             assertThat(schema.indexes[0].fields[0].order).isEqualTo(V3Order.DESC)
+        }
+    }
+
+    @Nested
+    inner class TableCacheConversionTest {
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - database: mydb
+              table: mytable
+              cacheName: cache1
+              cacheLimit: 50
+              cacheComment: cache desc
+            """,
+        )
+        fun `LabelEntity caches are preserved when converting to TableDescriptor Edge`(
+            database: String,
+            table: String,
+            cacheName: String,
+            cacheLimit: Int,
+            cacheComment: String,
+        ) {
+            val edgeSchema =
+                EdgeSchema(
+                    VertexField(VertexType.STRING, "source"),
+                    VertexField(VertexType.STRING, "target"),
+                    listOf(
+                        com.kakao.actionbase.v2.core.types
+                            .Field("score", DataType.INT, true, "score field"),
+                    ),
+                )
+            val v2Entity =
+                LabelEntity(
+                    active = true,
+                    name = EntityName(database, table),
+                    desc = "test table",
+                    type = LabelType.INDEXED,
+                    schema = edgeSchema,
+                    dirType = V2DirectionType.OUT,
+                    storage = "datastore://test_namespace/test_table",
+                    indices = emptyList(),
+                    groups = emptyList(),
+                    caches =
+                        listOf(
+                            Cache(
+                                cache = cacheName,
+                                fields = listOf(IndexField("score", V3Order.DESC)),
+                                limit = cacheLimit,
+                                comment = cacheComment,
+                            ),
+                        ),
+                    event = false,
+                    readOnly = false,
+                    mode = V2MutationMode.SYNC,
+                )
+
+            val v3Descriptor = v2Entity.toV3TableDescriptor(tenant) as TableDescriptor.Edge
+            val schema = v3Descriptor.schema
+            assertThat(schema.caches).hasSize(1)
+            assertThat(schema.caches[0].cache).isEqualTo(cacheName)
+            assertThat(schema.caches[0].limit).isEqualTo(cacheLimit)
+            assertThat(schema.caches[0].comment).isEqualTo(cacheComment)
+            assertThat(schema.caches[0].fields).hasSize(1)
+            assertThat(schema.caches[0].fields[0].field).isEqualTo("score")
+            assertThat(schema.caches[0].fields[0].order).isEqualTo(V3Order.DESC)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - database: mydb
+              table: mymultiedge
+              cacheName: cache1
+              cacheLimit: 100
+              cacheComment: multi-edge cache
+            """,
+        )
+        fun `LabelEntity caches are preserved when converting to TableDescriptor MultiEdge`(
+            database: String,
+            table: String,
+            cacheName: String,
+            cacheLimit: Int,
+            cacheComment: String,
+        ) {
+            val edgeSchema =
+                EdgeSchema(
+                    VertexField(VertexType.STRING, "source"),
+                    VertexField(VertexType.STRING, "target"),
+                    listOf(
+                        com.kakao.actionbase.v2.core.types
+                            .Field("_id", DataType.STRING, false, "id field"),
+                        com.kakao.actionbase.v2.core.types
+                            .Field("score", DataType.INT, true, "score field"),
+                    ),
+                )
+            val v2Entity =
+                LabelEntity(
+                    active = true,
+                    name = EntityName(database, table),
+                    desc = "test multi edge",
+                    type = LabelType.MULTI_EDGE,
+                    schema = edgeSchema,
+                    dirType = V2DirectionType.OUT,
+                    storage = "datastore://test_namespace/test_table",
+                    indices = emptyList(),
+                    groups = emptyList(),
+                    caches =
+                        listOf(
+                            Cache(
+                                cache = cacheName,
+                                fields = listOf(IndexField("score", V3Order.DESC)),
+                                limit = cacheLimit,
+                                comment = cacheComment,
+                            ),
+                        ),
+                    event = false,
+                    readOnly = true,
+                    mode = V2MutationMode.SYNC,
+                )
+
+            val v3Descriptor = v2Entity.toV3TableDescriptor(tenant) as TableDescriptor.MultiEdge
+            val schema = v3Descriptor.schema
+            assertThat(schema.caches).hasSize(1)
+            assertThat(schema.caches[0].cache).isEqualTo(cacheName)
+            assertThat(schema.caches[0].limit).isEqualTo(cacheLimit)
+            assertThat(schema.caches[0].comment).isEqualTo(cacheComment)
+            assertThat(schema.caches[0].fields).hasSize(1)
+            assertThat(schema.caches[0].fields[0].field).isEqualTo("score")
+            assertThat(schema.caches[0].fields[0].order).isEqualTo(V3Order.DESC)
         }
     }
 

--- a/website/src/content/docs/api-references/metadata.mdx
+++ b/website/src/content/docs/api-references/metadata.mdx
@@ -743,6 +743,7 @@ data class ModelSchema.Edge(
     val direction: DirectionType,                   // Direction type (OUT, IN, BOTH)
     val indexes: List<Index> = emptyList(),          // Index definitions
     val groups: List<Group> = emptyList(),            // Group definitions
+    val caches: List<Cache> = emptyList(),           // Cache definitions
 )
 ```
 
@@ -760,6 +761,7 @@ data class ModelSchema.MultiEdge(
     val direction: DirectionType,                   // Direction type (OUT, IN, BOTH)
     val indexes: List<Index> = emptyList(),          // Index definitions
     val groups: List<Group> = emptyList(),            // Group definitions
+    val caches: List<Cache> = emptyList(),           // Cache definitions
 )
 ```
 
@@ -825,6 +827,21 @@ data class Group(
     val ttl: Long = -1,                             // Time-to-live in milliseconds (-1 = no expiry)
 )
 ```
+
+### Cache
+
+Cache definition. Precomputes a bounded, sorted projection of edges (e.g., top-N by score) for low-latency reads.
+
+```kotlin
+data class Cache(
+    val cache: String,                              // Cache name
+    val fields: List<IndexField>,                   // Sort keys with order
+    val limit: Int = 100,                           // Maximum number of pre-sorted entries kept per source key (must be > 0)
+    val comment: String = Constants.DEFAULT_COMMENT,// Cache description
+)
+```
+
+> **Updating `indexes` / `groups` / `caches` via PUT**: these fields live inside `ModelSchema`, so a `PUT /graph/v3/databases/{database}/tables/{table}` body that omits `schema` does **not** change any of them. To change a cache, send the full `schema` payload with the desired `caches` array. This matches the existing semantics for `indexes` and `groups`.
 
 ### DatabaseCreateRequest
 


### PR DESCRIPTION
Add support for table `caches` in the V3 DDL API.

- Extend `V3MetadataConverter` so that `LabelEntity.caches` round-trips to `V3TableDescriptor` for both `Edge` and `MultiEdge` model schemas.
- Add `caches` to the V2 `LabelUpdateRequest` and forward it from `V3CompatService.updateTable` via a new `TableUpdateRequest.toV2Caches()`.
- Document the `caches` field and the new `Cache` type on the metadata API reference page.

## Test Plan

| Test | Coverage |
|---|---|
| `V3MetadataConverterTest` | `LabelEntity → V3 TableDescriptor` conversion preserves `caches` for both `Edge` and `MultiEdge` (regression for the original bug). |
| `TableControllerTest` | create → get → update → get round-trip; caches are returned on read and can be mutated via `updateTable`. |
| `DdlServiceSpec` | V2 `LabelUpdateRequest.caches` path is wired through `LabelDdlService`. |
| `./gradlew build` | Full build passes; existing `EdgeCacheQuerySpec` / `EdgeCacheQueryE2ETest` remain unaffected. |


## How to test

```bash
./gradlew :server:test --tests "com.kakao.actionbase.server.api.graph.v3.metadata.V3MetadataConverterTest"
./gradlew :server:test --tests "com.kakao.actionbase.server.api.graph.v3.metadata.TableControllerTest"
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.service.ddl.DdlServiceSpec"
```