### PR TITLE
Capture `Put`/`Delete`/`Increment` into `StorageOpCollector`

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,3 +1,50 @@
 package com.kakao.actionbase.core.storage
 
-sealed class StorageOp
+sealed class StorageOp {
+    abstract val kind: String
+    abstract val table: String
+
+    data class Put(
+        override val table: String,
+        val row: String,
+        val cells: List<Cell>,
+    ) : StorageOp() {
+        override val kind: String = "Put"
+    }
+
+    data class Delete(
+        override val table: String,
+        val row: String,
+        val cells: List<Cell>,
+    ) : StorageOp() {
+        override val kind: String = "Delete"
+    }
+
+    data class Increment(
+        override val table: String,
+        val row: String,
+        val deltas: List<Delta>,
+    ) : StorageOp() {
+        override val kind: String = "Increment"
+    }
+
+    data class Unknown(
+        override val table: String,
+        val type: String,
+    ) : StorageOp() {
+        override val kind: String = "Unknown"
+    }
+
+    data class Cell(
+        val family: String,
+        val qualifier: String,
+        val value: String?,
+        val type: String,
+    )
+
+    data class Delta(
+        val family: String,
+        val qualifier: String,
+        val delta: Long,
+    )
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -87,7 +87,7 @@ class MutationService(
                     val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
                     tb.write(key, state, after, collector)
                 }.map { summary ->
-                    val context = collector?.snapshot()?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) }
+                    val context = collector?.toContextMap()
                     MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc, context)
                 }
         }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -2,6 +2,19 @@ package com.kakao.actionbase.engine.storage
 
 import com.kakao.actionbase.core.storage.StorageOp
 
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.hadoop.hbase.Cell
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Mutation
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.util.Bytes
+import org.slf4j.LoggerFactory
+
 /**
  * Single-owner appender used under a Reactor chain (per-RMW in V3, per-edge in V2).
  * Not safe to share across parallel publishers — signals must arrive serially.
@@ -12,7 +25,6 @@ class StorageOpCollector(
     private val ops = mutableListOf<StorageOp>()
     private var truncated = false
 
-    @Suppress("UNUSED_PARAMETER")
     fun collect(
         request: Any,
         table: String,
@@ -21,7 +33,7 @@ class StorageOpCollector(
             truncated = true
             return
         }
-        // No-op until backend interpretation is added.
+        ops.add(toStorageOp(request, table))
     }
 
     fun collectAll(
@@ -35,8 +47,77 @@ class StorageOpCollector(
 
     fun isTruncated(): Boolean = truncated
 
+    fun toContextMap(): Map<String, Any> =
+        buildMap {
+            put(CONTEXT_KEY, snapshot())
+            if (truncated) put(TRUNCATED_KEY, true)
+        }
+
+    private fun toStorageOp(
+        request: Any,
+        table: String,
+    ): StorageOp =
+        when (request) {
+            is Put -> StorageOp.Put(table, request.row.toBase64(), extractCells(request))
+            is Delete -> StorageOp.Delete(table, request.row.toBase64(), extractCells(request))
+            is Increment -> StorageOp.Increment(table, request.row.toBase64(), extractDeltas(request))
+            else -> {
+                val type = request::class.qualifiedName ?: request::class.java.name
+                if (warnedTypes.add(type)) {
+                    log.warn("StorageOpCollector received unsupported request type: {}", type)
+                }
+                StorageOp.Unknown(table, type = type)
+            }
+        }
+
+    private fun extractCells(mutation: Mutation): List<StorageOp.Cell> =
+        mutation.familyCellMap.values
+            .asSequence()
+            .flatMap { it }
+            .map { cell ->
+                StorageOp.Cell(
+                    family = cell.familyBase64(),
+                    qualifier = cell.qualifierBase64(),
+                    value = if (cell.type == Cell.Type.Put) cell.valueBase64() else null,
+                    type = cell.type.name,
+                )
+            }.toList()
+
+    private fun extractDeltas(increment: Increment): List<StorageOp.Delta> =
+        increment.familyCellMap.values
+            .asSequence()
+            .flatMap { it }
+            .map { cell ->
+                StorageOp.Delta(
+                    family = cell.familyBase64(),
+                    qualifier = cell.qualifierBase64(),
+                    delta = Bytes.toLong(cell.valueArray, cell.valueOffset, cell.valueLength),
+                )
+            }.toList()
+
+    private fun Cell.familyBase64(): String = encodeBase64(familyArray, familyOffset, familyLength.toInt())
+
+    private fun Cell.qualifierBase64(): String = encodeBase64(qualifierArray, qualifierOffset, qualifierLength)
+
+    private fun Cell.valueBase64(): String = encodeBase64(valueArray, valueOffset, valueLength)
+
+    private fun ByteArray.toBase64(): String = BASE64.encodeToString(this)
+
+    private fun encodeBase64(
+        src: ByteArray,
+        offset: Int,
+        length: Int,
+    ): String {
+        val encoded = BASE64.encode(ByteBuffer.wrap(src, offset, length))
+        return String(encoded.array(), encoded.arrayOffset(), encoded.remaining(), StandardCharsets.ISO_8859_1)
+    }
+
     companion object {
         const val DEFAULT_MAX_OPS: Int = 1024
-        const val CONTEXT_KEY: String = "storage_ops"
+        const val CONTEXT_KEY: String = "storageOps"
+        const val TRUNCATED_KEY: String = "storageOpsTruncated"
+        private val BASE64 = Base64.getEncoder()
+        private val log = LoggerFactory.getLogger(StorageOpCollector::class.java)
+        private val warnedTypes = ConcurrentHashMap.newKeySet<String>()
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -341,7 +341,13 @@ class Graph(
                                             status = context.status,
                                             traceId = context.edge.traceId,
                                             edge = context.after ?: context.before,
-                                            context = context.storageOps?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) },
+                                            context =
+                                                context.storageOps?.let {
+                                                    buildMap {
+                                                        put(StorageOpCollector.CONTEXT_KEY, it)
+                                                        if (context.storageOpsTruncated) put(StorageOpCollector.TRUNCATED_KEY, true)
+                                                    }
+                                                },
                                         )
                                     }
                             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
@@ -31,6 +31,8 @@ data class CdcContext(
     val requestId: String = "",
     @JsonIgnore
     val storageOps: List<StorageOp>? = null,
+    @JsonIgnore
+    val storageOpsTruncated: Boolean = false,
 ) : Log {
     @Suppress("PropertyName")
     companion object {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
@@ -162,8 +162,12 @@ abstract class AbstractLabel<T>(
                 } else {
                     Mono.just(context)
                 }
-            }.map { context -> context.copy(storageOps = collector?.snapshot()) }
-            .subscribeOn(Schedulers.boundedElastic())
+            }.map { context ->
+                context.copy(
+                    storageOps = collector?.snapshot(),
+                    storageOpsTruncated = collector?.isTruncated() ?: false,
+                )
+            }.subscribeOn(Schedulers.boundedElastic())
             .doFinally {
                 releaseLock(edge.traceId, encodedLockEdge, bulk)
                     .subscribeOn(Schedulers.boundedElastic())

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollectorTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollectorTest.kt
@@ -1,0 +1,177 @@
+package com.kakao.actionbase.engine.storage
+
+import com.kakao.actionbase.core.storage.StorageOp
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.apache.hadoop.hbase.client.Append
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Put
+import org.junit.jupiter.api.Test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+class StorageOpCollectorTest {
+    private val table = "test_table"
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: Put with single cell
+          kind: PUT
+          row: row-1
+          family: cf
+          qualifier: q
+          value: value
+          expectedJson: '{"table":"test_table","row":"cm93LTE=","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":"dmFsdWU=","type":"Put"}],"kind":"Put"}'
+
+        - name: Delete full row yields no cells
+          kind: DELETE
+          row: row-2
+          expectedJson: '{"table":"test_table","row":"cm93LTI=","cells":[],"kind":"Delete"}'
+
+        - name: Delete with addColumns emits DeleteColumn cell with null value
+          kind: DELETE_COLUMNS
+          row: row-3
+          family: cf
+          qualifier: q
+          expectedJson: '{"table":"test_table","row":"cm93LTM=","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":null,"type":"DeleteColumn"}],"kind":"Delete"}'
+
+        - name: Delete with addFamily emits DeleteFamily cell with null value
+          kind: DELETE_FAMILY
+          row: row-3f
+          family: cf
+          expectedJson: '{"table":"test_table","row":"cm93LTNm","cells":[{"family":"Y2Y=","qualifier":"","value":null,"type":"DeleteFamily"}],"kind":"Delete"}'
+
+        - name: Increment with long delta
+          kind: INCREMENT
+          row: row-4
+          family: cf
+          qualifier: q
+          delta: 7
+          expectedJson: '{"table":"test_table","row":"cm93LTQ=","deltas":[{"family":"Y2Y=","qualifier":"cQ==","delta":7}],"kind":"Increment"}'
+
+        - name: Put with multi-byte value base64 encodes correctly
+          kind: PUT
+          row: row
+          family: cf
+          qualifier: q
+          valueHex: 00000000deadbeef
+          expectedJson: '{"table":"test_table","row":"cm93","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":"AAAAAN6tvu8=","type":"Put"}],"kind":"Put"}'
+        """,
+    )
+    fun `Mutation is captured as StorageOp`(
+        kind: String,
+        row: String,
+        family: String?,
+        qualifier: String?,
+        value: String?,
+        valueHex: String?,
+        delta: Long?,
+        expectedJson: String,
+    ) {
+        val mutation: Any =
+            when (kind) {
+                "PUT" ->
+                    Put(row.toByteArray()).addColumn(
+                        family!!.toByteArray(),
+                        qualifier!!.toByteArray(),
+                        value?.toByteArray() ?: hexToBytes(valueHex!!),
+                    )
+                "DELETE" -> Delete(row.toByteArray())
+                "DELETE_COLUMNS" -> Delete(row.toByteArray()).addColumns(family!!.toByteArray(), qualifier!!.toByteArray())
+                "DELETE_FAMILY" -> Delete(row.toByteArray()).addFamily(family!!.toByteArray())
+                "INCREMENT" -> Increment(row.toByteArray()).addColumn(family!!.toByteArray(), qualifier!!.toByteArray(), delta!!)
+                else -> error("unknown kind: $kind")
+            }
+
+        val collector = StorageOpCollector()
+        collector.collect(mutation, table)
+        val op = collector.snapshot().single()
+
+        assertEquals(expectedJson, mapper.writeValueAsString(op))
+    }
+
+    @Test
+    fun `Put across multiple column families emits one cell per family`() {
+        val put =
+            Put("row".toByteArray())
+                .addColumn("cf1".toByteArray(), "q".toByteArray(), "v1".toByteArray())
+                .addColumn("cf2".toByteArray(), "q".toByteArray(), "v2".toByteArray())
+
+        val collector = StorageOpCollector()
+        collector.collect(put, table)
+        val op = collector.snapshot().single() as StorageOp.Put
+
+        assertEquals(2, op.cells.size)
+        assertEquals(setOf("Y2Yx", "Y2Yy"), op.cells.map { it.family }.toSet())
+        op.cells.forEach { assertEquals("Put", it.type) }
+    }
+
+    @Test
+    fun `collectAll surfaces non-Mutation entries as Unknown and preserves order`() {
+        val collector = StorageOpCollector()
+        val put = Put("a".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray())
+        val delete = Delete("b".toByteArray())
+
+        collector.collectAll(listOf(put, "not-a-mutation", delete), table)
+        val ops = collector.snapshot()
+
+        assertEquals(3, ops.size)
+        assertTrue(ops[0] is StorageOp.Put)
+        assertTrue(ops[1] is StorageOp.Unknown)
+        assertEquals("kotlin.String", (ops[1] as StorageOp.Unknown).type)
+        assertTrue(ops[2] is StorageOp.Delete)
+    }
+
+    @Test
+    fun `Append is captured as Unknown rather than routed through Mutation path`() {
+        val collector = StorageOpCollector()
+        val append = Append("row".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray())
+
+        collector.collect(append, table)
+        val op = collector.snapshot().single()
+
+        assertTrue(op is StorageOp.Unknown)
+        assertEquals("org.apache.hadoop.hbase.client.Append", (op as StorageOp.Unknown).type)
+    }
+
+    @Test
+    fun `collect stops appending once the cap is reached and marks truncated`() {
+        val collector = StorageOpCollector(maxOps = 2)
+        repeat(5) { i ->
+            collector.collect(
+                Put("row-$i".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray()),
+                table,
+            )
+        }
+
+        assertEquals(2, collector.snapshot().size)
+        assertTrue(collector.isTruncated())
+    }
+
+    @Test
+    fun `toContextMap omits truncated flag when not truncated and includes it when truncated`() {
+        val ok = StorageOpCollector(maxOps = 2)
+        ok.collect(Put("r".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray()), table)
+        val okCtx = ok.toContextMap()
+        assertTrue(okCtx.containsKey(StorageOpCollector.CONTEXT_KEY))
+        assertFalse(okCtx.containsKey(StorageOpCollector.TRUNCATED_KEY))
+
+        val over = StorageOpCollector(maxOps = 1)
+        repeat(3) { over.collect(Put("r".toByteArray()), table) }
+        val overCtx = over.toContextMap()
+        assertEquals(true, overCtx[StorageOpCollector.TRUNCATED_KEY])
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { i ->
+            ((Character.digit(hex[i * 2], 16) shl 4) + Character.digit(hex[i * 2 + 1], 16)).toByte()
+        }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContextSerializationTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContextSerializationTest.kt
@@ -1,0 +1,69 @@
+package com.kakao.actionbase.v2.engine.cdc
+
+import com.kakao.actionbase.core.storage.StorageOp
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CdcContextSerializationTest {
+    @BeforeAll
+    fun setup() {
+        CdcContext.initialize(phase = "test", tenant = "test")
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: storageOps null is excluded
+          state: none
+
+        - name: storageOps empty is excluded
+          state: empty
+
+        - name: storageOps populated is excluded
+          state: populated
+        """,
+    )
+    fun `storageOps is always excluded from CDC JSON`(state: String) {
+        val storageOps: List<StorageOp>? =
+            when (state) {
+                "none" -> null
+                "empty" -> emptyList()
+                "populated" -> listOf(StorageOp.Put(table = "t", row = "deadbeef", cells = emptyList()))
+                else -> error("unknown state: $state")
+            }
+
+        val context =
+            CdcContext(
+                label = EntityName("db", "tbl"),
+                edge = Edge(1, "src", "tgt", emptyMap<String, Any>()).toTraceEdge(),
+                op = EdgeOperation.INSERT,
+                status = EdgeOperationStatus.CREATED,
+                before = null,
+                after = null,
+                acc = 0,
+                alias = null,
+                deferredRequests = emptyList(),
+                storageOps = storageOps,
+                storageOpsTruncated = true,
+            )
+
+        val (_, json) = context.toJsonString()
+
+        assertFalse(json.contains("storageOps"), "CDC JSON must not include storageOps: $json")
+        assertFalse(json.contains("storageOpsTruncated"), "CDC JSON must not include storageOpsTruncated: $json")
+        assertFalse(json.contains("deadbeef"), "CDC JSON must not leak raw row bytes")
+        assertTrue(json.contains("\"status\":\"CREATED\""))
+        assertTrue(json.contains("\"op\":\"INSERT\""))
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
@@ -1,0 +1,113 @@
+package com.kakao.actionbase.server.api.graph.v2.edge
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class V2EdgeStorageOpsSpec : E2ETestBase() {
+    private val service = "v2-storage-ops-svc"
+    private val label = "v2-storage-ops-label"
+    private val name = "$service.$label"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$service", "comment": "v2 storage ops test service"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$service/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$label",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/v2_storage_ops_label",
+                  "mode": "SYNC",
+                  "comment": "v2 storage ops label"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: v2 edge without header omits storage_ops
+          header: null
+          edge: |
+            {"ts": 1, "src": "a", "tgt": "b", "props": {"score": 1}}
+          storageOpsExists: false
+
+        - name: v2 edge with header exposes storage_ops
+          header: "true"
+          edge: |
+            {"ts": 1, "src": "x", "tgt": "y", "props": {"score": 2}}
+          storageOpsExists: true
+        """,
+    )
+    fun `storage_ops visibility gated by header`(
+        header: String?,
+        edge: String,
+        storageOpsExists: Boolean,
+    ) {
+        val request =
+            client
+                .post()
+                .uri("/graph/v2/edge")
+                .contentType(MediaType.APPLICATION_JSON)
+        if (header != null) request.header("AB-Include-Mutation-Context", header)
+
+        val result =
+            request
+                .bodyValue("""{"label": "$name", "edges": [$edge]}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.result[0].status")
+                .isEqualTo("CREATED")
+
+        if (storageOpsExists) {
+            result
+                .jsonPath("$.result[0].context.storageOps[0].kind")
+                .isEqualTo("Put")
+                .jsonPath("$.result[0].context.storageOps[0].table")
+                .isEqualTo("edges")
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].family")
+                .isEqualTo("Zg==")
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].qualifier")
+                .isEqualTo("ZQ==")
+                .jsonPath("$.result[0].context.storageOps[0].row")
+                .exists()
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].value")
+                .exists()
+        } else {
+            result.jsonPath("$.result[0].context.storageOps").doesNotExist()
+        }
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
@@ -1,0 +1,156 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EdgeMutationStorageOpsSpec : E2ETestBase() {
+    private val db = "storage-ops-db"
+    private val edgeTable = "storage-ops-edge"
+    private val multiEdgeTable = "storage-ops-multi"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "storage ops test db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$edgeTable",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/storage_ops_edge",
+                  "mode": "SYNC",
+                  "comment": "edge for storage-ops test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$multiEdgeTable",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "long", "comment": "id"},
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/storage_ops_multi",
+                  "mode": "SYNC",
+                  "comment": "multi edge for storage-ops test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: edge without header omits storage_ops
+          table: storage-ops-edge
+          path: edges
+          header: null
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "a", "target": "b", "properties": {"score": 1}}}]}
+          storageOpsExists: false
+
+        - name: edge with header exposes storage_ops
+          table: storage-ops-edge
+          path: edges
+          header: "true"
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "x", "target": "y", "properties": {"score": 2}}}]}
+          storageOpsExists: true
+
+        - name: multi-edge with header exposes storage_ops
+          table: storage-ops-multi
+          path: multi-edges
+          header: "true"
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "id": 42, "source": 1, "target": 2, "properties": {"score": 3}}}]}
+          storageOpsExists: true
+        """,
+    )
+    fun `storage_ops visibility gated by header`(
+        table: String,
+        path: String,
+        header: String?,
+        body: String,
+        storageOpsExists: Boolean,
+    ) {
+        val request =
+            client
+                .post()
+                .uri("/graph/v3/databases/$db/tables/$table/$path")
+                .contentType(MediaType.APPLICATION_JSON)
+        if (header != null) request.header("AB-Include-Mutation-Context", header)
+
+        val result =
+            request
+                .bodyValue(body)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.results[0].status")
+                .isEqualTo("CREATED")
+
+        if (storageOpsExists) {
+            result
+                .jsonPath("$.results[0].context.storageOps[0].kind")
+                .isEqualTo("Put")
+                .jsonPath("$.results[0].context.storageOps[0].table")
+                .isEqualTo("edges")
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].family")
+                .isEqualTo("Zg==")
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].qualifier")
+                .isEqualTo("ZQ==")
+                .jsonPath("$.results[0].context.storageOps[0].row")
+                .exists()
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].value")
+                .exists()
+        } else {
+            result.jsonPath("$.results[0].context.storageOps").doesNotExist()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #253. `StorageOpCollector.collect(...)` now decodes HBase `Put` / `Delete` / `Increment` into base64-encoded `StorageOp`. No call-site changes.

Set the `AB-Include-Mutation-Context: true` header on a mutation request to receive the captured ops under `context["storageOps"]` in the response. When the captured set exceeds the `DEFAULT_MAX_OPS` cap, `context["storageOpsTruncated"] = true` is added so clients can tell a truncated snapshot from a complete one. Without the header the wire format is unchanged.

## Changes

- `StorageOp` — adds `Put` / `Delete` / `Increment` / `Unknown` data classes; `Cell` carries `type` (`Put`, `DeleteColumn`, `DeleteFamily`, `DeleteFamilyVersion`, `Delete`) so delete subtypes are observable
- `StorageOpCollector.collect` — `when` on `Put` / `Delete` / `Increment`; base64-encode row/family/qualifier/value via `ByteBuffer.wrap` to avoid an extra cell clone; unknown request types become `StorageOp.Unknown` with a one-shot per-type `warn` log
- `StorageOpCollector.toContextMap()` — single source of the `storageOps` / `storageOpsTruncated` shape, consumed by V3 `MutationService` and V2 `Graph`
- `CdcContext.storageOpsTruncated` — carries the flag across the V2 pipeline; `@JsonIgnore` keeps it out of CDC

## How to Test

`./gradlew build`

- `StorageOpCollectorTest` — round-trip per op type, multi-CF Put, multi-byte value, truncation, `toContextMap` flag, `Append` → `Unknown`, non-`Mutation` fallthrough
- `CdcContextSerializationTest` — `storageOps` and `storageOpsTruncated` excluded from CDC
- `V2EdgeStorageOpsSpec` — V2 `/graph/v2/edge` with header
- `EdgeMutationStorageOpsSpec` — V3 edge + multi-edge, `context.storageOps[0]` assertions