### PR TITLE
Introduce v3 `DataFrame` and decouple payload construction from `TableBinding`

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/EdgeField.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/EdgeField.kt
@@ -1,0 +1,19 @@
+package com.kakao.actionbase.core.edge
+
+import com.kakao.actionbase.core.v2.edge.V2EdgeField
+
+object EdgeField {
+    const val VERSION = "version"
+    const val SOURCE = "source"
+    const val TARGET = "target"
+    const val DIRECTION = "direction"
+
+    fun toV3(name: String): String =
+        when (name) {
+            V2EdgeField.VERSION -> VERSION
+            V2EdgeField.SOURCE -> SOURCE
+            V2EdgeField.TARGET -> TARGET
+            V2EdgeField.DIRECTION -> DIRECTION
+            else -> name
+        }
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/StructType.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/StructType.kt
@@ -2,4 +2,8 @@ package com.kakao.actionbase.core.metadata.common
 
 data class StructType(
     val fields: List<StructField>,
-)
+) {
+    private val fieldNameSet: Set<String> by lazy { fields.mapTo(mutableSetOf()) { it.name } }
+
+    fun hasField(name: String): Boolean = name in fieldNameSet
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/v2/edge/V2EdgeField.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/v2/edge/V2EdgeField.kt
@@ -1,0 +1,8 @@
+package com.kakao.actionbase.core.v2.edge
+
+object V2EdgeField {
+    const val VERSION = "ts"
+    const val SOURCE = "src"
+    const val TARGET = "tgt"
+    const val DIRECTION = "dir"
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -2,11 +2,10 @@ package com.kakao.actionbase.engine.binding
 
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
 
 import reactor.core.publisher.Mono
@@ -38,12 +37,12 @@ interface TableBinding {
     fun count(
         sources: Set<Any>,
         direction: Direction,
-    ): Mono<DataFrameEdgeCountPayload>
+    ): Mono<DataFrame>
 
     fun gets(
         keys: List<Pair<Any, Any>>,
         filters: String?,
-    ): Mono<DataFrameEdgePayload>
+    ): Mono<DataFrame>
 
     fun scan(
         index: String,
@@ -54,7 +53,7 @@ interface TableBinding {
         ranges: String?,
         filters: String?,
         features: List<String>,
-    ): Mono<DataFrameEdgePayload>
+    ): Mono<DataFrame>
 
     fun seek(
         cache: String,
@@ -62,7 +61,7 @@ interface TableBinding {
         direction: Direction,
         limit: Int,
         offset: String?,
-    ): Mono<DataFrameEdgePayload>
+    ): Mono<DataFrame>
 
     fun agg(
         group: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -11,8 +11,6 @@ import com.kakao.actionbase.engine.query.ActionbaseQuery
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
-import com.kakao.actionbase.v2.engine.v3.V2BackedTableBinding.Companion.COUNT_FIELD
-import com.kakao.actionbase.v2.engine.v3.V2BackedTableBinding.Companion.toV3
 
 import reactor.core.publisher.Mono
 
@@ -61,7 +59,7 @@ class QueryService(
                         EdgeCountPayload(
                             start = row[EdgeField.SOURCE] as Any,
                             direction = direction.toV3(),
-                            count = row[COUNT_FIELD] as Long,
+                            count = row[DataFrame.COUNT_FIELD] as Long,
                             context = emptyMap(),
                         )
                     }
@@ -186,6 +184,12 @@ class QueryService(
 
     companion object {
         private val EDGE_FIELDS = setOf(EdgeField.VERSION, EdgeField.SOURCE, EdgeField.TARGET, EdgeField.DIRECTION)
+
+        private fun Direction.toV3(): com.kakao.actionbase.core.metadata.common.Direction =
+            when (this) {
+                Direction.OUT -> com.kakao.actionbase.core.metadata.common.Direction.OUT
+                Direction.IN -> com.kakao.actionbase.core.metadata.common.Direction.IN
+            }
 
         fun empty(direction: Direction): EdgeCountPayload =
             if (direction == Direction.OUT) {

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -1,14 +1,18 @@
 package com.kakao.actionbase.engine.service
 
+import com.kakao.actionbase.core.edge.EdgeField
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.edge.payload.EdgeCountPayload
+import com.kakao.actionbase.core.edge.payload.EdgePayload
 import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.query.ActionbaseQuery
+import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
-import com.kakao.actionbase.v2.engine.sql.DataFrame
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
+import com.kakao.actionbase.v2.engine.v3.V2BackedTableBinding.Companion.COUNT_FIELD
+import com.kakao.actionbase.v2.engine.v3.V2BackedTableBinding.Companion.toV3
 
 import reactor.core.publisher.Mono
 
@@ -48,7 +52,22 @@ class QueryService(
         require(filters == null) { "`filters` is not yet supported in count query." }
         require(features.isEmpty()) { "`features` ${features.joinToString(", ")} are not supported in get query." }
 
-        return engine.getTableBinding(database, table).count(start.toSet(), direction)
+        return engine
+            .getTableBinding(database, table)
+            .count(start.toSet(), direction)
+            .map { df ->
+                val counts =
+                    df.rows.map { row ->
+                        EdgeCountPayload(
+                            start = row[EdgeField.SOURCE] as Any,
+                            direction = direction.toV3(),
+                            count = row[COUNT_FIELD] as Long,
+                            context = emptyMap(),
+                        )
+                    }
+
+                DataFrameEdgeCountPayload(counts, counts.size, context = emptyMap())
+            }
     }
 
     @Suppress("UnusedParameter")
@@ -69,7 +88,10 @@ class QueryService(
                 target.distinct().map { t -> s to t }
             }
 
-        return engine.getTableBinding(database, table).gets(keys, filters)
+        return engine
+            .getTableBinding(database, table)
+            .gets(keys, filters)
+            .map { it.toEdgePayload() }
     }
 
     @Suppress("UnusedParameter")
@@ -89,7 +111,9 @@ class QueryService(
         }
 
         val keys = ids.distinct().map { id -> id to id }
-        return tb.gets(keys, filters)
+        return tb
+            .gets(keys, filters)
+            .map { it.toEdgePayload() }
     }
 
     fun scan(
@@ -103,7 +127,11 @@ class QueryService(
         ranges: String? = null,
         filters: String? = null,
         features: List<String> = emptyList(),
-    ): Mono<DataFrameEdgePayload> = engine.getTableBinding(database, table).scan(index, start, direction, limit, offset, ranges, filters, features)
+    ): Mono<DataFrameEdgePayload> =
+        engine
+            .getTableBinding(database, table)
+            .scan(index, start, direction, limit, offset, ranges, filters, features)
+            .map { it.toEdgePayload(flip = direction == Direction.IN) }
 
     fun seek(
         database: String,
@@ -113,7 +141,11 @@ class QueryService(
         direction: Direction,
         limit: Int = ScanFilter.defaultLimit,
         offset: String? = null,
-    ): Mono<DataFrameEdgePayload> = engine.getTableBinding(database, table).seek(cache, start, direction, limit, offset)
+    ): Mono<DataFrameEdgePayload> =
+        engine
+            .getTableBinding(database, table)
+            .seek(cache, start, direction, limit, offset)
+            .map { it.toEdgePayload() }
 
     fun agg(
         database: String,
@@ -127,9 +159,34 @@ class QueryService(
         ttl: Long? = null,
     ): Mono<DataFrameEdgeAggPayload> = engine.getTableBinding(database, table).agg(group, start, direction, ranges, filters, features, ttl)
 
-    fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>> = engine.query(request)
+    fun query(request: ActionbaseQuery): Mono<Map<String, com.kakao.actionbase.v2.engine.sql.DataFrame>> = engine.query(request)
+
+    private fun DataFrame.toEdgePayload(flip: Boolean = false): DataFrameEdgePayload {
+        val edges =
+            rows.map { row ->
+                val (source, target) = if (!flip) row[EdgeField.SOURCE]!! to row[EdgeField.TARGET]!! else row[EdgeField.TARGET]!! to row[EdgeField.SOURCE]!!
+
+                EdgePayload(
+                    version = row[EdgeField.VERSION] as Long,
+                    source = source,
+                    target = target,
+                    properties = row.data.filterKeys { it !in EDGE_FIELDS },
+                    context = emptyMap(),
+                )
+            }
+        return DataFrameEdgePayload(
+            edges = edges,
+            count = count,
+            total = total,
+            offset = offset,
+            hasNext = hasNext,
+            context = emptyMap(),
+        )
+    }
 
     companion object {
+        private val EDGE_FIELDS = setOf(EdgeField.VERSION, EdgeField.SOURCE, EdgeField.TARGET, EdgeField.DIRECTION)
+
         fun empty(direction: Direction): EdgeCountPayload =
             if (direction == Direction.OUT) {
                 emptyEdgeCountPayloadOut

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/DataFrame.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/DataFrame.kt
@@ -1,0 +1,21 @@
+package com.kakao.actionbase.engine.sql
+
+import com.kakao.actionbase.core.metadata.common.StructType
+
+data class DataFrame(
+    val rows: List<Row>,
+    val schema: StructType,
+    val count: Int = rows.size,
+    val total: Long,
+    val offset: String? = null,
+    val hasNext: Boolean = false,
+) {
+    companion object {
+        val empty: DataFrame =
+            DataFrame(
+                rows = emptyList(),
+                schema = StructType(emptyList()),
+                total = 0L,
+            )
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/DataFrame.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/DataFrame.kt
@@ -11,6 +11,8 @@ data class DataFrame(
     val hasNext: Boolean = false,
 ) {
     companion object {
+        const val COUNT_FIELD = "COUNT(1)"
+
         val empty: DataFrame =
             DataFrame(
                 rows = emptyList(),

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/Row.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/Row.kt
@@ -1,0 +1,17 @@
+package com.kakao.actionbase.engine.sql
+
+import com.kakao.actionbase.core.metadata.common.StructType
+
+data class Row(
+    val data: Map<String, Any?>,
+    val schema: StructType,
+) {
+    val size: Int get() = data.size
+
+    operator fun get(fieldName: String): Any? {
+        if (!schema.hasField(fieldName)) {
+            throw IllegalArgumentException("Field '$fieldName' does not exist in the schema.")
+        }
+        return data[fieldName]
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
@@ -89,6 +89,7 @@ interface Label : AutoCloseable {
         cacheName: String,
         direction: Direction,
         limit: Int,
+        offset: String? = null,
     ): Mono<DataFrame> = Mono.error(UnsupportedOperationException("cache is not supported for ${this::class.simpleName}"))
 
     fun count(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseIndexedLabel.kt
@@ -3,7 +3,9 @@ package com.kakao.actionbase.v2.engine.label.hbase
 import com.kakao.actionbase.core.edge.Edge
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.record.EdgeCacheRecord
+import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.engine.binding.TableBinding
+import com.kakao.actionbase.v2.core.code.CryptoUtils
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.Index
@@ -75,6 +77,7 @@ open class HBaseIndexedLabel(
         cacheName: String,
         direction: Direction,
         limit: Int,
+        offset: String?,
     ): Mono<DataFrame> {
         val cache =
             entity.caches.find { it.cache == cacheName }
@@ -103,15 +106,35 @@ open class HBaseIndexedLabel(
         val descriptor = V3TableDescriptor.create(entity)
         val schema = buildSchema()
 
-        return hbaseGetWideRow(keys, from = null, to = null, order, limit)
+        val decodedOffset = offset?.let { CryptoUtils.decodeAndDecryptUrlSafe(it) }
+        val (from, to) =
+            if (decodedOffset == null) {
+                null to null
+            } else if (order == Order.DESC) {
+                null to decodedOffset
+            } else {
+                decodedOffset to null
+            }
+
+        return hbaseGetWideRow(keys, from, to, order, limit + 1)
             .map { records ->
+                val hasNext = records.size > limit
+                val results = if (hasNext) records.dropLast(1) else records
                 val rows =
-                    records.map { record ->
+                    results.map { record ->
                         val decoded = cacheMapper.decoder.decode(record.key, record.qualifier, record.value)
                         val edge = decoded.toEdge(descriptor.schema)
                         toRow(edge, schema)
                     }
-                DataFrame(rows, schema)
+                val nextOffset =
+                    if (hasNext) {
+                        results.lastOrNull()?.qualifier?.let {
+                            CryptoUtils.encryptAndEncodeUrlSafe(it)
+                        }
+                    } else {
+                        null
+                    }
+                DataFrame(rows, schema, offsets = listOfNotNull(nextOffset), hasNext = listOf(hasNext))
             }
     }
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -2,13 +2,12 @@ package com.kakao.actionbase.v2.engine.v3
 
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
 
 import reactor.core.publisher.Mono
@@ -38,12 +37,12 @@ class NilTableBinding(
     override fun count(
         sources: Set<Any>,
         direction: Direction,
-    ): Mono<DataFrameEdgeCountPayload> = Mono.just(DataFrameEdgeCountPayload(emptyList(), 0, emptyMap()))
+    ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun gets(
         keys: List<Pair<Any, Any>>,
         filters: String?,
-    ): Mono<DataFrameEdgePayload> = V2BackedTableBinding.EMPTY_EDGE_PAYLOAD
+    ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun scan(
         index: String,
@@ -54,7 +53,7 @@ class NilTableBinding(
         ranges: String?,
         filters: String?,
         features: List<String>,
-    ): Mono<DataFrameEdgePayload> = V2BackedTableBinding.EMPTY_EDGE_PAYLOAD
+    ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun seek(
         cache: String,
@@ -62,7 +61,7 @@ class NilTableBinding(
         direction: Direction,
         limit: Int,
         offset: String?,
-    ): Mono<DataFrameEdgePayload> = V2BackedTableBinding.EMPTY_EDGE_PAYLOAD
+    ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun agg(
         group: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -200,7 +200,7 @@ class V2BackedTableBinding(
                     .count(setOf(start), direction)
                     .map {
                         val jsonFormat = it.toJsonFormat()
-                        jsonFormat.data.first()[COUNT_FIELD] as Long
+                        jsonFormat.data.first()[DataFrame.COUNT_FIELD] as Long
                     }
             } else {
                 DEFAULT_TOTAL_VALUE_MONO
@@ -497,7 +497,6 @@ class V2BackedTableBinding(
     companion object {
         private val log = LoggerFactory.getLogger(V2BackedTableBinding::class.java)
 
-        internal const val COUNT_FIELD = "COUNT(1)"
         private const val FEATURE_TOTAL = "total"
         private const val DEFAULT_TOTAL_VALUE = -1L
         private val DEFAULT_TOTAL_VALUE_MONO = Mono.just(DEFAULT_TOTAL_VALUE)

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -1,23 +1,19 @@
 package com.kakao.actionbase.v2.engine.v3
 
 import com.kakao.actionbase.v2.core.code.hbase.Constants as HBaseConstants
+import com.kakao.actionbase.v2.engine.sql.DataFrame as V2DataFrame
 
 import com.kakao.actionbase.core.Constants
+import com.kakao.actionbase.core.edge.EdgeField
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.mapper.EdgeGroupRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mutation.EdgeMutationBuilder
 import com.kakao.actionbase.core.edge.mutation.EdgeMutationRecords
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
-import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.edge.payload.EdgeAggPayload
-import com.kakao.actionbase.core.edge.payload.EdgeCountPayload
-import com.kakao.actionbase.core.edge.payload.EdgePayload
-import com.kakao.actionbase.core.edge.record.EdgeCacheRecord
 import com.kakao.actionbase.core.edge.record.EdgeGroupRecord
 import com.kakao.actionbase.core.edge.record.EdgeStateRecord
-import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.SpecialStateValue
@@ -26,7 +22,8 @@ import com.kakao.actionbase.core.storage.HBaseRecord
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
-import com.kakao.actionbase.v2.core.code.CryptoUtils
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -121,30 +118,16 @@ class V2BackedTableBinding(
     override fun count(
         sources: Set<Any>,
         direction: Direction,
-    ): Mono<DataFrameEdgeCountPayload> =
+    ): Mono<DataFrame> =
         label
             .count(sources, direction)
-            .map {
-                val jsonFormat = it.toJsonFormat()
-                DataFrameEdgeCountPayload(
-                    counts =
-                        jsonFormat.data.map { row ->
-                            EdgeCountPayload(
-                                start = row[SRC_FIELD] as Any,
-                                direction = direction.toV3(),
-                                count = row[SELECT_COUNT_FIELD] as Long,
-                                context = emptyMap(),
-                            )
-                        },
-                    count = jsonFormat.rows,
-                    context = emptyMap(),
-                )
-            }.switchIfEmpty(EMPTY_COUNT_PAYLOAD)
+            .map { it.toV3() }
+            .switchIfEmpty(EMPTY_DATAFRAME)
 
     override fun gets(
         keys: List<Pair<Any, Any>>,
         filters: String?,
-    ): Mono<DataFrameEdgePayload> {
+    ): Mono<DataFrame> {
         val postPredicates = filters?.let { WherePredicate.parse(it, label.entity.schema) }?.toSet() ?: emptySet()
 
         val hbaseGets =
@@ -158,8 +141,8 @@ class V2BackedTableBinding(
         return label
             .getActiveStates(hbaseGets)
             .map {
-                it.applyPredicates(postPredicates).toDataFrameEdgePayload(flip = false)
-            }.switchIfEmpty(EMPTY_EDGE_PAYLOAD)
+                it.applyPredicates(postPredicates).toV3()
+            }.switchIfEmpty(EMPTY_DATAFRAME)
     }
 
     override fun scan(
@@ -171,7 +154,7 @@ class V2BackedTableBinding(
         ranges: String?,
         filters: String?,
         features: List<String>,
-    ): Mono<DataFrameEdgePayload> {
+    ): Mono<DataFrame> {
         val indexFieldNames =
             label.entity.indices
                 .find { it.name == index }
@@ -217,7 +200,7 @@ class V2BackedTableBinding(
                     .count(setOf(start), direction)
                     .map {
                         val jsonFormat = it.toJsonFormat()
-                        jsonFormat.data.first()[SELECT_COUNT_FIELD] as Long
+                        jsonFormat.data.first()[COUNT_FIELD] as Long
                     }
             } else {
                 DEFAULT_TOTAL_VALUE_MONO
@@ -231,9 +214,8 @@ class V2BackedTableBinding(
             .map { tuple ->
                 val df = tuple.t1
                 val total = tuple.t2
-                val flip = direction == Direction.IN
-                df.applyPredicates(postPredicates).toDataFrameEdgePayload(flip, total)
-            }.switchIfEmpty(EMPTY_EDGE_PAYLOAD)
+                df.applyPredicates(postPredicates).toV3(total)
+            }.switchIfEmpty(EMPTY_DATAFRAME)
     }
 
     override fun seek(
@@ -242,82 +224,11 @@ class V2BackedTableBinding(
         direction: Direction,
         limit: Int,
         offset: String?,
-    ): Mono<DataFrameEdgePayload> {
-        val cacheEntity = label.entity.caches.find { it.cache == cache }
-        requireNotNull(cacheEntity) { "cache `$cache` is not found in label `${label.entity.name}`." }
-
-        val order = cacheEntity.fields.first().order
-        val casted =
-            if (direction == Direction.OUT) {
-                label.entity.schema.src.type.type
-                    .cast(start)
-            } else {
-                label.entity.schema.tgt.type.type
-                    .cast(start)
-            }
-        val key =
-            EdgeCacheRecord.Key.of(
-                directedSource = casted,
-                tableCode = label.entity.id,
-                direction = direction.toV3(),
-                cacheCode = cacheEntity.code,
-            )
-        val encodedKey = cacheRecordMapper.encoder.encodeKey(key)
-
-        val offsetNext = offset?.let { CryptoUtils.decodeAndDecryptUrlSafe(it) }
-        val (from, to) =
-            if (offsetNext == null) {
-                null to null
-            } else if (order == Order.DESC) {
-                null to offsetNext
-            } else {
-                offsetNext to null
-            }
-
-        return label
-            .hbaseGetWideRow(listOf(encodedKey), from, to, order, limit = limit + 1)
-            .map { records ->
-                val hasNext = records.size > limit
-                val results = if (hasNext) records.dropLast(1) else records
-                val fieldNameMap = label.entity.schema.hashToFieldNameMap
-                val edges =
-                    results.map { record ->
-                        val decoded = cacheRecordMapper.decoder.decode(record.key, record.qualifier, record.value)
-                        val (source, target) =
-                            when (direction) {
-                                Direction.OUT -> decoded.key.directedSource to decoded.qualifier.directedTarget
-                                Direction.IN -> decoded.qualifier.directedTarget to decoded.key.directedSource
-                            }
-                        EdgePayload(
-                            version = decoded.value.version,
-                            source = source,
-                            target = target,
-                            properties =
-                                decoded.value.properties
-                                    .mapNotNull { (code, value) ->
-                                        fieldNameMap[code]?.let { it to value }
-                                    }.toMap(),
-                            context = emptyMap(),
-                        )
-                    }
-                val nextOffset =
-                    if (hasNext) {
-                        results.lastOrNull()?.qualifier?.let {
-                            CryptoUtils.encryptAndEncodeUrlSafe(it)
-                        }
-                    } else {
-                        null
-                    }
-                DataFrameEdgePayload(
-                    edges = edges,
-                    count = edges.size,
-                    total = edges.size.toLong(),
-                    offset = nextOffset,
-                    hasNext = hasNext,
-                    context = emptyMap(),
-                )
-            }.switchIfEmpty(EMPTY_EDGE_PAYLOAD)
-    }
+    ): Mono<DataFrame> =
+        label
+            .cache(listOf(start), cache, direction, limit, offset)
+            .map { it.toV3() }
+            .switchIfEmpty(EMPTY_DATAFRAME)
 
     override fun agg(
         group: String,
@@ -576,66 +487,23 @@ class V2BackedTableBinding(
                 },
         )
 
-    private fun com.kakao.actionbase.v2.engine.sql.DataFrame.applyPredicates(predicates: Set<WherePredicate>): com.kakao.actionbase.v2.engine.sql.DataFrame =
+    private fun V2DataFrame.applyPredicates(predicates: Set<WherePredicate>): V2DataFrame =
         if (predicates.isEmpty()) {
             this
         } else {
             this.where(predicates)
         }
 
-    private fun com.kakao.actionbase.v2.engine.sql.DataFrame.toDataFrameEdgePayload(
-        flip: Boolean,
-        total: Long? = null,
-    ): DataFrameEdgePayload {
-        val jsonFormat = toJsonFormat()
-        val edges =
-            jsonFormat.data.map { row ->
-                EdgePayload(
-                    version = row[TS_FIELD] as Long,
-                    source = if (!flip) row[SRC_FIELD]!! else row[TGT_FIELD]!!,
-                    target = if (!flip) row[TGT_FIELD]!! else row[SRC_FIELD]!!,
-                    properties = row.filterKeys { it !in EDGE_FIELDS },
-                    context = emptyMap(),
-                )
-            }
-        return DataFrameEdgePayload(
-            edges = edges,
-            count = jsonFormat.rows,
-            total = total ?: rows.size.toLong(),
-            offset = if (jsonFormat.hasNext) jsonFormat.offset else null,
-            hasNext = jsonFormat.hasNext,
-            context = emptyMap(),
-        )
-    }
-
     companion object {
         private val log = LoggerFactory.getLogger(V2BackedTableBinding::class.java)
 
-        private const val SELECT_COUNT_FIELD = "COUNT(1)"
-        private const val TS_FIELD = "ts"
-        private const val SRC_FIELD = "src"
-        private const val TGT_FIELD = "tgt"
-        private const val DIR_FIELD = "dir"
-        private val EDGE_FIELDS = setOf(TS_FIELD, SRC_FIELD, TGT_FIELD, DIR_FIELD)
+        internal const val COUNT_FIELD = "COUNT(1)"
         private const val FEATURE_TOTAL = "total"
         private const val DEFAULT_TOTAL_VALUE = -1L
         private val DEFAULT_TOTAL_VALUE_MONO = Mono.just(DEFAULT_TOTAL_VALUE)
         private val AVAILABLE_SCAN_FEATURES = setOf(FEATURE_TOTAL)
 
-        val EMPTY_EDGE_PAYLOAD: Mono<DataFrameEdgePayload> =
-            Mono.just(
-                DataFrameEdgePayload(
-                    edges = emptyList(),
-                    count = 0,
-                    total = 0L,
-                    offset = null,
-                    hasNext = false,
-                    context = emptyMap(),
-                ),
-            )
-
-        val EMPTY_COUNT_PAYLOAD: Mono<DataFrameEdgeCountPayload> =
-            Mono.just(DataFrameEdgeCountPayload(emptyList(), 0, emptyMap()))
+        val EMPTY_DATAFRAME: Mono<DataFrame> = Mono.just(DataFrame.empty)
 
         private fun MutationKey.toSourceTarget(): Pair<Any, Any> =
             when (this) {
@@ -671,4 +539,41 @@ class V2BackedTableBinding(
                 Direction.IN -> com.kakao.actionbase.core.metadata.common.Direction.IN
             }
     }
+}
+
+internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
+    val v3Schema =
+        com.kakao.actionbase.core.metadata.common.StructType(
+            schema.fields.map { field ->
+                com.kakao.actionbase.core.metadata.common.StructField(
+                    name = EdgeField.toV3(field.name),
+                    type =
+                        com.kakao.actionbase.core.types.PrimitiveType
+                            .valueOf(field.type.name),
+                    comment = field.desc,
+                    nullable = field.isNullable,
+                )
+            },
+        )
+    val newRows =
+        rows.map { row ->
+            Row(
+                data =
+                    schema.fieldNames
+                        .mapIndexed { i, name ->
+                            EdgeField.toV3(name) to row.array[i]
+                        }.toMap(),
+                schema = v3Schema,
+            )
+        }
+    val rawOffset = offsets.singleOrNull()
+    val hasNext = rawOffset?.let { this.hasNext.singleOrNull() ?: false } ?: false
+    val offset = if (hasNext) rawOffset else null
+    return DataFrame(
+        rows = newRows,
+        schema = v3Schema,
+        total = total ?: rows.size.toLong(),
+        offset = offset,
+        hasNext = hasNext,
+    )
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.v3
 
+import com.kakao.actionbase.core.edge.EdgeField
 import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.core.metadata.common.Field
 import com.kakao.actionbase.core.metadata.common.Group
@@ -144,23 +145,15 @@ sealed class V3TableDescriptor {
                 index = this.name,
                 fields =
                     this.fields.map { field ->
-                        IndexField(field.name.toV3FieldName(), field.order.toV3())
+                        IndexField(EdgeField.toV3(field.name), field.order.toV3())
                     },
                 comment = this.desc,
             )
 
-        private fun String.toV3FieldName(): String =
-            when (this) {
-                "ts" -> "version"
-                "src" -> "source"
-                "tgt" -> "target"
-                else -> this
-            }
-
         private fun Group.toV3(): Group = copy(fields = fields.map { it.toV3() })
 
-        private fun Group.Field.toV3(): Group.Field = copy(name = name.toV3FieldName())
+        private fun Group.Field.toV3(): Group.Field = copy(name = EdgeField.toV3(name))
 
-        private fun Cache.toV3(): Cache = copy(fields = fields.map { it.copy(field = it.field.toV3FieldName()) })
+        private fun Cache.toV3(): Cache = copy(fields = fields.map { it.copy(field = EdgeField.toV3(it.field)) })
     }
 }


### PR DESCRIPTION
## Summary

Decouple payload construction from `TableBinding` by introducing a v3 `DataFrame` / `Row` model under `engine/sql`. Query methods (`gets`, `count`, `scan`, `seek`) now return `Mono<DataFrame>` instead of payload types directly, and `QueryService` owns the conversion to `DataFrameEdgePayload` / `DataFrameEdgeCountPayload` — consolidating field-name constants and direction-dependent logic in one place. Follow-up to the discussion in #245.

## Test plan

- `./gradlew :engine:build` — engine compile catches signature/type breakage across `TableBinding`, `DataFrame` / `Row`, `Label.cache(offset)`, and `QueryService` call sites.
- `./gradlew :engine:test --tests "*QueryServiceSpec*"` — `count` / `gets` / `scan` build payloads via `DataFrame.toEdgePayload()`, covering `offset`, `features=total`, `ranges`, and the IN-direction flip in `scan`.
- `./gradlew :engine:test --tests "*EdgeCacheQuerySpec*"` — `QueryService.seek` pagination; `HBaseIndexedLabel.cache()` `limit + 1` / `nextOffset` across `OUT` / `IN`; simplified `V2BackedTableBinding.seek()` preserves existing behavior.
- `./gradlew :engine:test --tests "*V2BackedTableBindingTest*"` — V2 array row → V3 map row conversion via `V2BackedTableBinding.toV3()`, replacing the removed `DataFrame.rowToMap()` helper alongside the new `buildEdgeStructType()`.
- `./gradlew :engine:test --tests "*LabelSpec*" --tests "*EventualConsistencySpec*"` — `Label.cache()` / `label.scan()` unchanged for existing callers after the default-`null` `offset` parameter.
- Grep audit under `engine/` and `server/` for `Mono<DataFrameEdgePayload>` / `Mono<DataFrameEdgeCountPayload>` / `TableBinding.gets(` — confirms no production caller still expects the old payload-returning signatures.
