### PR TITLE
Backport read-only mode to 0.2.x

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -116,6 +116,7 @@ class Graph(
     LabelProvider,
     AutoCloseable {
     internal val mutationRequestTimeout = config.mutationRequestTimeout
+    internal val readOnly = config.readOnly
 
     private var metadataInitialized = false
 
@@ -685,7 +686,7 @@ class Graph(
                 if (it) {
                     Mono
                         .defer {
-                            if (label.entity.readOnly) {
+                            if (label.entity.readOnly || readOnly) {
                                 Mono.empty()
                             } else {
                                 writeWarmUp

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphConfig.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphConfig.kt
@@ -35,6 +35,7 @@ data class GraphConfig(
     val hbase: Map<String, String> = emptyMap(),
     val metadataFetchLimit: Int = DdlService.DEFAULT_METADATA_LIMIT,
     val systemMutationMode: MutationMode? = null,
+    val readOnly: Boolean = false,
 ) {
     companion object {
         val builder: Builder
@@ -64,6 +65,7 @@ data class GraphConfig(
         private var hbase: Map<String, String> = emptyMap()
         private var metadataFetchLimit: Int = DdlService.DEFAULT_METADATA_LIMIT
         private var systemMutationMode: MutationMode? = null
+        private var readOnly: Boolean = false
 
         // Aligned with nginx.conf proxy_read_timeout 300
         private var mutationRequestTimeout: Long = 300_000
@@ -124,6 +126,8 @@ data class GraphConfig(
 
         fun withSystemMutationMode(systemMutationMode: MutationMode?) = apply { this.systemMutationMode = systemMutationMode }
 
+        fun withReadOnly(readOnly: Boolean) = apply { this.readOnly = readOnly }
+
         fun build(): GraphConfig =
             GraphConfig(
                 phase = phase,
@@ -149,6 +153,7 @@ data class GraphConfig(
                 hbase = hbase,
                 metadataFetchLimit = metadataFetchLimit,
                 systemMutationMode = systemMutationMode,
+                readOnly = readOnly,
             )
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
@@ -38,6 +38,7 @@ class GraphConfiguration {
     @Suppress("CyclomaticComplexMethod")
     fun provideGraphConfig(
         properties: GraphProperties,
+        serverProperties: ServerProperties,
         infoEndpoint: InfoEndpoint,
     ): GraphConfig {
         val builder =
@@ -83,6 +84,7 @@ class GraphConfiguration {
                 withHBase(properties.hbase)
                 properties.metadataFetchLimit?.let { withMetadataFetchLimit(it) }
                 properties.systemMutationMode?.let { withSystemMutationMode(it) }
+                withReadOnly(serverProperties.readOnly)
             }
         return builder.build()
     }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServerProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServerProperties.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class ServerProperties(
     val tenant: String,
     val datastore: DatastoreProperties,
+    val readOnly: Boolean = false,
 ) {
     data class DatastoreProperties(
         val type: DatastoreType,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
@@ -23,6 +23,7 @@ import reactor.core.publisher.Flux
 class ServiceLabelEdgeControllerWarmUp(
     @Value("\${server.port:8080}") private val serverPort: Int,
     graphProperties: GraphProperties,
+    serverProperties: ServerProperties,
     @Qualifier("tokenAuthenticationFilter") private val tokenAuthenticationFilter: WebFilter,
 ) : ApplicationListener<ApplicationReadyEvent> {
     private val log: Logger = LoggerFactory.getLogger(ServiceLabelEdgeControllerWarmUp::class.java)
@@ -43,7 +44,12 @@ class ServiceLabelEdgeControllerWarmUp(
         log.info("WarmUp is added. serverPort: $serverPort, config: $warmUpConfig")
     }
 
-    private val allMethods = listOf(HttpMethod.POST, HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE)
+    private val allMethods =
+        if (serverProperties.readOnly) {
+            listOf(HttpMethod.GET)
+        } else {
+            listOf(HttpMethod.POST, HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE)
+        }
 
     fun warmUpInfo(
         i: Int,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/WebFilterConfig.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/WebFilterConfig.kt
@@ -2,6 +2,7 @@ package com.kakao.actionbase.server.configuration
 
 import com.kakao.actionbase.server.filter.CustomTokenFilter
 import com.kakao.actionbase.server.filter.MirrorRequestFilter
+import com.kakao.actionbase.server.filter.ReadOnlyRequestFilter
 import com.kakao.actionbase.server.filter.ResponseMetaFactory
 import com.kakao.actionbase.server.filter.ResponseMetaFilter
 import com.kakao.actionbase.server.filter.TokenAuthenticationFilter
@@ -17,6 +18,7 @@ import org.springframework.web.server.WebFilter
 @Configuration
 class WebFilterConfig(
     private val properties: GraphProperties,
+    private val serverProperties: ServerProperties,
     private val gitProperties: GitProperties?,
     private val buildProperties: BuildProperties,
 ) {
@@ -29,6 +31,15 @@ class WebFilterConfig(
 
     @Bean
     @Order(1)
+    fun readOnlyRequestFilter(): WebFilter? =
+        if (serverProperties.readOnly) {
+            ReadOnlyRequestFilter()
+        } else {
+            null
+        }
+
+    @Bean
+    @Order(2)
     fun mirrorRequestFilter(): WebFilter? =
         if (properties.allowMirror) {
             MirrorRequestFilter()
@@ -37,7 +48,7 @@ class WebFilterConfig(
         }
 
     @Bean("tokenAuthenticationFilter")
-    @Order(2)
+    @Order(3)
     fun tokenAuthenticationFilter(customTokenFilterProvider: ObjectProvider<CustomTokenFilter>): WebFilter {
         val customTokenFilter = customTokenFilterProvider.getIfAvailable()
         return TokenAuthenticationFilter(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilter.kt
@@ -1,0 +1,54 @@
+package com.kakao.actionbase.server.filter
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+
+import reactor.core.publisher.Mono
+
+// Rejects non-GET methods on graph path prefixes with 403.
+// Exceptions: read-only POST endpoints matched by readSuffixes.
+class ReadOnlyRequestFilter : WebFilter {
+    private val log = LoggerFactory.getLogger(ReadOnlyRequestFilter::class.java)
+
+    private val paths = setOf("/graph/v2", "/graph/v3")
+    private val readMethod = HttpMethod.GET
+    private val readSuffixes =
+        setOf(
+            "/edges/get",
+            "/multi-edges/ids",
+            "/query",
+        )
+
+    init {
+        log.info("ReadOnlyRequestFilter is active. Write operations on {} will be rejected.", paths)
+    }
+
+    override fun filter(
+        exchange: ServerWebExchange,
+        chain: WebFilterChain,
+    ): Mono<Void> {
+        val method = exchange.request.method
+        val path = exchange.request.uri.path
+
+        if (method == readMethod || !paths.any { path.startsWith(it) } || isRead(path)) {
+            return chain.filter(exchange)
+        }
+
+        log.warn("Blocked write request in read-only mode: {} {}", method, path)
+        val bufferFactory = exchange.response.bufferFactory()
+        val messageBuffer =
+            bufferFactory.wrap(
+                """{"message":"Write operation not allowed in read-only mode: $method $path"}""".toByteArray(),
+            )
+        exchange.response.statusCode = HttpStatus.FORBIDDEN
+        exchange.response.headers.contentType = MediaType.APPLICATION_JSON
+        return exchange.response.writeWith(Mono.just(messageBuffer))
+    }
+
+    private fun isRead(path: String): Boolean = readSuffixes.any { path.endsWith(it) }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
@@ -162,3 +162,16 @@ class StartUpWithReadOnlyDisabledTest : E2ETestBase() {
             }
     }
 }
+
+@TestPropertySource(properties = ["actionbase.read-only=true", "kc.graph.warmup.enabled=true", "kc.graph.warmup.count=1"])
+class StartUpWithReadOnlyAndWarmUpEnabledTest : E2ETestBase() {
+    @Test
+    fun `server boots with read-only and warmup enabled`() {
+        client
+            .get()
+            .uri("/graph/v2")
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
@@ -1,6 +1,8 @@
 package com.kakao.actionbase.server
 
 import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 
 import kotlin.test.Test
 
@@ -25,6 +27,18 @@ class StartUpTest : E2ETestBase() {
             .exchange()
             .expectStatus()
             .isOk
+    }
+
+    @Test
+    fun `POST is not rejected as 403 when read-only is not configured`() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .exchange()
+            .expectStatus()
+            .value { status ->
+                assert(status != 403) { "Expected non-403, got $status" }
+            }
     }
 }
 
@@ -51,5 +65,100 @@ class StartUpWithSystemMutationModeAsyncTest : E2ETestBase() {
             .exchange()
             .expectStatus()
             .isOk
+    }
+}
+
+@TestPropertySource(properties = ["actionbase.read-only=true"])
+class StartUpWithReadOnlyEnabledTest : E2ETestBase() {
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - method: POST
+          uri: /graph/v3/databases
+        - method: PUT
+          uri: /graph/v3/databases/db/tables/t
+        - method: DELETE
+          uri: /graph/v2/admin/service/test
+        """,
+    )
+    fun `should block write requests`(
+        method: String,
+        uri: String,
+    ) {
+        client
+            .method(
+                org.springframework.http.HttpMethod
+                    .valueOf(method),
+            ).uri(uri)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - method: GET
+          uri: /graph/v2
+        - method: GET
+          uri: /graph/v3
+        - method: POST
+          uri: /graph/v2/query
+        - method: POST
+          uri: /graph/v3/query
+        - method: POST
+          uri: /graph/v3/databases/db/tables/t/edges/get
+        - method: POST
+          uri: /actuator/health
+        """,
+    )
+    fun `should allow read requests`(
+        method: String,
+        uri: String,
+    ) {
+        client
+            .method(
+                org.springframework.http.HttpMethod
+                    .valueOf(method),
+            ).uri(uri)
+            .exchange()
+            .expectStatus()
+            .value { status ->
+                assert(status != 403) { "Expected non-403 for $method $uri, got $status" }
+            }
+    }
+}
+
+@TestPropertySource(properties = ["actionbase.read-only=false"])
+class StartUpWithReadOnlyDisabledTest : E2ETestBase() {
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - method: GET
+          uri: /graph/v2/service
+        - method: GET
+          uri: /graph/v3/databases
+        - method: POST
+          uri: /graph/v3/databases
+        - method: PUT
+          uri: /graph/v3/databases/db/tables/t
+        - method: DELETE
+          uri: /graph/v2/admin/service/test
+        """,
+    )
+    fun `no request is blocked when read-only is disabled`(
+        method: String,
+        uri: String,
+    ) {
+        client
+            .method(
+                org.springframework.http.HttpMethod
+                    .valueOf(method),
+            ).uri(uri)
+            .exchange()
+            .expectStatus()
+            .value { status ->
+                assert(status != 403) { "Expected non-403 for $method $uri, got $status" }
+            }
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -1,0 +1,304 @@
+package com.kakao.actionbase.server.filter
+
+import com.kakao.actionbase.server.test.EndpointScanner
+
+import java.util.stream.Stream
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.WebFilterChain
+
+import reactor.core.publisher.Mono
+
+// Test strategy:
+// 1. Scan all @RestController endpoints via reflection at test time.
+// 2. Compare scanned set against READ/WRITE/NON_GRAPH constants — any mismatch fails the build.
+// 3. Run each endpoint through the filter: READ → allowed, WRITE → 403, NON_GRAPH → allowed.
+// Adding a new endpoint without classifying it here will break the exhaustiveness check.
+class ReadOnlyRequestFilterTest {
+    private lateinit var filter: ReadOnlyRequestFilter
+
+    @BeforeEach
+    fun setup() {
+        filter = ReadOnlyRequestFilter()
+    }
+
+    @Test
+    fun `declared endpoints must match scanned controller annotations`() {
+        val scanned = EndpointScanner.scan("com.kakao.actionbase.server.api").map { (m, p) -> "$m $p" }.toSet()
+        val declared = READ_ENDPOINTS + WRITE_ENDPOINTS + NON_GRAPH_ENDPOINTS
+
+        val missing = scanned - declared
+        val stale = declared - scanned
+
+        assertTrue(missing.isEmpty(), "Not declared:\n${missing.joinToString("\n") { "  + $it" }}")
+        assertTrue(stale.isEmpty(), "Stale:\n${stale.joinToString("\n") { "  - $it" }}")
+    }
+
+    @ParameterizedTest
+    @MethodSource("readEndpoints")
+    fun `should allow read requests on graph paths`(
+        method: String,
+        path: String,
+    ) {
+        assertAllowed(method, path)
+    }
+
+    @ParameterizedTest
+    @MethodSource("writeEndpoints")
+    fun `should block write requests on graph paths`(
+        method: String,
+        path: String,
+    ) {
+        assertBlocked(method, path)
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonGraphEndpoints")
+    fun `should allow requests outside graph path prefixes`(
+        method: String,
+        path: String,
+    ) {
+        assertAllowed(method, path)
+    }
+
+    @Test
+    fun `should include method and path in error response body`() {
+        val path = "/graph/v3/databases"
+        val exchange = buildExchange("POST", path)
+        filter.filter(exchange, WebFilterChain { Mono.empty() }).block()
+
+        val body = exchange.response.bodyAsString.block() ?: ""
+        assertTrue(body.contains("POST"))
+        assertTrue(body.contains(path))
+        assertTrue(body.contains("read-only"))
+    }
+
+    private fun assertAllowed(
+        method: String,
+        path: String,
+    ) {
+        val exchange = buildExchange(method, path)
+        var passed = false
+        filter
+            .filter(
+                exchange,
+                WebFilterChain {
+                    passed = true
+                    Mono.empty()
+                },
+            ).block()
+        assertTrue(passed, "Expected $method $path to be allowed")
+    }
+
+    private fun assertBlocked(
+        method: String,
+        path: String,
+    ) {
+        val exchange = buildExchange(method, path)
+        var passed = false
+        filter
+            .filter(
+                exchange,
+                WebFilterChain {
+                    passed = true
+                    Mono.empty()
+                },
+            ).block()
+        assertFalse(passed, "Expected $method $path to be blocked")
+        assertEquals(HttpStatus.FORBIDDEN, exchange.response.statusCode)
+        assertEquals(org.springframework.http.MediaType.APPLICATION_JSON, exchange.response.headers.contentType)
+    }
+
+    private fun buildExchange(
+        method: String,
+        path: String,
+    ): MockServerWebExchange = MockServerWebExchange.from(MockServerHttpRequest.method(HttpMethod.valueOf(method), path))
+
+    companion object {
+        val READ_ENDPOINTS =
+            setOf(
+                // v2 GET
+                "GET /graph/v2",
+                "GET /graph/v2/admin/dump",
+                "GET /graph/v2/admin/hbase/cluster",
+                "GET /graph/v2/admin/hbase/cluster/{cluster}",
+                "GET /graph/v2/admin/hbase/cluster/{cluster}/replication",
+                "GET /graph/v2/admin/hbase/cluster/{cluster}/table",
+                "GET /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}",
+                "GET /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}/metric",
+                "GET /graph/v2/admin/labels",
+                "GET /graph/v2/admin/metadata/service",
+                "GET /graph/v2/admin/metadata/service/{service}/alias",
+                "GET /graph/v2/admin/metadata/service/{service}/label",
+                "GET /graph/v2/admin/metadata/service/{service}/query",
+                "GET /graph/v2/admin/metadata/storage",
+                "GET /graph/v2/admin//migration/{name}",
+                "GET /graph/v2/metastore/global",
+                "GET /graph/v2/metastore/local",
+                "GET /graph/v2/service",
+                "GET /graph/v2/service/{service}",
+                "GET /graph/v2/service/{service}/alias",
+                "GET /graph/v2/service/{service}/alias/{alias}",
+                "GET /graph/v2/service/{service}/label",
+                "GET /graph/v2/service/{service}/label/{label}",
+                "GET /graph/v2/service/{service}/label/{label}/edge",
+                "GET /graph/v2/service/{service}/label/{label}/edge/id/{edgeId}",
+                "GET /graph/v2/service/{service}/label/{label}/status",
+                "GET /graph/v2/service/{service}/query",
+                "GET /graph/v2/service/{service}/query/{query}",
+                "GET /graph/v2/storage",
+                "GET /graph/v2/storage/{storage}",
+                // v3 GET
+                "GET /graph/v3",
+                "GET /graph/v3/databases",
+                "GET /graph/v3/databases/{database}",
+                "GET /graph/v3/databases/{database}/aliases",
+                "GET /graph/v3/databases/{database}/aliases/{alias}",
+                "GET /graph/v3/databases/{database}/tables",
+                "GET /graph/v3/databases/{database}/tables/{table}",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/agg/{group}",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/cache/{cache}",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/count",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/counts",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/get",
+                "GET /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}",
+                "GET /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",
+                "GET /graph/v3/datastore",
+                // read-only POST
+                "POST /graph/v3/query",
+                "POST /graph/v3/databases/{database}/tables/{table}/edges/get",
+                "POST /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",
+            )
+
+        val WRITE_ENDPOINTS =
+            setOf(
+                // v2 mutation
+                "DELETE /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}",
+                "DELETE /graph/v2/admin/service/{service}",
+                "DELETE /graph/v2/admin/service/{service}/alias/{alias}",
+                "DELETE /graph/v2/admin/service/{service}/label/{label}",
+                "DELETE /graph/v2/admin/storage/{storage}",
+                "DELETE /graph/v2/edge",
+                "DELETE /graph/v2/edge/id",
+                "DELETE /graph/v2/service/{service}/alias/{alias}",
+                "DELETE /graph/v2/service/{service}/label/{label}/edge",
+                "DELETE /graph/v2/service/{service}/label/{label}/edge/id/{edgeId}",
+                "DELETE /graph/v2/service/{service}/label/{label}/edge/purge",
+                "DELETE /graph/v2/service/{service}/label/{label}/edge/sync",
+                "POST /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}",
+                "POST /graph/v2/edge",
+                "POST /graph/v2/edge/id",
+                "POST /graph/v2/service/{service}",
+                "POST /graph/v2/service/{service}/alias/{alias}",
+                "POST /graph/v2/service/{service}/alias/{alias}/new-label",
+                "POST /graph/v2/service/{service}/label/{label}",
+                "POST /graph/v2/service/{service}/label/{label}/copy",
+                "POST /graph/v2/service/{service}/label/{label}/edge",
+                "POST /graph/v2/service/{service}/label/{label}/edge/delete",
+                "POST /graph/v2/service/{service}/label/{label}/edge/delete/id/{edgeId}",
+                "POST /graph/v2/service/{service}/label/{label}/edge/id/{edgeId}",
+                "POST /graph/v2/service/{service}/label/{label}/edge/purge",
+                "POST /graph/v2/service/{service}/label/{label}/edge/sync",
+                "POST /graph/v2/service/{service}/query/{query}",
+                "POST /graph/v2/storage/{storage}",
+                "PUT /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}",
+                "PUT /graph/v2/edge",
+                "PUT /graph/v2/edge/id",
+                "PUT /graph/v2/service/{service}",
+                "PUT /graph/v2/service/{service}/alias/{alias}",
+                "PUT /graph/v2/service/{service}/label/{label}",
+                "PUT /graph/v2/service/{service}/label/{label}/edge",
+                "PUT /graph/v2/service/{service}/label/{label}/edge/id/{edgeId}",
+                "PUT /graph/v2/service/{service}/label/{label}/edge/sync",
+                "PUT /graph/v2/service/{service}/query/{query}",
+                "PUT /graph/v2/storage/{storage}",
+                // v3 mutation
+                "DELETE /graph/v3/databases/{database}",
+                "DELETE /graph/v3/databases/{database}/aliases/{alias}",
+                "DELETE /graph/v3/databases/{database}/tables/{table}",
+                "POST /graph/v3/databases",
+                "POST /graph/v3/databases/{database}/aliases",
+                "POST /graph/v3/databases/{database}/tables",
+                "POST /graph/v3/databases/{database}/tables/{table}/edges",
+                "POST /graph/v3/databases/{database}/tables/{table}/edges/sync",
+                "POST /graph/v3/databases/{database}/tables/{table}/multi-edges",
+                "POST /graph/v3/databases/{database}/tables/{table}/multi-edges/sync",
+                "PUT /graph/v3/databases/{database}",
+                "PUT /graph/v3/databases/{database}/aliases/{alias}",
+                "PUT /graph/v3/databases/{database}/tables/{table}",
+            )
+
+        val NON_GRAPH_ENDPOINTS =
+            setOf(
+                "GET /",
+                "GET /graph",
+                "GET /graph/check/delay_with_cache",
+                "GET /graph/check/delay_without_cache",
+                "GET /graph/check/emoji",
+                "GET /graph/check/error",
+                "GET /graph/check/mono",
+                "GET /graph/check/response-meta",
+                "GET /graph/check/sentry",
+                "GET /graph/health",
+                "GET /graph/health/liveness",
+                "GET /graph/health/readiness",
+                "PUT /graph/health/readiness",
+            )
+
+        @JvmStatic
+        fun readEndpoints(): Stream<Arguments> = READ_ENDPOINTS.sorted().map { it.toTestArgs() }.stream()
+
+        @JvmStatic
+        fun writeEndpoints(): Stream<Arguments> = WRITE_ENDPOINTS.sorted().map { it.toTestArgs() }.stream()
+
+        @JvmStatic
+        fun nonGraphEndpoints(): Stream<Arguments> =
+            NON_GRAPH_ENDPOINTS
+                .filter { !it.startsWith("GET ") }
+                .sorted()
+                .map { it.toTestArgs() }
+                .stream()
+
+        private fun String.toTestArgs(): Arguments {
+            val (method, path) = split(" ", limit = 2)
+            return Arguments.of(method, resolvePath(path))
+        }
+
+        private val PATH_VARS =
+            mapOf(
+                "alias" to "a",
+                "cache" to "c",
+                "cluster" to "c",
+                "database" to "db",
+                "edgeId" to "e",
+                "group" to "g",
+                "index" to "idx",
+                "label" to "l",
+                "name" to "n",
+                "query" to "q",
+                "service" to "s",
+                "storage" to "st",
+                "table" to "t",
+                "tableFullName" to "t",
+                "tableName" to "t",
+            )
+
+        private fun resolvePath(template: String): String =
+            template.replace(Regex("\\{([^}]+)\\}")) {
+                PATH_VARS[it.groupValues[1]]
+                    ?: error("Unknown path variable '${it.groupValues[1]}' in $template. Add it to PATH_VARS.")
+            }
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -177,6 +177,7 @@ class ReadOnlyRequestFilterTest {
                 "GET /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",
                 "GET /graph/v3/datastore",
                 // read-only POST
+                "POST /graph/v2/query",
                 "POST /graph/v3/query",
                 "POST /graph/v3/databases/{database}/tables/{table}/edges/get",
                 "POST /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",

--- a/server/src/testFixtures/kotlin/com/kakao/actionbase/server/test/EndpointScanner.kt
+++ b/server/src/testFixtures/kotlin/com/kakao/actionbase/server/test/EndpointScanner.kt
@@ -1,0 +1,45 @@
+package com.kakao.actionbase.server.test
+
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+object EndpointScanner {
+    private val MAPPING_ANNOTATIONS: Map<Class<out Annotation>, (Annotation) -> Pair<String, Array<String>>> =
+        mapOf(
+            GetMapping::class.java to { "GET" to (it as GetMapping).value },
+            PostMapping::class.java to { "POST" to (it as PostMapping).value },
+            PutMapping::class.java to { "PUT" to (it as PutMapping).value },
+            DeleteMapping::class.java to { "DELETE" to (it as DeleteMapping).value },
+            PatchMapping::class.java to { "PATCH" to (it as PatchMapping).value },
+        )
+
+    fun scan(basePackage: String): List<Pair<String, String>> {
+        val provider = ClassPathScanningCandidateComponentProvider(false)
+        provider.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+
+        return provider
+            .findCandidateComponents(basePackage)
+            .flatMap { beanDef ->
+                val cls = Class.forName(beanDef.beanClassName)
+                val prefixes = cls.getAnnotation(RequestMapping::class.java)?.value?.ifEmpty { arrayOf("") } ?: arrayOf("")
+                prefixes.flatMap { prefix ->
+                    cls.declaredMethods.flatMap { m ->
+                        MAPPING_ANNOTATIONS.flatMap { (annCls, extract) ->
+                            m.getAnnotation(annCls)?.let { ann ->
+                                val (httpMethod, paths) = extract(ann)
+                                (paths.ifEmpty { arrayOf("") }).map { httpMethod to (prefix + it) }
+                            } ?: emptyList()
+                        }
+                    }
+                }
+            }.distinct()
+            .sortedWith(compareBy({ it.second }, { it.first }))
+    }
+}


### PR DESCRIPTION
## Summary

Backport read-only mode from \`main\` to the \`0.2.x\` release branch, so it can be included in a v0.2.1 patch release.

## Changes

- Cherry-pick d936f56 — Add read-only mode to reject write operations (#230)
- Cherry-pick f0a84e8 — Skip write warmup in read-only mode (#239)
- Add \`POST /graph/v2/query\` to \`READ_ENDPOINTS\` in \`ReadOnlyRequestFilterTest\` (0.2.x-specific: this endpoint was removed on \`main\` via #228 but still exists on 0.2.x; the filter's \`readSuffixes\` already includes \`/query\` so no filter logic change is needed)

Note: PR #236 (*Fix ReadOnlyRequestFilterTest for renamed edges/cache → edges/seek endpoint*) is intentionally **not** included — the \`edges/cache → edges/seek\` rename has not been applied to 0.2.x, so applying #236 would break the test suite here.

## How to Test

```bash
./gradlew :server:test --tests "*ReadOnly*" --tests "*StartUp*"
./gradlew build
```