### PR TITLE
Backport storage-ops shadow testing to 0.2.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,14 @@ name: 'Continuous Integration'
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - '*.x'
 
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - '*.x'
     types:
       - opened
       - reopened

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeMutationResponse.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.core.edge.payload
 
 import com.kakao.actionbase.core.edge.MutationKey
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class EdgeMutationResponse(
     val results: List<Item>,
 ) {
@@ -10,6 +12,8 @@ data class EdgeMutationResponse(
         val target: Any,
         val status: String,
         val count: Int,
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val context: Map<String, Any?>? = null,
     )
 
     companion object {
@@ -20,7 +24,13 @@ data class EdgeMutationResponse(
                         val key =
                             it.key as? MutationKey.SourceTarget
                                 ?: error("EdgeMutationResponse requires SourceTarget key, got ${it.key::class.simpleName}")
-                        Item(source = key.source, target = key.target, count = it.count, status = it.status)
+                        Item(
+                            source = key.source,
+                            target = key.target,
+                            count = it.count,
+                            status = it.status,
+                            context = it.context,
+                        )
                     }.sortedBy { "${it.source}:${it.target}" },
             )
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeMutationResponse.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.core.edge.payload
 
 import com.kakao.actionbase.core.edge.MutationKey
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class MultiEdgeMutationResponse(
     val results: List<Item>,
 ) {
@@ -9,6 +11,8 @@ data class MultiEdgeMutationResponse(
         val id: Any,
         val status: String,
         val count: Int,
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val context: Map<String, Any?>? = null,
     )
 
     companion object {
@@ -19,7 +23,7 @@ data class MultiEdgeMutationResponse(
                         val key =
                             it.key as? MutationKey.Id
                                 ?: error("MultiEdgeMutationResponse requires Id key, got ${it.key::class.simpleName}")
-                        Item(id = key.id, count = it.count, status = it.status)
+                        Item(id = key.id, count = it.count, status = it.status, context = it.context)
                     }.sortedBy { it.id.toString() },
             )
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationResult.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationResult.kt
@@ -10,6 +10,7 @@ data class MutationResult(
     val before: State = State.initial,
     val after: State = State.initial,
     val acc: Long = 0,
+    val context: Map<String, Any?>? = null,
 ) {
     companion object {
         fun of(

--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,0 +1,3 @@
+package com.kakao.actionbase.core.storage
+
+sealed class StorageOp

--- a/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/storage/StorageOp.kt
@@ -1,3 +1,50 @@
 package com.kakao.actionbase.core.storage
 
-sealed class StorageOp
+sealed class StorageOp {
+    abstract val kind: String
+    abstract val table: String
+
+    data class Put(
+        override val table: String,
+        val row: String,
+        val cells: List<Cell>,
+    ) : StorageOp() {
+        override val kind: String = "Put"
+    }
+
+    data class Delete(
+        override val table: String,
+        val row: String,
+        val cells: List<Cell>,
+    ) : StorageOp() {
+        override val kind: String = "Delete"
+    }
+
+    data class Increment(
+        override val table: String,
+        val row: String,
+        val deltas: List<Delta>,
+    ) : StorageOp() {
+        override val kind: String = "Increment"
+    }
+
+    data class Unknown(
+        override val table: String,
+        val type: String,
+    ) : StorageOp() {
+        override val kind: String = "Unknown"
+    }
+
+    data class Cell(
+        val family: String,
+        val qualifier: String,
+        val value: String?,
+        val type: String,
+    )
+
+    data class Delta(
+        val family: String,
+        val qualifier: String,
+        val delta: Long,
+    )
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeMutationResponseItemContextTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeMutationResponseItemContextTest.kt
@@ -1,0 +1,63 @@
+package com.kakao.actionbase.core.payload
+
+import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class EdgeMutationResponseItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            source: 1
+            target: 2
+            status: CREATED
+            count: 1
+            context: null
+          expectedJson: '{"source":1,"target":2,"status":"CREATED","count":1}'
+
+        - name: non-null context is serialized
+          item:
+            source: 1
+            target: 2
+            status: CREATED
+            count: 1
+            context: { debug: "trace-1", size: 10 }
+          expectedJson: '{"source":1,"target":2,"status":"CREATED","count":1,"context":{"debug":"trace-1","size":10}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: EdgeMutationResponse.Item,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"source":1,"target":2,"status":"CREATED","count":1}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"source":"s","target":"t","status":"CREATED","count":3,"context":{"k":"v"}}'
+          expectedContext: { k: v }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<EdgeMutationResponse.Item>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeMutationResponseItemContextTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeMutationResponseItemContextTest.kt
@@ -1,0 +1,61 @@
+package com.kakao.actionbase.core.payload
+
+import com.kakao.actionbase.core.edge.payload.MultiEdgeMutationResponse
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class MultiEdgeMutationResponseItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            id: 100
+            status: CREATED
+            count: 1
+            context: null
+          expectedJson: '{"id":100,"status":"CREATED","count":1}'
+
+        - name: non-null context is serialized
+          item:
+            id: 100
+            status: CREATED
+            count: 1
+            context: { debug: "trace-1" }
+          expectedJson: '{"id":100,"status":"CREATED","count":1,"context":{"debug":"trace-1"}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: MultiEdgeMutationResponse.Item,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"id":100,"status":"CREATED","count":1}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"id":42,"status":"UPDATED","count":2,"context":{"k":"v","n":1}}'
+          expectedContext: { k: v, n: 1 }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<MultiEdgeMutationResponse.Item>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 
 import reactor.core.publisher.Mono
 
@@ -23,6 +24,7 @@ interface TableBinding {
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector? = null,
     ): Mono<MutationRecordsSummary>
 
     fun handleMutationError(error: Throwable)

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
@@ -1,13 +1,17 @@
 package com.kakao.actionbase.engine.context
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
+
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 data class RequestContext(
     val requestId: String,
     val actor: String,
-    @field:JsonIgnore
+    @JsonIgnore
     val includeContext: Boolean = false,
 ) {
+    fun newCollector(): StorageOpCollector? = if (includeContext) StorageOpCollector() else null
+
     companion object {
         val DEFAULT = RequestContext("-", "-")
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/context/RequestContext.kt
@@ -1,8 +1,12 @@
 package com.kakao.actionbase.engine.context
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 data class RequestContext(
     val requestId: String,
     val actor: String,
+    @field:JsonIgnore
+    val includeContext: Boolean = false,
 ) {
     companion object {
         val DEFAULT = RequestContext("-", "-")

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -87,7 +87,7 @@ class MutationService(
                     val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
                     tb.write(key, state, after, collector)
                 }.map { summary ->
-                    val context = collector?.snapshot()?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) }
+                    val context = collector?.toContextMap()
                     MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc, context)
                 }
         }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -12,6 +12,7 @@ import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.context.RequestContext
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.metadata.MutationModeContext
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.engine.util.component1
 import com.kakao.actionbase.engine.util.component2
 import com.kakao.actionbase.engine.util.runEvenIfCancelled
@@ -58,7 +59,7 @@ class MutationService(
                         } else {
                             groupMono.flatMap { group ->
                                 val sorted = group.sortedBy { it.event.version }
-                                readModifyWrite(tb, key, sorted, acquireLock)
+                                readModifyWrite(tb, key, sorted, acquireLock, requestContext.newCollector())
                                     .doOnNext { result ->
                                         engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
                                     }.onErrorResume {
@@ -68,7 +69,6 @@ class MutationService(
                             }
                         }
                     }.collectList()
-                    .map { list -> if (requestContext.includeContext) list.map { it.copy(context = emptyMap()) } else list }
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }
@@ -78,15 +78,17 @@ class MutationService(
         key: MutationKey,
         sorted: List<MutationEvent>,
         acquireLock: Boolean,
+        collector: StorageOpCollector?,
     ): Mono<MutationResult> {
         val rwm = {
             tb
                 .read(key)
                 .flatMap { state ->
                     val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
-                    tb.write(key, state, after)
+                    tb.write(key, state, after, collector)
                 }.map { summary ->
-                    MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc)
+                    val context = collector?.snapshot()?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) }
+                    MutationResult(key, sorted.size, summary.status, summary.before, summary.after, summary.acc, context)
                 }
         }
         return if (acquireLock) tb.withLock(key, rwm) else rwm()

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -68,6 +68,7 @@ class MutationService(
                             }
                         }
                     }.collectList()
+                    .map { list -> if (requestContext.includeContext) list.map { it.copy(context = emptyMap()) } else list }
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -2,6 +2,19 @@ package com.kakao.actionbase.engine.storage
 
 import com.kakao.actionbase.core.storage.StorageOp
 
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.hadoop.hbase.Cell
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Mutation
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.util.Bytes
+import org.slf4j.LoggerFactory
+
 /**
  * Single-owner appender used under a Reactor chain (per-RMW in V3, per-edge in V2).
  * Not safe to share across parallel publishers — signals must arrive serially.
@@ -12,7 +25,6 @@ class StorageOpCollector(
     private val ops = mutableListOf<StorageOp>()
     private var truncated = false
 
-    @Suppress("UNUSED_PARAMETER")
     fun collect(
         request: Any,
         table: String,
@@ -21,7 +33,7 @@ class StorageOpCollector(
             truncated = true
             return
         }
-        // No-op until backend interpretation is added.
+        ops.add(toStorageOp(request, table))
     }
 
     fun collectAll(
@@ -35,8 +47,77 @@ class StorageOpCollector(
 
     fun isTruncated(): Boolean = truncated
 
+    fun toContextMap(): Map<String, Any> =
+        buildMap {
+            put(CONTEXT_KEY, snapshot())
+            if (truncated) put(TRUNCATED_KEY, true)
+        }
+
+    private fun toStorageOp(
+        request: Any,
+        table: String,
+    ): StorageOp =
+        when (request) {
+            is Put -> StorageOp.Put(table, request.row.toBase64(), extractCells(request))
+            is Delete -> StorageOp.Delete(table, request.row.toBase64(), extractCells(request))
+            is Increment -> StorageOp.Increment(table, request.row.toBase64(), extractDeltas(request))
+            else -> {
+                val type = request::class.qualifiedName ?: request::class.java.name
+                if (warnedTypes.add(type)) {
+                    log.warn("StorageOpCollector received unsupported request type: {}", type)
+                }
+                StorageOp.Unknown(table, type = type)
+            }
+        }
+
+    private fun extractCells(mutation: Mutation): List<StorageOp.Cell> =
+        mutation.familyCellMap.values
+            .asSequence()
+            .flatMap { it }
+            .map { cell ->
+                StorageOp.Cell(
+                    family = cell.familyBase64(),
+                    qualifier = cell.qualifierBase64(),
+                    value = if (cell.type == Cell.Type.Put) cell.valueBase64() else null,
+                    type = cell.type.name,
+                )
+            }.toList()
+
+    private fun extractDeltas(increment: Increment): List<StorageOp.Delta> =
+        increment.familyCellMap.values
+            .asSequence()
+            .flatMap { it }
+            .map { cell ->
+                StorageOp.Delta(
+                    family = cell.familyBase64(),
+                    qualifier = cell.qualifierBase64(),
+                    delta = Bytes.toLong(cell.valueArray, cell.valueOffset, cell.valueLength),
+                )
+            }.toList()
+
+    private fun Cell.familyBase64(): String = encodeBase64(familyArray, familyOffset, familyLength.toInt())
+
+    private fun Cell.qualifierBase64(): String = encodeBase64(qualifierArray, qualifierOffset, qualifierLength)
+
+    private fun Cell.valueBase64(): String = encodeBase64(valueArray, valueOffset, valueLength)
+
+    private fun ByteArray.toBase64(): String = BASE64.encodeToString(this)
+
+    private fun encodeBase64(
+        src: ByteArray,
+        offset: Int,
+        length: Int,
+    ): String {
+        val encoded = BASE64.encode(ByteBuffer.wrap(src, offset, length))
+        return String(encoded.array(), encoded.arrayOffset(), encoded.remaining(), StandardCharsets.ISO_8859_1)
+    }
+
     companion object {
         const val DEFAULT_MAX_OPS: Int = 1024
-        const val CONTEXT_KEY: String = "storage_ops"
+        const val CONTEXT_KEY: String = "storageOps"
+        const val TRUNCATED_KEY: String = "storageOpsTruncated"
+        private val BASE64 = Base64.getEncoder()
+        private val log = LoggerFactory.getLogger(StorageOpCollector::class.java)
+        private val warnedTypes = ConcurrentHashMap.newKeySet<String>()
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollector.kt
@@ -1,0 +1,42 @@
+package com.kakao.actionbase.engine.storage
+
+import com.kakao.actionbase.core.storage.StorageOp
+
+/**
+ * Single-owner appender used under a Reactor chain (per-RMW in V3, per-edge in V2).
+ * Not safe to share across parallel publishers — signals must arrive serially.
+ */
+class StorageOpCollector(
+    private val maxOps: Int = DEFAULT_MAX_OPS,
+) {
+    private val ops = mutableListOf<StorageOp>()
+    private var truncated = false
+
+    @Suppress("UNUSED_PARAMETER")
+    fun collect(
+        request: Any,
+        table: String,
+    ) {
+        if (ops.size >= maxOps) {
+            truncated = true
+            return
+        }
+        // No-op until backend interpretation is added.
+    }
+
+    fun collectAll(
+        requests: Collection<Any>,
+        table: String,
+    ) {
+        requests.forEach { collect(it, table) }
+    }
+
+    fun snapshot(): List<StorageOp> = ops.toList()
+
+    fun isTruncated(): Boolean = truncated
+
+    companion object {
+        const val DEFAULT_MAX_OPS: Int = 1024
+        const val CONTEXT_KEY: String = "storage_ops"
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -344,7 +344,13 @@ class Graph(
                                             status = context.status,
                                             traceId = context.edge.traceId,
                                             edge = context.after ?: context.before,
-                                            context = context.storageOps?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) },
+                                            context =
+                                                context.storageOps?.let {
+                                                    buildMap {
+                                                        put(StorageOpCollector.CONTEXT_KEY, it)
+                                                        if (context.storageOpsTruncated) put(StorageOpCollector.TRUNCATED_KEY, true)
+                                                    }
+                                                },
                                         )
                                     }
                             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.core.edge.mapper.EdgeIndexRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeLockRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
 import com.kakao.actionbase.v2.core.code.EmptyEdgeIdEncoder
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
@@ -288,7 +289,7 @@ class Graph(
         mode: MutationMode? = null,
         force: Boolean = false,
         failOnExist: Boolean = false,
-        includeContext: Boolean = false,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> {
         val mutationModeContext = MutationModeContext.of(label.entity.mode, mode, systemMutationMode, force)
 
@@ -311,7 +312,7 @@ class Graph(
                                 )
                             } else {
                                 label
-                                    .mutate(edge, operation, alias, bulk, failOnExist)
+                                    .mutate(edge, operation, alias, bulk, failOnExist, newCollector)
                                     .map { context ->
                                         // fill audit and requestId
                                         context.copy(audit = audit, requestId = requestId)
@@ -343,6 +344,7 @@ class Graph(
                                             status = context.status,
                                             traceId = context.edge.traceId,
                                             edge = context.after ?: context.before,
+                                            context = context.storageOps?.let { mapOf(StorageOpCollector.CONTEXT_KEY to it) },
                                         )
                                     }
                             }
@@ -373,11 +375,8 @@ class Graph(
                         )
                     }
             }.collectList()
