### PR TITLE
Add `context` map to mutation response payloads

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeMutationResponse.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.core.edge.payload
 
 import com.kakao.actionbase.core.edge.MutationKey
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class EdgeMutationResponse(
     val results: List<Item>,
 ) {
@@ -10,6 +12,8 @@ data class EdgeMutationResponse(
         val target: Any,
         val status: String,
         val count: Int,
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val context: Map<String, Any?>? = null,
     )
 
     companion object {
@@ -20,7 +24,13 @@ data class EdgeMutationResponse(
                         val key =
                             it.key as? MutationKey.SourceTarget
                                 ?: error("EdgeMutationResponse requires SourceTarget key, got ${it.key::class.simpleName}")
-                        Item(source = key.source, target = key.target, count = it.count, status = it.status)
+                        Item(
+                            source = key.source,
+                            target = key.target,
+                            count = it.count,
+                            status = it.status,
+                            context = it.context,
+                        )
                     }.sortedBy { "${it.source}:${it.target}" },
             )
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeMutationResponse.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.core.edge.payload
 
 import com.kakao.actionbase.core.edge.MutationKey
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class MultiEdgeMutationResponse(
     val results: List<Item>,
 ) {
@@ -9,6 +11,8 @@ data class MultiEdgeMutationResponse(
         val id: Any,
         val status: String,
         val count: Int,
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val context: Map<String, Any?>? = null,
     )
 
     companion object {
@@ -19,7 +23,7 @@ data class MultiEdgeMutationResponse(
                         val key =
                             it.key as? MutationKey.Id
                                 ?: error("MultiEdgeMutationResponse requires Id key, got ${it.key::class.simpleName}")
-                        Item(id = key.id, count = it.count, status = it.status)
+                        Item(id = key.id, count = it.count, status = it.status, context = it.context)
                     }.sortedBy { it.id.toString() },
             )
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationResult.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationResult.kt
@@ -10,6 +10,7 @@ data class MutationResult(
     val before: State = State.initial,
     val after: State = State.initial,
     val acc: Long = 0,
+    val context: Map<String, Any?>? = null,
 ) {
     companion object {
         fun of(

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeMutationResponseItemContextTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeMutationResponseItemContextTest.kt
@@ -1,0 +1,63 @@
+package com.kakao.actionbase.core.payload
+
+import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class EdgeMutationResponseItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            source: 1
+            target: 2
+            status: CREATED
+            count: 1
+            context: null
+          expectedJson: '{"source":1,"target":2,"status":"CREATED","count":1}'
+
+        - name: non-null context is serialized
+          item:
+            source: 1
+            target: 2
+            status: CREATED
+            count: 1
+            context: { debug: "trace-1", size: 10 }
+          expectedJson: '{"source":1,"target":2,"status":"CREATED","count":1,"context":{"debug":"trace-1","size":10}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: EdgeMutationResponse.Item,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"source":1,"target":2,"status":"CREATED","count":1}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"source":"s","target":"t","status":"CREATED","count":3,"context":{"k":"v"}}'
+          expectedContext: { k: v }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<EdgeMutationResponse.Item>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeMutationResponseItemContextTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeMutationResponseItemContextTest.kt
@@ -1,0 +1,61 @@
+package com.kakao.actionbase.core.payload
+
+import com.kakao.actionbase.core.edge.payload.MultiEdgeMutationResponse
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class MultiEdgeMutationResponseItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            id: 100
+            status: CREATED
+            count: 1
+            context: null
+          expectedJson: '{"id":100,"status":"CREATED","count":1}'
+
+        - name: non-null context is serialized
+          item:
+            id: 100
+            status: CREATED
+            count: 1
+            context: { debug: "trace-1" }
+          expectedJson: '{"id":100,"status":"CREATED","count":1,"context":{"debug":"trace-1"}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: MultiEdgeMutationResponse.Item,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"id":100,"status":"CREATED","count":1}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"id":42,"status":"UPDATED","count":2,"context":{"k":"v","n":1}}'
+          expectedContext: { k: v, n: 1 }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<MultiEdgeMutationResponse.Item>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItem.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItem.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.v2.engine.edge
 
 import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class MutationResult(
     val result: List<MutationResultItem>,
 )
@@ -10,4 +12,6 @@ data class MutationResultItem(
     val status: EdgeOperationStatus,
     val traceId: String,
     val edge: HashEdge?,
+    @field:JsonInclude(JsonInclude.Include.NON_NULL)
+    val context: Map<String, Any?>? = null,
 )

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItemContextTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItemContextTest.kt
@@ -1,0 +1,60 @@
+package com.kakao.actionbase.v2.engine.edge
+
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class MutationResultItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            status: CREATED
+            traceId: trace-1
+            edge: null
+            context: null
+          expectedJson: '{"status":"CREATED","traceId":"trace-1","edge":null}'
+
+        - name: non-null context is serialized
+          item:
+            status: CREATED
+            traceId: trace-1
+            edge: null
+            context: { debug: "trace-1", size: 10 }
+          expectedJson: '{"status":"CREATED","traceId":"trace-1","edge":null,"context":{"debug":"trace-1","size":10}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: MutationResultItem,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"status":"CREATED","traceId":"trace-1","edge":null}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"status":"UPDATED","traceId":"trace-2","edge":null,"context":{"k":"v","n":1}}'
+          expectedContext: { k: v, n: 1 }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<MutationResultItem>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}


### PR DESCRIPTION
## Summary

Query payloads (`EdgePayload`, etc.) already carry a `context: Map<String, Any?>?` slot; add the same slot to mutation payloads for symmetry. Applies to both V2 and V3 endpoints.

Nullable with `@JsonInclude(NON_NULL)` — **non-breaking**. Existing callers are unaffected.

## Changes

- `core.MutationResult.context: Map<String, Any?>? = null`
- V3 `EdgeMutationResponse.Item.context` and `MultiEdgeMutationResponse.Item.context`
- V2 `engine.edge.MutationResultItem.context`
- `from(...)` factories thread it through unchanged

## Tests

- `MutationResponseContextTest` (core) — V3 items ser/der: null omitted, non-null round-trip
- `MutationResultItemContextTest` (engine) — same for V2 `MutationResultItem`
