### PR TITLE
Add `StorageOpCollector` scaffold and wire it through the mutation path

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,0 +1,36 @@
+package com.kakao.actionbase.core.storage
+
+sealed class StorageOp {
+    abstract val table: String
+    abstract val rowHex: String
+
+    data class Put(
+        override val table: String,
+        override val rowHex: String,
+        val cells: List<Cell>,
+    ) : StorageOp()
+
+    data class Delete(
+        override val table: String,
+        override val rowHex: String,
+        val cells: List<Cell>,
+    ) : StorageOp()
+
+    data class Increment(
+        override val table: String,
+        override val rowHex: String,
+        val deltas: List<Delta>,
+    ) : StorageOp()
+
+    data class Cell(
+        val familyHex: String,
+        val qualifierHex: String,
+        val valueHex: String?,
+    )
+
+    data class Delta(
+        val familyHex: String,
+        val qualifierHex: String,
+        val delta: Long,
+    )
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,36 +1,3 @@
 package com.kakao.actionbase.core.storage
 
-sealed class StorageOp {
-    abstract val table: String
-    abstract val rowHex: String
-
-    data class Put(
-        override val table: String,
-        override val rowHex: String,
-        val cells: List<Cell>,
-    ) : StorageOp()
-
-    data class Delete(
-        override val table: String,
-        override val rowHex: String,
-        val cells: List<Cell>,
-    ) : StorageOp()
-
-    data class Increment(
-        override val table: String,
-        override val rowHex: String,
-        val deltas: List<Delta>,
-    ) : StorageOp()
-
-    data class Cell(
-        val familyHex: String,
-        val qualifierHex: String,
-        val valueHex: String?,
-    )
-
-    data class Delta(
-        val familyHex: String,
-        val qualifierHex: String,
-        val delta: Long,
-    )
-}
+sealed class StorageOp

--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,3 +1,36 @@
 package com.kakao.actionbase.core.storage
 
-sealed class StorageOp
+sealed class StorageOp {
+    abstract val table: String
+    abstract val rowHex: String
+
+    data class Put(
+        override val table: String,
+        override val rowHex: String,
+        val cells: List<Cell>,
+    ) : StorageOp()
+
+    data class Delete(
+        override val table: String,
+        override val rowHex: String,
+        val cells: List<Cell>,
+    ) : StorageOp()
+
+    data class Increment(
+        override val table: String,
+        override val rowHex: String,
+        val deltas: List<Delta>,
+    ) : StorageOp()
+
+    data class Cell(
+        val familyHex: String,
+        val qualifierHex: String,
+        val valueHex: String?,
+    )
+
+    data class Delta(
+        val familyHex: String,
+        val qualifierHex: String,
+        val delta: Long,
+    )
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -6,6 +6,7 @@ import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.metadata.Direction
 
 import reactor.core.publisher.Mono
@@ -28,6 +29,7 @@ interface TableBinding {
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector? = null,
     ): Mono<MutationRecordsSummary>
 
     fun handleMutationError(error: Throwable)

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
@@ -1,13 +1,17 @@
 package com.kakao.actionbase.engine.context
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
+
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 data class RequestContext(
     val requestId: String,
     val actor: String,
-    @field:JsonIgnore
+    @JsonIgnore
     val includeContext: Boolean = false,
 ) {
+    fun newCollector(): StorageOpCollector? = if (includeContext) StorageOpCollector() else null
+
     companion object {
         val DEFAULT = RequestContext("-", "-")
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -12,6 +12,7 @@ import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.context.RequestContext
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.metadata.MutationModeContext
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.engine.util.component1
 import com.kakao.actionbase.engine.util.component2
 import com.kakao.actionbase.engine.util.runEvenIfCancelled
@@ -58,7 +59,8 @@ class MutationService(
                         } else {
                             groupMono.flatMap { group ->
                                 val sorted = group.sortedBy { it.event.version }
-                                readModifyWrite(tb, key, sorted, acquireLock)
+                                val collector = if (requestContext.includeContext) StorageOpCollector() else null
+                                readModifyWrite(tb, key, sorted, acquireLock, collector)
                                     .doOnNext { result ->
                                         engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
                                     }.onErrorResume {
@@ -68,7 +70,6 @@ class MutationService(
                             }
                         }
                     }.collectList()
-                    .map { list -> if (requestContext.includeContext) list.map { it.copy(context = emptyMap()) } else list }
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }
@@ -78,15 +79,17 @@ class MutationService(
         key: MutationKey,
         sorted: List<MutationEvent>,
         acquireLock: Boolean,
+        collector: StorageOpCollector?,
     ): Mono<MutationResult> {
         val rwm = {
             tb
                 .read(key)
                 .flatMap { state ->
                     val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
-                    tb.write(key, state, after)
+                    tb.write(key, state, after, collector)
                 }.map { summary ->
-                    MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc)
+                    val context = collector?.snapshot()?.let { mapOf("storage_ops" to it) }
+                    MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc, context)
                 }
         }
         return if (acquireLock) tb.withLock(key, rwm) else rwm()

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -59,8 +59,7 @@ class MutationService(
                         } else {
                             groupMono.flatMap { group ->
                                 val sorted = group.sortedBy { it.event.version }
-                                val collector = if (requestContext.includeContext) StorageOpCollector() else null
-                                readModifyWrite(tb, key, sorted, acquireLock, collector)
+                                readModifyWrite(tb, key, sorted, acquireLock, requestContext.newCollector())
                                     .doOnNext { result ->
                                         engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
                                     }.onErrorResume {
@@ -88,7 +87,7 @@ class MutationService(
                     val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
                     tb.write(key, state, after, collector)
                 }.map { summary ->
-                    val context = collector?.snapshot()?.let { mapOf("storage_ops" to it) }
+                    val context = collector?.snapshot()?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) }
                     MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc, context)
                 }
         }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -2,6 +2,10 @@ package com.kakao.actionbase.engine.storage
 
 import com.kakao.actionbase.core.storage.StorageOp
 
+/**
+ * Single-owner appender used under a Reactor chain (per-RMW in V3, per-edge in V2).
+ * Not safe to share across parallel publishers — signals must arrive serially.
+ */
 class StorageOpCollector(
     private val maxOps: Int = DEFAULT_MAX_OPS,
 ) {
@@ -33,5 +37,6 @@ class StorageOpCollector(
 
     companion object {
         const val DEFAULT_MAX_OPS: Int = 1024
+        const val CONTEXT_KEY: String = "storage_ops"
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -2,14 +2,10 @@ package com.kakao.actionbase.engine.storage
 
 import com.kakao.actionbase.core.storage.StorageOp
 
-import java.util.concurrent.CopyOnWriteArrayList
-
 class StorageOpCollector(
     private val maxOps: Int = DEFAULT_MAX_OPS,
 ) {
-    private val ops = CopyOnWriteArrayList<StorageOp>()
-
-    @Volatile
+    private val ops = mutableListOf<StorageOp>()
     private var truncated = false
 
     @Suppress("UNUSED_PARAMETER")

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -1,0 +1,41 @@
+package com.kakao.actionbase.engine.storage
+
+import com.kakao.actionbase.core.storage.StorageOp
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class StorageOpCollector(
+    private val maxOps: Int = DEFAULT_MAX_OPS,
+) {
+    private val ops = CopyOnWriteArrayList<StorageOp>()
+
+    @Volatile
+    private var truncated = false
+
+    @Suppress("UNUSED_PARAMETER")
+    fun collect(
+        request: Any,
+        table: String,
+    ) {
+        if (ops.size >= maxOps) {
+            truncated = true
+            return
+        }
+        // No-op until backend interpretation is added.
+    }
+
+    fun collectAll(
+        requests: Collection<Any>,
+        table: String,
+    ) {
+        requests.forEach { collect(it, table) }
+    }
+
+    fun snapshot(): List<StorageOp> = ops.toList()
+
+    fun isTruncated(): Boolean = truncated
+
+    companion object {
+        const val DEFAULT_MAX_OPS: Int = 1024
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -10,6 +10,7 @@ import com.kakao.actionbase.core.edge.mapper.EdgeLockRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
 import com.kakao.actionbase.engine.query.LabelProvider
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
 import com.kakao.actionbase.v2.core.code.EmptyEdgeIdEncoder
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
@@ -285,7 +286,7 @@ class Graph(
         mode: MutationMode? = null,
         force: Boolean = false,
         failOnExist: Boolean = false,
-        includeContext: Boolean = false,
+        collectorFactory: (() -> StorageOpCollector)? = null,
     ): Mono<MutationResult> {
         val mutationModeContext = MutationModeContext.of(label.entity.mode, mode, systemMutationMode, force)
 
@@ -308,7 +309,7 @@ class Graph(
                                 )
                             } else {
                                 label
-                                    .mutate(edge, operation, alias, bulk, failOnExist)
+                                    .mutate(edge, operation, alias, bulk, failOnExist, collectorFactory)
                                     .map { context ->
                                         // fill audit and requestId
                                         context.copy(audit = audit, requestId = requestId)
@@ -340,6 +341,7 @@ class Graph(
                                             status = context.status,
                                             traceId = context.edge.traceId,
                                             edge = context.after ?: context.before,
+                                            context = context.storageOps?.let { mapOf("storage_ops" to it) },
                                         )
                                     }
                             }
@@ -370,11 +372,8 @@ class Graph(
                         )
                     }
             }.collectList()
-            .map { items ->
-                MutationResult(
-                    if (includeContext) items.map { it.copy(context = emptyMap()) } else items,
-                )
-            }.timeout(Duration.ofMillis(mutationRequestTimeout))
+            .map { MutationResult(it) }
+            .timeout(Duration.ofMillis(mutationRequestTimeout))
             // Ensures all work completes even if the request is cancelled - https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cache--
             .cache(Duration.ZERO)
             .subscribeOn(Schedulers.boundedElastic())
@@ -384,7 +383,7 @@ class Graph(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        collectorFactory: (() -> StorageOpCollector)? = null,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -395,14 +394,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            collectorFactory = collectorFactory,
         )
 
     fun update(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        collectorFactory: (() -> StorageOpCollector)? = null,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -413,14 +412,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            collectorFactory = collectorFactory,
         )
 
     fun delete(
         request: DeleteEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        collectorFactory: (() -> StorageOpCollector)? = null,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -431,7 +430,7 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            collectorFactory = collectorFactory,
         )
 
     fun purge(request: DeleteEdgeRequest): Mono<MutationResult> =
@@ -449,18 +448,18 @@ class Graph(
 
     fun upsert(
         request: InsertIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        collectorFactory: (() -> StorageOpCollector)? = null,
+    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
 
     fun update(
         request: InsertIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        collectorFactory: (() -> StorageOpCollector)? = null,
+    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
 
     fun delete(
         request: DeleteIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        collectorFactory: (() -> StorageOpCollector)? = null,
+    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
 
     // -- query
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -286,7 +286,7 @@ class Graph(
         mode: MutationMode? = null,
         force: Boolean = false,
         failOnExist: Boolean = false,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> {
         val mutationModeContext = MutationModeContext.of(label.entity.mode, mode, systemMutationMode, force)
 
@@ -309,7 +309,7 @@ class Graph(
                                 )
                             } else {
                                 label
-                                    .mutate(edge, operation, alias, bulk, failOnExist, collectorFactory)
+                                    .mutate(edge, operation, alias, bulk, failOnExist, newCollector)
                                     .map { context ->
                                         // fill audit and requestId
                                         context.copy(audit = audit, requestId = requestId)
@@ -341,7 +341,7 @@ class Graph(
                                             status = context.status,
                                             traceId = context.edge.traceId,
                                             edge = context.after ?: context.before,
-                                            context = context.storageOps?.let { mapOf("storage_ops" to it) },
+                                            context = context.storageOps?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) },
                                         )
                                     }
                             }
@@ -383,7 +383,7 @@ class Graph(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -394,14 +394,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            collectorFactory = collectorFactory,
+            newCollector = newCollector,
         )
 
     fun update(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -412,14 +412,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            collectorFactory = collectorFactory,
+            newCollector = newCollector,
         )
 
     fun delete(
         request: DeleteEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -430,7 +430,7 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            collectorFactory = collectorFactory,
+            newCollector = newCollector,
         )
 
     fun purge(request: DeleteEdgeRequest): Mono<MutationResult> =
@@ -448,18 +448,18 @@ class Graph(
 
     fun upsert(
         request: InsertIdEdgeRequest,
-        collectorFactory: (() -> StorageOpCollector)? = null,
-    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     fun update(
         request: InsertIdEdgeRequest,
-        collectorFactory: (() -> StorageOpCollector)? = null,
-    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     fun delete(
         request: DeleteIdEdgeRequest,
-        collectorFactory: (() -> StorageOpCollector)? = null,
-    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), collectorFactory = collectorFactory)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     // -- query
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.cdc
 
+import com.kakao.actionbase.core.storage.StorageOp
 import com.kakao.actionbase.v2.core.edge.TraceEdge
 import com.kakao.actionbase.v2.core.metadata.EdgeOperation
 import com.kakao.actionbase.v2.engine.audit.Audit
@@ -28,6 +29,8 @@ data class CdcContext(
     val message: String? = null,
     val audit: Audit = Audit.default,
     val requestId: String = "",
+    @JsonIgnore
+    val storageOps: List<StorageOp>? = null,
 ) : Log {
     @Suppress("PropertyName")
     companion object {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
@@ -92,7 +92,7 @@ abstract class AbstractLabel<T>(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
-        collectorFactory: (() -> StorageOpCollector)?,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> {
         if (entity.readOnly) {
             return Mono.error(UnsupportedOperationException("This Label (${entity.fullName}) is read-only"))
@@ -100,7 +100,7 @@ abstract class AbstractLabel<T>(
         return Flux
             .fromIterable(edges)
             .map { it.ensureType(entity.schema) }
-            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist, collectorFactory?.invoke()) }
+            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist, newCollector()) }
             .collectList()
     }
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.EncodedKey
 import com.kakao.actionbase.v2.core.code.HashEdgeValue
@@ -91,6 +92,7 @@ abstract class AbstractLabel<T>(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        collectorFactory: (() -> StorageOpCollector)?,
     ): Mono<List<CdcContext>> {
         if (entity.readOnly) {
             return Mono.error(UnsupportedOperationException("This Label (${entity.fullName}) is read-only"))
@@ -98,7 +100,7 @@ abstract class AbstractLabel<T>(
         return Flux
             .fromIterable(edges)
             .map { it.ensureType(entity.schema) }
-            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist) }
+            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist, collectorFactory?.invoke()) }
             .collectList()
     }
 
@@ -109,6 +111,7 @@ abstract class AbstractLabel<T>(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean = false,
+        collector: StorageOpCollector? = null,
     ): Mono<CdcContext> {
         log.debug("mutate {} {}", op, edge)
         val encodedHashEdgeKey = coder.encodeHashEdgeKey(edge, entity.id)
@@ -154,12 +157,13 @@ abstract class AbstractLabel<T>(
             }.flatMap { context ->
                 if (context.deferredRequests.isNotEmpty()) {
                     log.debug("6. handle {} deferred  requests", context.deferredRequests.size)
-                    handleDeferredRequests(context.deferredRequests)
+                    handleDeferredRequests(context.deferredRequests, collector)
                         .thenReturn(context.copy(deferredRequests = emptyList()))
                 } else {
                     Mono.just(context)
                 }
-            }.subscribeOn(Schedulers.boundedElastic())
+            }.map { context -> context.copy(storageOps = collector?.snapshot()) }
+            .subscribeOn(Schedulers.boundedElastic())
             .doFinally {
                 releaseLock(edge.traceId, encodedLockEdge, bulk)
                     .subscribeOn(Schedulers.boundedElastic())
@@ -671,7 +675,10 @@ abstract class AbstractLabel<T>(
 
     abstract fun deleteOnLock(keyField: KeyValue<T>): Mono<Boolean>
 
-    open fun handleDeferredRequests(deferredRequests: List<Any>): Mono<Boolean> = Mono.just(true)
+    open fun handleDeferredRequests(
+        deferredRequests: List<Any>,
+        storageOpCollector: StorageOpCollector? = null,
+    ): Mono<Boolean> = Mono.just(true)
 
     abstract fun setnx(
         keyField: EncodedKey<T>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
 import com.kakao.actionbase.v2.core.edge.TraceEdge
@@ -29,6 +30,7 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
+        collectorFactory: (() -> StorageOpCollector)? = null,
     ): Mono<List<CdcContext>>
 
     fun mutate(
@@ -37,7 +39,10 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
-    ): Mono<CdcContext> = mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist).map { it.first() }
+        collectorFactory: (() -> StorageOpCollector)? = null,
+    ): Mono<CdcContext> =
+        mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
+            .map { it.first() }
 
     fun scan(
         scanFilter: ScanFilter,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
@@ -30,7 +30,7 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<List<CdcContext>>
 
     fun mutate(
@@ -39,9 +39,9 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
-        collectorFactory: (() -> StorageOpCollector)? = null,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<CdcContext> =
-        mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
+        mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
             .map { it.first() }
 
     fun scan(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
@@ -98,10 +98,9 @@ open class HBaseHashLabel(
         storageOpCollector: StorageOpCollector?,
     ): Mono<Boolean> =
         tables
-            .flatMap { t ->
-                storageOpCollector?.collectAll(deferredRequests, t.edge.name.nameAsString)
-                t.edge.batch(deferredRequests)
-            }.thenReturn(true)
+            .doOnNext { t -> storageOpCollector?.collectAll(deferredRequests, t.edge.name.nameAsString) }
+            .flatMap { t -> t.edge.batch(deferredRequests) }
+            .thenReturn(true)
 
     override fun setnx(
         keyField: EncodedKey<ByteArray>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
@@ -2,6 +2,7 @@ package com.kakao.actionbase.v2.engine.label.hbase
 
 import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.core.storage.HBaseRecord
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.engine.util.HBaseRecordCache
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.EncodedKey
@@ -92,7 +93,15 @@ open class HBaseHashLabel(
         return Mono.just(listOf(delete))
     }
 
-    override fun handleDeferredRequests(deferredRequests: List<Any>): Mono<Boolean> = tables.flatMap { it.edge.batch(deferredRequests) }.thenReturn(true)
+    override fun handleDeferredRequests(
+        deferredRequests: List<Any>,
+        storageOpCollector: StorageOpCollector?,
+    ): Mono<Boolean> =
+        tables
+            .flatMap { t ->
+                storageOpCollector?.collectAll(deferredRequests, t.edge.name.nameAsString)
+                t.edge.batch(deferredRequests)
+            }.thenReturn(true)
 
     override fun setnx(
         keyField: EncodedKey<ByteArray>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label.metastore
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
@@ -64,11 +65,12 @@ class LocalBackedJdbcHashLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        collectorFactory: (() -> StorageOpCollector)?,
     ): Mono<List<CdcContext>> =
         if (useLocalStore) {
-            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist)
+            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
         } else {
-            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist)
+            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
         }
 
     override fun scan(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
@@ -65,12 +65,12 @@ class LocalBackedJdbcHashLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
-        collectorFactory: (() -> StorageOpCollector)?,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> =
         if (useLocalStore) {
-            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
+            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
         } else {
-            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, collectorFactory = collectorFactory)
+            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
         }
 
     override fun scan(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label.nil
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
 import com.kakao.actionbase.v2.core.edge.TraceEdge
@@ -45,6 +46,7 @@ class NilLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        collectorFactory: (() -> StorageOpCollector)?,
     ): Mono<List<CdcContext>> =
         Mono.fromCallable {
             edges.map {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
@@ -46,7 +46,7 @@ class NilLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
-        collectorFactory: (() -> StorageOpCollector)?,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> =
         Mono.fromCallable {
             edges.map {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.metadata.Direction
 
 import reactor.core.publisher.Mono
@@ -30,6 +31,7 @@ class NilTableBinding(
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector?,
     ): Mono<MutationRecordsSummary> = Mono.just(MutationRecordsSummary(IDLE, 0, State.initial, State.initial))
 
     override fun handleMutationError(error: Throwable) {}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -24,6 +24,7 @@ import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -92,6 +93,7 @@ class V2BackedTableBinding(
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector?,
     ): Mono<MutationRecordsSummary> {
         val (source, target) = key.toSourceTarget()
         val beforeClean = before.specialStateValueToNull()
@@ -100,7 +102,7 @@ class V2BackedTableBinding(
         val afterRecord = EdgeStateRecord.of(source, target, afterClean, label.entity.id)
         val records = buildMutationRecords(beforeRecord, afterRecord)
         return label
-            .handleDeferredRequests(buildHBaseMutations(records))
+            .handleDeferredRequests(buildHBaseMutations(records), storageOpCollector)
             .thenReturn(MutationRecordsSummary(records.status, records.acc, beforeClean, afterClean))
     }
 

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.api.graph.v2.edge
 
 import com.kakao.actionbase.engine.context.RequestContext
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.core.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
@@ -30,7 +31,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge")
     fun update(
@@ -38,7 +39,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge")
     fun delete(
@@ -46,23 +47,25 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: DeleteEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
 
     @PostMapping("/graph/v2/edge/id")
     fun insertId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.collectorFactory()).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge/id")
     fun updateId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.collectorFactory()).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge/id")
     fun deleteId(
         @RequestBody request: DeleteIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.collectorFactory()).mapToResponseEntity()
 }
+
+private fun RequestContext.collectorFactory(): (() -> StorageOpCollector)? = if (includeContext) ({ StorageOpCollector() }) else null

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
@@ -1,7 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.edge
 
 import com.kakao.actionbase.engine.context.RequestContext
-import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.core.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
@@ -31,7 +30,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge")
     fun update(
@@ -39,7 +38,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge")
     fun delete(
@@ -47,25 +46,23 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: DeleteEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @PostMapping("/graph/v2/edge/id")
     fun insertId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext::newCollector).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge/id")
     fun updateId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext::newCollector).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge/id")
     fun deleteId(
         @RequestBody request: DeleteIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.collectorFactory()).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext::newCollector).mapToResponseEntity()
 }
-
-private fun RequestContext.collectorFactory(): (() -> StorageOpCollector)? = if (includeContext) ({ StorageOpCollector() }) else null


### PR DESCRIPTION
## Summary

Scaffolds a request-scoped `StorageOpCollector` and plumbs it through the V2/V3 mutation paths so #253 can surface storage ops on responses. `collect()` is a no-op here — HBase interpretation lands in #254.

## Changes

- `core.storage.StorageOp` sealed hierarchy (`Put` / `Delete` / `Increment`)
- `engine.storage.StorageOpCollector` — thread-safe, per-RMW cap; `collect` no-op
- V3 `MutationService` — gate on `RequestContext.includeContext`, attach `context["storage_ops"]`
- V2 `Graph.mutate` + overloads take `collectorFactory: (() -> StorageOpCollector)?`
- `HBaseHashLabel.handleDeferredRequests` forwards to `collector?.collectAll`
- `CdcContext.storageOps` internal-only (`@JsonIgnore`)

## How to Test

```bash
./gradlew build
```