### PR TITLE
Verify mutation response `context` is non-breaking via opt-in header and e2e

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
@@ -1,8 +1,12 @@
 package com.kakao.actionbase.engine.context
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 data class RequestContext(
     val requestId: String,
     val actor: String,
+    @field:JsonIgnore
+    val includeContext: Boolean = false,
 ) {
     companion object {
         val DEFAULT = RequestContext("-", "-")

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -68,6 +68,7 @@ class MutationService(
                             }
                         }
                     }.collectList()
+                    .map { list -> if (requestContext.includeContext) list.map { it.copy(context = emptyMap()) } else list }
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -285,6 +285,7 @@ class Graph(
         mode: MutationMode? = null,
         force: Boolean = false,
         failOnExist: Boolean = false,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> {
         val mutationModeContext = MutationModeContext.of(label.entity.mode, mode, systemMutationMode, force)
 
@@ -369,8 +370,11 @@ class Graph(
                         )
                     }
             }.collectList()
-            .map { MutationResult(it) }
-            .timeout(Duration.ofMillis(mutationRequestTimeout))
+            .map { items ->
+                MutationResult(
+                    if (includeContext) items.map { it.copy(context = emptyMap()) } else items,
+                )
+            }.timeout(Duration.ofMillis(mutationRequestTimeout))
             // Ensures all work completes even if the request is cancelled - https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cache--
             .cache(Duration.ZERO)
             .subscribeOn(Schedulers.boundedElastic())
@@ -380,6 +384,7 @@ class Graph(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -390,12 +395,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun update(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -406,12 +413,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun delete(
         request: DeleteEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -422,6 +431,7 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun purge(request: DeleteEdgeRequest): Mono<MutationResult> =
@@ -437,11 +447,20 @@ class Graph(
             false,
         )
 
-    fun upsert(request: InsertIdEdgeRequest): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder))
+    fun upsert(
+        request: InsertIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
-    fun update(request: InsertIdEdgeRequest): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder))
+    fun update(
+        request: InsertIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
-    fun delete(request: DeleteIdEdgeRequest): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder))
+    fun delete(
+        request: DeleteIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
     // -- query
 

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.edge
 
+import com.kakao.actionbase.engine.context.RequestContext
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.core.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
@@ -28,34 +29,40 @@ class EdgeController(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge")
     fun update(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge")
     fun delete(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: DeleteEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @PostMapping("/graph/v2/edge/id")
     fun insertId(
         @RequestBody request: InsertIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.includeContext).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge/id")
     fun updateId(
         @RequestBody request: InsertIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.includeContext).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge/id")
     fun deleteId(
         @RequestBody request: DeleteIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.includeContext).mapToResponseEntity()
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/HttpHeaderConstants.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/HttpHeaderConstants.kt
@@ -6,4 +6,5 @@ object HttpHeaderConstants {
     const val ACTOR_ROLE = "Actor-ROLE"
     const val AB_ACTOR_ID = "X-AB-Actor-ID" // legacy support
     const val RESPONSE_META = "Response-Meta"
+    const val INCLUDE_MUTATION_CONTEXT = "AB-Include-Mutation-Context"
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/resolver/ServerRequestContextArgumentResolver.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/resolver/ServerRequestContextArgumentResolver.kt
@@ -29,6 +29,12 @@ class ServerRequestContextArgumentResolver : HandlerMethodArgumentResolver {
                 ?: headers.getFirst(HttpHeaderConstants.AB_ACTOR_ID)
                 ?: RequestContext.DEFAULT.actor
 
-        return Mono.just(RequestContext(requestId, actor))
+        val includeContext =
+            headers
+                .getFirst(HttpHeaderConstants.INCLUDE_MUTATION_CONTEXT)
+                ?.trim()
+                ?.equals("true", ignoreCase = true) == true
+
+        return Mono.just(RequestContext(requestId, actor, includeContext))
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
@@ -1,0 +1,221 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants.INCLUDE_MUTATION_CONTEXT
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MutationContextOptInE2ETest : E2ETestBase() {
+    private val db = "ctx_optin_db"
+    private val edgeTable = "ctx_optin_edge"
+    private val multiEdgeTable = "ctx_optin_multi_edge"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "context opt-in test"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$edgeTable",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/ctx_optin_edge",
+                  "mode": "SYNC",
+                  "comment": "edge for context opt-in test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$multiEdgeTable",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "long", "comment": "id"},
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/ctx_optin_multi_edge",
+                  "mode": "SYNC",
+                  "comment": "multi-edge for context opt-in test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `edge mutation without header omits context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s1", "target": "t1", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s2", "target": "t2", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `multi-edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$multiEdgeTable/multi-edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "id": 77777, "source": 1, "target": 2, "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `edge mutation with header false omits context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "false")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-false", "target": "t-false", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `V3 async edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-async", "target": "t-async", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `header is case-insensitive`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "TRUE")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s3", "target": "t3", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `V2 edge mutation without header omits context`() {
+        client
+            .post()
+            .uri("/graph/v2/edge")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-a", "tgt": "t-v2-a", "props": {}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.result[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `V2 edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v2/edge")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-b", "tgt": "t-v2-b", "props": {}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.result[0].context")
+            .isMap
+    }
+}


### PR DESCRIPTION
## Summary

Follows #258. Adds an opt-in header `AB-Include-Mutation-Context` (case-insensitive) that attaches an empty `context: {}` map to each mutation response item. Without it, `context` stays `null` and is omitted — wire-identical for existing callers. Covers V2 and V3 endpoints, verified end-to-end.

## How it works

V3 carries the flag on `RequestContext.includeContext`, which the existing `ServerRequestContextArgumentResolver` already assembles from request headers — V3 controllers stay untouched. V2 `EdgeController` also receives `RequestContext` and forwards the flag to `Graph`. Other V2 service-label controllers keep the default (`false`) via `Graph`'s default parameter.

Enrichment (`.copy(context = emptyMap())`) happens *after* `.collectList()`, so WAL, storage, and CDC payloads are unaffected.

## Changes

- `HttpHeaderConstants.INCLUDE_MUTATION_CONTEXT` — new header constant
- `engine.context.RequestContext.includeContext` — new `Boolean` field, `@field:JsonIgnore` to keep it out of `GET /graph` response
- `ServerRequestContextArgumentResolver` — reads the header (trim + case-insensitive `"true"`)
- `engine.service.MutationService.mutate` — enriches items when `requestContext.includeContext`
- `v2.engine.Graph.mutate` + `upsert`/`update`/`delete` overloads — `includeContext: Boolean = false` parameter threading into the same enrichment
- V2 `EdgeController` — now takes `RequestContext` (no new `@RequestHeader` noise) and forwards `includeContext`

## Tests

- `MutationContextOptInE2ETest` (e2e via `WebTestClient`) — V3 edge sync/async + multi-edge sync, V2 edge; header on/off/false, case-insensitive (8 cases)
