### PR TITLE
Run CI on release branches (*.x)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,14 @@ name: 'Continuous Integration'
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - '*.x'
 
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - '*.x'
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary

`continuous-integration.yml` only triggers on pushes and PRs targeting `main`. PRs against release branches (e.g., `0.2.x` for v0.2.1 backports) skip the `Build` job, so patch-release workflows rely on local verification only.

Extend both `push` and `pull_request` branch filters to match `*.x` in addition to `main`. Matches the same pattern used by `post-release.yml`.

## Changes

- `.github/workflows/continuous-integration.yml` — `branches: [main]` -> `[main, *.x]` on both `push` and `pull_request`
- The existing draft-skip `if:` on the `build` job is untouched, so draft PR behavior is unchanged

## Test plan

- Merging this PR itself triggers CI on main (no change in behavior for main)
- Next PR targeting a release branch (e.g., #262 for 0.2.x) should now show the `Build` check

Relates to #262 (v0.2.1 backport) which is currently missing CI because of this gap.