-            .map { items ->
-                MutationResult(
-                    if (includeContext) items.map { it.copy(context = emptyMap()) } else items,
-                )
-            }.timeout(Duration.ofMillis(mutationRequestTimeout))
+            .map { MutationResult(it) }
+            .timeout(Duration.ofMillis(mutationRequestTimeout))
             // Ensures all work completes even if the request is cancelled - https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cache--
             .cache(Duration.ZERO)
             .subscribeOn(Schedulers.boundedElastic())
@@ -387,7 +386,7 @@ class Graph(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -398,14 +397,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            newCollector = newCollector,
         )
 
     fun update(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -416,14 +415,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            newCollector = newCollector,
         )
 
     fun delete(
         request: DeleteEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
-        includeContext: Boolean = false,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -434,7 +433,7 @@ class Graph(
             request.requestId,
             bulk,
             mode,
-            includeContext = includeContext,
+            newCollector = newCollector,
         )
 
     fun purge(request: DeleteEdgeRequest): Mono<MutationResult> =
@@ -452,18 +451,18 @@ class Graph(
 
     fun upsert(
         request: InsertIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     fun update(
         request: InsertIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     fun delete(
         request: DeleteIdEdgeRequest,
-        includeContext: Boolean = false,
-    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), includeContext = includeContext)
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), newCollector = newCollector)
 
     // -- query
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -288,6 +288,7 @@ class Graph(
         mode: MutationMode? = null,
         force: Boolean = false,
         failOnExist: Boolean = false,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> {
         val mutationModeContext = MutationModeContext.of(label.entity.mode, mode, systemMutationMode, force)
 
@@ -372,8 +373,11 @@ class Graph(
                         )
                     }
             }.collectList()
-            .map { MutationResult(it) }
-            .timeout(Duration.ofMillis(mutationRequestTimeout))
+            .map { items ->
+                MutationResult(
+                    if (includeContext) items.map { it.copy(context = emptyMap()) } else items,
+                )
+            }.timeout(Duration.ofMillis(mutationRequestTimeout))
             // Ensures all work completes even if the request is cancelled - https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cache--
             .cache(Duration.ZERO)
             .subscribeOn(Schedulers.boundedElastic())
@@ -383,6 +387,7 @@ class Graph(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -393,12 +398,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun update(
         request: InsertEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -409,12 +416,14 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun delete(
         request: DeleteEdgeRequest,
         bulk: Boolean = false,
         mode: MutationMode? = null,
+        includeContext: Boolean = false,
     ): Mono<MutationResult> =
         mutate(
             request.name,
@@ -425,6 +434,7 @@ class Graph(
             request.requestId,
             bulk,
             mode,
+            includeContext = includeContext,
         )
 
     fun purge(request: DeleteEdgeRequest): Mono<MutationResult> =
@@ -440,11 +450,20 @@ class Graph(
             false,
         )
 
-    fun upsert(request: InsertIdEdgeRequest): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder))
+    fun upsert(
+        request: InsertIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = upsert(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
-    fun update(request: InsertIdEdgeRequest): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder))
+    fun update(
+        request: InsertIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = update(request.toInsertEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
-    fun delete(request: DeleteIdEdgeRequest): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder))
+    fun delete(
+        request: DeleteIdEdgeRequest,
+        includeContext: Boolean = false,
+    ): Mono<MutationResult> = delete(request.toDeleteEdgeRequest(idEdgeEncoder), includeContext = includeContext)
 
     // -- query
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.cdc
 
+import com.kakao.actionbase.core.storage.StorageOp
 import com.kakao.actionbase.v2.core.edge.TraceEdge
 import com.kakao.actionbase.v2.core.metadata.EdgeOperation
 import com.kakao.actionbase.v2.engine.audit.Audit
@@ -28,6 +29,8 @@ data class CdcContext(
     val message: String? = null,
     val audit: Audit = Audit.default,
     val requestId: String = "",
+    @JsonIgnore
+    val storageOps: List<StorageOp>? = null,
 ) : Log {
     @Suppress("PropertyName")
     companion object {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContext.kt
@@ -31,6 +31,8 @@ data class CdcContext(
     val requestId: String = "",
     @JsonIgnore
     val storageOps: List<StorageOp>? = null,
+    @JsonIgnore
+    val storageOpsTruncated: Boolean = false,
 ) : Log {
     @Suppress("PropertyName")
     companion object {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItem.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItem.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.v2.engine.edge
 
 import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class MutationResult(
     val result: List<MutationResultItem>,
 )
@@ -10,4 +12,6 @@ data class MutationResultItem(
     val status: EdgeOperationStatus,
     val traceId: String,
     val edge: HashEdge?,
+    @field:JsonInclude(JsonInclude.Include.NON_NULL)
+    val context: Map<String, Any?>? = null,
 )

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.EncodedKey
 import com.kakao.actionbase.v2.core.code.HashEdgeValue
@@ -91,6 +92,7 @@ abstract class AbstractLabel<T>(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> {
         if (entity.readOnly) {
             return Mono.error(UnsupportedOperationException("This Label (${entity.fullName}) is read-only"))
@@ -98,7 +100,7 @@ abstract class AbstractLabel<T>(
         return Flux
             .fromIterable(edges)
             .map { it.ensureType(entity.schema) }
-            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist) }
+            .flatMapSequential { processEdgeMutation(it, op, alias, bulk, failOnExist, newCollector()) }
             .collectList()
     }
 
@@ -109,6 +111,7 @@ abstract class AbstractLabel<T>(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean = false,
+        collector: StorageOpCollector? = null,
     ): Mono<CdcContext> {
         log.debug("mutate {} {}", op, edge)
         val encodedHashEdgeKey = coder.encodeHashEdgeKey(edge, entity.id)
@@ -154,12 +157,13 @@ abstract class AbstractLabel<T>(
             }.flatMap { context ->
                 if (context.deferredRequests.isNotEmpty()) {
                     log.debug("6. handle {} deferred  requests", context.deferredRequests.size)
-                    handleDeferredRequests(context.deferredRequests)
+                    handleDeferredRequests(context.deferredRequests, collector)
                         .thenReturn(context.copy(deferredRequests = emptyList()))
                 } else {
                     Mono.just(context)
                 }
-            }.subscribeOn(Schedulers.boundedElastic())
+            }.map { context -> context.copy(storageOps = collector?.snapshot()) }
+            .subscribeOn(Schedulers.boundedElastic())
             .doFinally {
                 releaseLock(edge.traceId, encodedLockEdge, bulk)
                     .subscribeOn(Schedulers.boundedElastic())
@@ -671,7 +675,10 @@ abstract class AbstractLabel<T>(
 
     abstract fun deleteOnLock(keyField: KeyValue<T>): Mono<Boolean>
 
-    open fun handleDeferredRequests(deferredRequests: List<Any>): Mono<Boolean> = Mono.just(true)
+    open fun handleDeferredRequests(
+        deferredRequests: List<Any>,
+        storageOpCollector: StorageOpCollector? = null,
+    ): Mono<Boolean> = Mono.just(true)
 
     abstract fun setnx(
         keyField: EncodedKey<T>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabel.kt
@@ -162,8 +162,12 @@ abstract class AbstractLabel<T>(
                 } else {
                     Mono.just(context)
                 }
-            }.map { context -> context.copy(storageOps = collector?.snapshot()) }
-            .subscribeOn(Schedulers.boundedElastic())
+            }.map { context ->
+                context.copy(
+                    storageOps = collector?.snapshot(),
+                    storageOpsTruncated = collector?.isTruncated() ?: false,
+                )
+            }.subscribeOn(Schedulers.boundedElastic())
             .doFinally {
                 releaseLock(edge.traceId, encodedLockEdge, bulk)
                     .subscribeOn(Schedulers.boundedElastic())

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
 import com.kakao.actionbase.v2.core.edge.TraceEdge
@@ -29,6 +30,7 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
+        newCollector: () -> StorageOpCollector? = { null },
     ): Mono<List<CdcContext>>
 
     fun mutate(
@@ -37,7 +39,10 @@ interface Label : AutoCloseable {
         alias: EntityName? = null,
         bulk: Boolean = false,
         failOnExist: Boolean = false,
-    ): Mono<CdcContext> = mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist).map { it.first() }
+        newCollector: () -> StorageOpCollector? = { null },
+    ): Mono<CdcContext> =
+        mutate(listOf(edge), op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
+            .map { it.first() }
 
     fun scan(
         scanFilter: ScanFilter,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
@@ -2,6 +2,7 @@ package com.kakao.actionbase.v2.engine.label.hbase
 
 import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.core.storage.HBaseRecord
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.engine.util.HBaseRecordCache
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.EncodedKey
@@ -90,7 +91,14 @@ open class HBaseHashLabel(
         return Mono.just(listOf(delete))
     }
 
-    override fun handleDeferredRequests(deferredRequests: List<Any>): Mono<Boolean> = tables.flatMap { it.edge.batch(deferredRequests) }.thenReturn(true)
+    override fun handleDeferredRequests(
+        deferredRequests: List<Any>,
+        storageOpCollector: StorageOpCollector?,
+    ): Mono<Boolean> =
+        tables
+            .doOnNext { t -> storageOpCollector?.collectAll(deferredRequests, t.edge.name.nameAsString) }
+            .flatMap { t -> t.edge.batch(deferredRequests) }
+            .thenReturn(true)
 
     override fun setnx(
         keyField: EncodedKey<ByteArray>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label.metastore
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
@@ -64,11 +65,12 @@ class LocalBackedJdbcHashLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> =
         if (useLocalStore) {
-            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist)
+            localLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
         } else {
-            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist)
+            globalLabel.mutate(edges, op, alias = alias, bulk = bulk, failOnExist = failOnExist, newCollector = newCollector)
         }
 
     override fun scan(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/nil/NilLabel.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label.nil
 
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
 import com.kakao.actionbase.v2.core.code.KeyValue
 import com.kakao.actionbase.v2.core.edge.TraceEdge
@@ -45,6 +46,7 @@ class NilLabel(
         alias: EntityName?,
         bulk: Boolean,
         failOnExist: Boolean,
+        newCollector: () -> StorageOpCollector?,
     ): Mono<List<CdcContext>> =
         Mono.fromCallable {
             edges.map {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -6,6 +6,7 @@ import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 
 import reactor.core.publisher.Mono
 
@@ -27,6 +28,7 @@ class NilTableBinding(
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector?,
     ): Mono<MutationRecordsSummary> = Mono.just(MutationRecordsSummary(IDLE, 0, State.initial, State.initial))
 
     override fun handleMutationError(error: Throwable) {}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -12,6 +12,7 @@ import com.kakao.actionbase.core.state.State
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.hbase.Constants
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.engine.label.LockAcquisitionFailedException
@@ -70,6 +71,7 @@ class V2BackedTableBinding(
         key: MutationKey,
         before: State,
         after: State,
+        storageOpCollector: StorageOpCollector?,
     ): Mono<MutationRecordsSummary> {
         val (source, target) = key.toSourceTarget()
         val beforeClean = before.specialStateValueToNull()
@@ -78,7 +80,7 @@ class V2BackedTableBinding(
         val afterRecord = EdgeStateRecord.of(source, target, afterClean, label.entity.id)
         val records = buildMutationRecords(beforeRecord, afterRecord)
         return label
-            .handleDeferredRequests(buildHBaseMutations(records))
+            .handleDeferredRequests(buildHBaseMutations(records), storageOpCollector)
             .thenReturn(MutationRecordsSummary(records.status, records.acc, beforeClean, afterClean))
     }
 

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollectorTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/StorageOpCollectorTest.kt
@@ -1,0 +1,177 @@
+package com.kakao.actionbase.engine.storage
+
+import com.kakao.actionbase.core.storage.StorageOp
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.apache.hadoop.hbase.client.Append
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Put
+import org.junit.jupiter.api.Test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+class StorageOpCollectorTest {
+    private val table = "test_table"
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: Put with single cell
+          kind: PUT
+          row: row-1
+          family: cf
+          qualifier: q
+          value: value
+          expectedJson: '{"table":"test_table","row":"cm93LTE=","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":"dmFsdWU=","type":"Put"}],"kind":"Put"}'
+
+        - name: Delete full row yields no cells
+          kind: DELETE
+          row: row-2
+          expectedJson: '{"table":"test_table","row":"cm93LTI=","cells":[],"kind":"Delete"}'
+
+        - name: Delete with addColumns emits DeleteColumn cell with null value
+          kind: DELETE_COLUMNS
+          row: row-3
+          family: cf
+          qualifier: q
+          expectedJson: '{"table":"test_table","row":"cm93LTM=","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":null,"type":"DeleteColumn"}],"kind":"Delete"}'
+
+        - name: Delete with addFamily emits DeleteFamily cell with null value
+          kind: DELETE_FAMILY
+          row: row-3f
+          family: cf
+          expectedJson: '{"table":"test_table","row":"cm93LTNm","cells":[{"family":"Y2Y=","qualifier":"","value":null,"type":"DeleteFamily"}],"kind":"Delete"}'
+
+        - name: Increment with long delta
+          kind: INCREMENT
+          row: row-4
+          family: cf
+          qualifier: q
+          delta: 7
+          expectedJson: '{"table":"test_table","row":"cm93LTQ=","deltas":[{"family":"Y2Y=","qualifier":"cQ==","delta":7}],"kind":"Increment"}'
+
+        - name: Put with multi-byte value base64 encodes correctly
+          kind: PUT
+          row: row
+          family: cf
+          qualifier: q
+          valueHex: 00000000deadbeef
+          expectedJson: '{"table":"test_table","row":"cm93","cells":[{"family":"Y2Y=","qualifier":"cQ==","value":"AAAAAN6tvu8=","type":"Put"}],"kind":"Put"}'
+        """,
+    )
+    fun `Mutation is captured as StorageOp`(
+        kind: String,
+        row: String,
+        family: String?,
+        qualifier: String?,
+        value: String?,
+        valueHex: String?,
+        delta: Long?,
+        expectedJson: String,
+    ) {
+        val mutation: Any =
+            when (kind) {
+                "PUT" ->
+                    Put(row.toByteArray()).addColumn(
+                        family!!.toByteArray(),
+                        qualifier!!.toByteArray(),
+                        value?.toByteArray() ?: hexToBytes(valueHex!!),
+                    )
+                "DELETE" -> Delete(row.toByteArray())
+                "DELETE_COLUMNS" -> Delete(row.toByteArray()).addColumns(family!!.toByteArray(), qualifier!!.toByteArray())
+                "DELETE_FAMILY" -> Delete(row.toByteArray()).addFamily(family!!.toByteArray())
+                "INCREMENT" -> Increment(row.toByteArray()).addColumn(family!!.toByteArray(), qualifier!!.toByteArray(), delta!!)
+                else -> error("unknown kind: $kind")
+            }
+
+        val collector = StorageOpCollector()
+        collector.collect(mutation, table)
+        val op = collector.snapshot().single()
+
+        assertEquals(expectedJson, mapper.writeValueAsString(op))
+    }
+
+    @Test
+    fun `Put across multiple column families emits one cell per family`() {
+        val put =
+            Put("row".toByteArray())
+                .addColumn("cf1".toByteArray(), "q".toByteArray(), "v1".toByteArray())
+                .addColumn("cf2".toByteArray(), "q".toByteArray(), "v2".toByteArray())
+
+        val collector = StorageOpCollector()
+        collector.collect(put, table)
+        val op = collector.snapshot().single() as StorageOp.Put
+
+        assertEquals(2, op.cells.size)
+        assertEquals(setOf("Y2Yx", "Y2Yy"), op.cells.map { it.family }.toSet())
+        op.cells.forEach { assertEquals("Put", it.type) }
+    }
+
+    @Test
+    fun `collectAll surfaces non-Mutation entries as Unknown and preserves order`() {
+        val collector = StorageOpCollector()
+        val put = Put("a".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray())
+        val delete = Delete("b".toByteArray())
+
+        collector.collectAll(listOf(put, "not-a-mutation", delete), table)
+        val ops = collector.snapshot()
+
+        assertEquals(3, ops.size)
+        assertTrue(ops[0] is StorageOp.Put)
+        assertTrue(ops[1] is StorageOp.Unknown)
+        assertEquals("kotlin.String", (ops[1] as StorageOp.Unknown).type)
+        assertTrue(ops[2] is StorageOp.Delete)
+    }
+
+    @Test
+    fun `Append is captured as Unknown rather than routed through Mutation path`() {
+        val collector = StorageOpCollector()
+        val append = Append("row".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray())
+
+        collector.collect(append, table)
+        val op = collector.snapshot().single()
+
+        assertTrue(op is StorageOp.Unknown)
+        assertEquals("org.apache.hadoop.hbase.client.Append", (op as StorageOp.Unknown).type)
+    }
+
+    @Test
+    fun `collect stops appending once the cap is reached and marks truncated`() {
+        val collector = StorageOpCollector(maxOps = 2)
+        repeat(5) { i ->
+            collector.collect(
+                Put("row-$i".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray()),
+                table,
+            )
+        }
+
+        assertEquals(2, collector.snapshot().size)
+        assertTrue(collector.isTruncated())
+    }
+
+    @Test
+    fun `toContextMap omits truncated flag when not truncated and includes it when truncated`() {
+        val ok = StorageOpCollector(maxOps = 2)
+        ok.collect(Put("r".toByteArray()).addColumn("cf".toByteArray(), "q".toByteArray(), "v".toByteArray()), table)
+        val okCtx = ok.toContextMap()
+        assertTrue(okCtx.containsKey(StorageOpCollector.CONTEXT_KEY))
+        assertFalse(okCtx.containsKey(StorageOpCollector.TRUNCATED_KEY))
+
+        val over = StorageOpCollector(maxOps = 1)
+        repeat(3) { over.collect(Put("r".toByteArray()), table) }
+        val overCtx = over.toContextMap()
+        assertEquals(true, overCtx[StorageOpCollector.TRUNCATED_KEY])
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { i ->
+            ((Character.digit(hex[i * 2], 16) shl 4) + Character.digit(hex[i * 2 + 1], 16)).toByte()
+        }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContextSerializationTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcContextSerializationTest.kt
@@ -1,0 +1,69 @@
+package com.kakao.actionbase.v2.engine.cdc
+
+import com.kakao.actionbase.core.storage.StorageOp
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CdcContextSerializationTest {
+    @BeforeAll
+    fun setup() {
+        CdcContext.initialize(phase = "test", tenant = "test")
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: storageOps null is excluded
+          state: none
+
+        - name: storageOps empty is excluded
+          state: empty
+
+        - name: storageOps populated is excluded
+          state: populated
+        """,
+    )
+    fun `storageOps is always excluded from CDC JSON`(state: String) {
+        val storageOps: List<StorageOp>? =
+            when (state) {
+                "none" -> null
+                "empty" -> emptyList()
+                "populated" -> listOf(StorageOp.Put(table = "t", row = "deadbeef", cells = emptyList()))
+                else -> error("unknown state: $state")
+            }
+
+        val context =
+            CdcContext(
+                label = EntityName("db", "tbl"),
+                edge = Edge(1, "src", "tgt", emptyMap<String, Any>()).toTraceEdge(),
+                op = EdgeOperation.INSERT,
+                status = EdgeOperationStatus.CREATED,
+                before = null,
+                after = null,
+                acc = 0,
+                alias = null,
+                deferredRequests = emptyList(),
+                storageOps = storageOps,
+                storageOpsTruncated = true,
+            )
+
+        val (_, json) = context.toJsonString()
+
+        assertFalse(json.contains("storageOps"), "CDC JSON must not include storageOps: $json")
+        assertFalse(json.contains("storageOpsTruncated"), "CDC JSON must not include storageOpsTruncated: $json")
+        assertFalse(json.contains("deadbeef"), "CDC JSON must not leak raw row bytes")
+        assertTrue(json.contains("\"status\":\"CREATED\""))
+        assertTrue(json.contains("\"op\":\"INSERT\""))
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItemContextTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/edge/MutationResultItemContextTest.kt
@@ -1,0 +1,60 @@
+package com.kakao.actionbase.v2.engine.edge
+
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertEquals
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class MutationResultItemContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: null context is omitted from JSON
+          item:
+            status: CREATED
+            traceId: trace-1
+            edge: null
+            context: null
+          expectedJson: '{"status":"CREATED","traceId":"trace-1","edge":null}'
+
+        - name: non-null context is serialized
+          item:
+            status: CREATED
+            traceId: trace-1
+            edge: null
+            context: { debug: "trace-1", size: 10 }
+          expectedJson: '{"status":"CREATED","traceId":"trace-1","edge":null,"context":{"debug":"trace-1","size":10}}'
+        """,
+    )
+    fun `Item serializes`(
+        item: MutationResultItem,
+        expectedJson: String,
+    ) {
+        assertEquals(expectedJson, mapper.writeValueAsString(item))
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: missing context field deserializes to null
+          json: '{"status":"CREATED","traceId":"trace-1","edge":null}'
+          expectedContext: null
+
+        - name: non-null context round-trips through deser
+          json: '{"status":"UPDATED","traceId":"trace-2","edge":null,"context":{"k":"v","n":1}}'
+          expectedContext: { k: v, n: 1 }
+        """,
+    )
+    fun `Item deserializes`(
+        json: String,
+        expectedContext: Map<String, Any?>?,
+    ) {
+        val item = mapper.readValue<MutationResultItem>(json)
+        assertEquals(expectedContext, item.context)
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
@@ -30,7 +30,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge")
     fun update(
@@ -38,7 +38,7 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge")
     fun delete(
@@ -46,23 +46,23 @@ class EdgeController(
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: DeleteEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext::newCollector).mapToResponseEntity()
 
     @PostMapping("/graph/v2/edge/id")
     fun insertId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext::newCollector).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge/id")
     fun updateId(
         @RequestBody request: InsertIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext::newCollector).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge/id")
     fun deleteId(
         @RequestBody request: DeleteIdEdgeRequest,
         requestContext: RequestContext,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.includeContext).mapToResponseEntity()
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext::newCollector).mapToResponseEntity()
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/EdgeController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.edge
 
+import com.kakao.actionbase.engine.context.RequestContext
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.core.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.Graph
@@ -28,34 +29,40 @@ class EdgeController(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge")
     fun update(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: InsertEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge")
     fun delete(
         @RequestParam(required = false) bulk: Boolean = false,
         @RequestParam(required = false) mode: MutationMode?,
         @RequestBody request: DeleteEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, bulk, mode, requestContext.includeContext).mapToResponseEntity()
 
     @PostMapping("/graph/v2/edge/id")
     fun insertId(
         @RequestBody request: InsertIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.upsert(request, requestContext.includeContext).mapToResponseEntity()
 
     @PutMapping("/graph/v2/edge/id")
     fun updateId(
         @RequestBody request: InsertIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.update(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.update(request, requestContext.includeContext).mapToResponseEntity()
 
     @DeleteMapping("/graph/v2/edge/id")
     fun deleteId(
         @RequestBody request: DeleteIdEdgeRequest,
-    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request).mapToResponseEntity()
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<MutationResult>> = graph.delete(request, requestContext.includeContext).mapToResponseEntity()
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/HttpHeaderConstants.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/HttpHeaderConstants.kt
@@ -6,4 +6,5 @@ object HttpHeaderConstants {
     const val ACTOR_ROLE = "Actor-ROLE"
     const val AB_ACTOR_ID = "X-AB-Actor-ID" // legacy support
     const val RESPONSE_META = "Response-Meta"
+    const val INCLUDE_MUTATION_CONTEXT = "AB-Include-Mutation-Context"
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/resolver/ServerRequestContextArgumentResolver.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/resolver/ServerRequestContextArgumentResolver.kt
@@ -29,6 +29,12 @@ class ServerRequestContextArgumentResolver : HandlerMethodArgumentResolver {
                 ?: headers.getFirst(HttpHeaderConstants.AB_ACTOR_ID)
                 ?: RequestContext.DEFAULT.actor
 
-        return Mono.just(RequestContext(requestId, actor))
+        val includeContext =
+            headers
+                .getFirst(HttpHeaderConstants.INCLUDE_MUTATION_CONTEXT)
+                ?.trim()
+                ?.equals("true", ignoreCase = true) == true
+
+        return Mono.just(RequestContext(requestId, actor, includeContext))
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
@@ -1,0 +1,113 @@
+package com.kakao.actionbase.server.api.graph.v2.edge
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class V2EdgeStorageOpsSpec : E2ETestBase() {
+    private val service = "v2-storage-ops-svc"
+    private val label = "v2-storage-ops-label"
+    private val name = "$service.$label"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$service", "comment": "v2 storage ops test service"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$service/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$label",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/v2_storage_ops_label",
+                  "mode": "SYNC",
+                  "comment": "v2 storage ops label"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: v2 edge without header omits storage_ops
+          header: null
+          edge: |
+            {"ts": 1, "src": "a", "tgt": "b", "props": {"score": 1}}
+          storageOpsExists: false
+
+        - name: v2 edge with header exposes storage_ops
+          header: "true"
+          edge: |
+            {"ts": 1, "src": "x", "tgt": "y", "props": {"score": 2}}
+          storageOpsExists: true
+        """,
+    )
+    fun `storage_ops visibility gated by header`(
+        header: String?,
+        edge: String,
+        storageOpsExists: Boolean,
+    ) {
+        val request =
+            client
+                .post()
+                .uri("/graph/v2/edge")
+                .contentType(MediaType.APPLICATION_JSON)
+        if (header != null) request.header("AB-Include-Mutation-Context", header)
+
+        val result =
+            request
+                .bodyValue("""{"label": "$name", "edges": [$edge]}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.result[0].status")
+                .isEqualTo("CREATED")
+
+        if (storageOpsExists) {
+            result
+                .jsonPath("$.result[0].context.storageOps[0].kind")
+                .isEqualTo("Put")
+                .jsonPath("$.result[0].context.storageOps[0].table")
+                .isEqualTo("edges")
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].family")
+                .isEqualTo("Zg==")
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].qualifier")
+                .isEqualTo("ZQ==")
+                .jsonPath("$.result[0].context.storageOps[0].row")
+                .exists()
+                .jsonPath("$.result[0].context.storageOps[0].cells[0].value")
+                .exists()
+        } else {
+            result.jsonPath("$.result[0].context.storageOps").doesNotExist()
+        }
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
@@ -1,0 +1,156 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EdgeMutationStorageOpsSpec : E2ETestBase() {
+    private val db = "storage-ops-db"
+    private val edgeTable = "storage-ops-edge"
+    private val multiEdgeTable = "storage-ops-multi"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "storage ops test db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$edgeTable",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/storage_ops_edge",
+                  "mode": "SYNC",
+                  "comment": "edge for storage-ops test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$multiEdgeTable",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "long", "comment": "id"},
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [
+                      {"name": "score", "type": "long", "comment": "score"}
+                    ],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/storage_ops_multi",
+                  "mode": "SYNC",
+                  "comment": "multi edge for storage-ops test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        cases = """
+        - name: edge without header omits storage_ops
+          table: storage-ops-edge
+          path: edges
+          header: null
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "a", "target": "b", "properties": {"score": 1}}}]}
+          storageOpsExists: false
+
+        - name: edge with header exposes storage_ops
+          table: storage-ops-edge
+          path: edges
+          header: "true"
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "x", "target": "y", "properties": {"score": 2}}}]}
+          storageOpsExists: true
+
+        - name: multi-edge with header exposes storage_ops
+          table: storage-ops-multi
+          path: multi-edges
+          header: "true"
+          body: |
+            {"mutations": [{"type": "INSERT", "edge": {"version": 1, "id": 42, "source": 1, "target": 2, "properties": {"score": 3}}}]}
+          storageOpsExists: true
+        """,
+    )
+    fun `storage_ops visibility gated by header`(
+        table: String,
+        path: String,
+        header: String?,
+        body: String,
+        storageOpsExists: Boolean,
+    ) {
+        val request =
+            client
+                .post()
+                .uri("/graph/v3/databases/$db/tables/$table/$path")
+                .contentType(MediaType.APPLICATION_JSON)
+        if (header != null) request.header("AB-Include-Mutation-Context", header)
+
+        val result =
+            request
+                .bodyValue(body)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.results[0].status")
+                .isEqualTo("CREATED")
+
+        if (storageOpsExists) {
+            result
+                .jsonPath("$.results[0].context.storageOps[0].kind")
+                .isEqualTo("Put")
+                .jsonPath("$.results[0].context.storageOps[0].table")
+                .isEqualTo("edges")
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].family")
+                .isEqualTo("Zg==")
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].qualifier")
+                .isEqualTo("ZQ==")
+                .jsonPath("$.results[0].context.storageOps[0].row")
+                .exists()
+                .jsonPath("$.results[0].context.storageOps[0].cells[0].value")
+                .exists()
+        } else {
+            result.jsonPath("$.results[0].context.storageOps").doesNotExist()
+        }
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
@@ -1,0 +1,221 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants.INCLUDE_MUTATION_CONTEXT
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MutationContextOptInE2ETest : E2ETestBase() {
+    private val db = "ctx_optin_db"
+    private val edgeTable = "ctx_optin_edge"
+    private val multiEdgeTable = "ctx_optin_multi_edge"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "context opt-in test"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$edgeTable",
+                  "schema": {
+                    "type": "EDGE",
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "OUT",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/ctx_optin_edge",
+                  "mode": "SYNC",
+                  "comment": "edge for context opt-in test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$multiEdgeTable",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "long", "comment": "id"},
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": []
+                  },
+                  "storage": "datastore://test_namespace/ctx_optin_multi_edge",
+                  "mode": "SYNC",
+                  "comment": "multi-edge for context opt-in test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `edge mutation without header omits context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s1", "target": "t1", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s2", "target": "t2", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `multi-edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$multiEdgeTable/multi-edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "id": 77777, "source": 1, "target": 2, "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `edge mutation with header false omits context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "false")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-false", "target": "t-false", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `V3 async edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-async", "target": "t-async", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `header is case-insensitive`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges/sync")
+            .header(INCLUDE_MUTATION_CONTEXT, "TRUE")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s3", "target": "t3", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].context")
+            .isMap
+    }
+
+    @Test
+    fun `V2 edge mutation without header omits context`() {
+        client
+            .post()
+            .uri("/graph/v2/edge")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-a", "tgt": "t-v2-a", "props": {}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.result[0].context")
+            .doesNotExist()
+    }
+
+    @Test
+    fun `V2 edge mutation with header emits empty context`() {
+        client
+            .post()
+            .uri("/graph/v2/edge")
+            .header(INCLUDE_MUTATION_CONTEXT, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-b", "tgt": "t-v2-b", "props": {}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.result[0].context")
+            .isMap
+    }
+}


### PR DESCRIPTION
## Summary

Backports the storage-ops shadow-testing feature to the v0.2.x line for the v0.2.1 release. Cherry-picks four squash-merged main commits in order: #258 -> #259 -> #261 -> #254.

With the `AB-Include-Mutation-Context: true` header, mutation responses surface the HBase `Put` / `Delete` / `Increment` ops actually issued to storage under `context["storageOps"]`, base64-encoded. Without the header the wire format is unchanged.

## Cherry-picked commits

| Upstream | SHA | Contents |
| --- | --- | --- |
| #258 | `3692c41` | `context: Map<String, Any>?` on V2 / V3 mutation response items |
| #259 | `1ef1b6d` | `AB-Include-Mutation-Context` header + e2e non-breaking verification |
| #261 | `5e97d9b` | `StorageOpCollector` scaffold + mutation-path wiring |
| #254 | `9bfa878` | `collect()` implementation for `Put` / `Delete` / `Increment` + tests |

## Conflict resolution

All conflicts landed in #261 and were limited to the import region — 0.2.x does not have main's post-v0.2.0 refactors (`engine.sql.DataFrame`, `engine.query.LabelProvider`, etc.). Resolved by keeping the 0.2.x imports as-is and adding only the `StorageOpCollector` import. No behavioral changes beyond what the four upstream commits define.

Affected files:
- `engine/binding/TableBinding.kt`
- `v2/engine/Graph.kt`
- `v2/engine/v3/NilTableBinding.kt`
- `v2/engine/v3/V2BackedTableBinding.kt`

## Test plan

`./gradlew build` locally passed. Key suites:

- `StorageOpCollectorTest` — round-trip per op type, multi-CF Put, multi-byte value, truncation, `Append` → `Unknown`, non-`Mutation` fallthrough
- `CdcContextSerializationTest` — `storageOps` / `storageOpsTruncated` excluded from CDC JSON
- `V2EdgeStorageOpsSpec` — V2 `/graph/v2/edge` with / without header
- `EdgeMutationStorageOpsSpec` — V3 edge + multi-edge with header
- `MutationResultItemContextTest`, `MutationContextOptInE2ETest` — context field shape and opt-in gating
