### PR TITLE
Add unit tests for ByteArrayBuffer extension functions

### DIFF
--- a/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
@@ -16,25 +16,31 @@ class ByteArrayBufferTest {
     companion object {
         private const val BUFFER_SIZE = 64
         private const val FIELD_SOURCES = """
-- field:
-    type: int
-    value: "27"
-- field:
-    type: long
-    value: "123456789"
-- field:
-    type: string
-    value: "hello"
-- field:
-    type: boolean
-    value: "true"
-- field:
-    type: float
-    value: "3.14"
-- field:
-    type: double
-    value: "3.14159"
-"""
+        - field:
+            type: int
+            value: "27"
+        - field:
+            type: long
+            value: "123456789"
+        - field:
+            type: string
+            value: "hello"
+        - field:
+            type: boolean
+            value: "true"
+        - field:
+            type: float
+            value: "3.14"
+        - field:
+            type: double
+            value: "3.14159"
+        - field:
+            type: byte
+            value: "127"
+        - field:
+            type: short
+            value: "32767"
+        """
     }
 
     @ObjectSourceParameterizedTest
@@ -82,9 +88,9 @@ class ByteArrayBufferTest {
     fun `hasRemaining should return true when data exists`(field: Field) {
         val buffer = ByteArray(BUFFER_SIZE).buffer()
         buffer.putValue(field.cast(), Order.ASC)
-        buffer.setPosition(0)
+        val readBuffer = buffer.toByteArray().buffer()
 
-        assertTrue(buffer.hasRemaining())
+        assertTrue(readBuffer.hasRemaining())
     }
 
     @ObjectSourceParameterizedTest
@@ -100,6 +106,13 @@ class ByteArrayBufferTest {
         readBuffer.getValue<Any>()
 
         assertFalse(readBuffer.hasRemaining())
+    }
+
+    @Test
+    fun `hasRemaining should return false after data is empty`() {
+        val buffer = ByteArray(0).buffer()
+
+        assertFalse(buffer.hasRemaining())
     }
 
     @ObjectSourceParameterizedTest

--- a/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
@@ -1,0 +1,131 @@
+package com.kakao.actionbase.core.codec
+
+import com.kakao.actionbase.core.java.codec.common.hbase.Order
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ByteArrayBufferTest {
+    companion object {
+        private const val BUFFER_SIZE = 64
+        private const val FIELD_SOURCES = """
+- field:
+    type: int
+    value: "27"
+- field:
+    type: long
+    value: "123456789"
+- field:
+    type: string
+    value: "hello"
+- field:
+    type: boolean
+    value: "true"
+- field:
+    type: float
+    value: "3.14"
+- field:
+    type: double
+    value: "3.14159"
+"""
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `putValue and getValue should round trip in ascending order`(field: Field) {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(field.cast(), Order.ASC)
+        buffer.setPosition(0)
+
+        assertEquals(field.cast(), buffer.getValue())
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `putValue and getValue should round trip in descending order`(field: Field) {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(field.cast(), Order.DESC)
+        buffer.setPosition(0)
+
+        assertEquals(field.cast(), buffer.getValue())
+    }
+
+    @Test
+    fun `getValue should throw IllegalStateException when value is null`() {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(null, Order.ASC)
+        buffer.setPosition(0)
+
+        assertThrows<IllegalStateException> {
+            buffer.getValue<Any>()
+        }
+    }
+
+    @Test
+    fun `getValueOrNull should return null when value is null`() {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(null, Order.ASC)
+        buffer.setPosition(0)
+
+        assertNull(buffer.getValueOrNull<Any>())
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `hasRemaining should return true when data exists`(field: Field) {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(field.cast(), Order.ASC)
+        buffer.setPosition(0)
+
+        assertTrue(buffer.hasRemaining())
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `hasRemaining should return false after data is consumed`(field: Field) {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(field.cast(), Order.ASC)
+
+        val writtenBytes = buffer.toByteArray()
+        val readBuffer = writtenBytes.buffer()
+
+        // consume buffer
+        readBuffer.getValue<Any>()
+
+        assertFalse(readBuffer.hasRemaining())
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `buffer should create ByteArrayBuffer from ByteArray`(field: Field) {
+        val tempBuffer = ByteArray(BUFFER_SIZE)
+
+        val buffer = tempBuffer.buffer()
+        buffer.putValue(field.cast(), Order.ASC)
+        buffer.setPosition(0)
+
+        assertEquals(field.cast(), buffer.getValue())
+        assertSame(buffer.bytes, tempBuffer)
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(FIELD_SOURCES)
+    fun `putValue should produce different bytes for asc and desc order`(field: Field) {
+        val ascBuffer = ByteArray(BUFFER_SIZE).buffer()
+        ascBuffer.putValue(field.cast(), Order.ASC)
+        val ascBytes = ascBuffer.toByteArray()
+
+        val descBuffer = ByteArray(BUFFER_SIZE).buffer()
+        descBuffer.putValue(field.cast(), Order.DESC)
+        val descBytes = descBuffer.toByteArray()
+
+        assertFalse(ascBytes.contentEquals(descBytes))
+    }
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/codec/ByteArrayBufferTest.kt
@@ -141,4 +141,34 @@ class ByteArrayBufferTest {
 
         assertFalse(ascBytes.contentEquals(descBytes))
     }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - field1:
+            type: int
+            value: "27"
+          field2:
+            type: string
+            value: "hello"
+          field3:
+            type: boolean
+            value: "true"
+        """,
+    )
+    fun `putValue and getValue should maintain order for multiple values`(
+        field1: Field,
+        field2: Field,
+        field3: Field,
+    ) {
+        val buffer = ByteArray(BUFFER_SIZE).buffer()
+        buffer.putValue(field1.cast(), Order.ASC)
+        buffer.putValue(field2.cast(), Order.ASC)
+        buffer.putValue(field3.cast(), Order.ASC)
+        buffer.setPosition(0)
+
+        assertEquals(field1.cast(), buffer.getValue())
+        assertEquals(field2.cast(), buffer.getValue())
+        assertEquals(field3.cast(), buffer.getValue())
+    }
 }


### PR DESCRIPTION
## Summary
Add unit tests for `ByteArrayBuffer` extension functions defined in `ByteArrayBuffer.kt`.
Closes #119

## Changes
- Added `ByteArrayBufferTest.kt` at `core/src/test/kotlin/com/kakao/actionbase/core/codec/`

## Test Plan
| Test | Coverage |
|------|----------|
| `putValue and getValue should round trip in ascending order` | putValue + getValue roundtrip with ASC ordering |
| `putValue and getValue should round trip in descending order` | putValue + getValue roundtrip with DESC ordering |
| `getValue should throw IllegalStateException when value is null` | getValue throws IllegalStateException when value is null |
| `getValueOrNull should return null when value is null` | getValueOrNull returns null when value is null |
| `hasRemaining should return true when data exists` | hasRemaining returns true when data exists |
| `hasRemaining should return false after data is consumed` | hasRemaining returns false after data is consumed |
| `hasRemaining should return false for empty buffer` | hasRemaining returns false for empty buffer |
| `buffer should create ByteArrayBuffer from ByteArray` | buffer() creates valid ByteArrayBuffer from ByteArray |
| `putValue should produce different bytes for asc and desc order` | ASC and DESC produce different byte representations |
| `putValue and getValue should maintain order for multiple values` | putValue + getValue maintains insertion order for multiple values |

## How to Test
./gradlew spotlessApply
./gradlew :core:test