### PR TITLE
Skip CI for docs-only and website-only changes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - '*.x'
+    paths-ignore:
+      - 'website/**'
+      - 'guides/**'
+      - 'docker/**'
+      - '**/*.md'
+      - 'CNAME'
+      - '.github/workflows/deploy-website.yml'
+      - '.github/workflows/website-ci.yml'
+      - '.github/workflows/translation.yml'
 
   pull_request:
     branches:
@@ -15,6 +24,15 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths-ignore:
+      - 'website/**'
+      - 'guides/**'
+      - 'docker/**'
+      - '**/*.md'
+      - 'CNAME'
+      - '.github/workflows/deploy-website.yml'
+      - '.github/workflows/website-ci.yml'
+      - '.github/workflows/translation.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The Gradle build + spotless check runs on every push and PR, taking 3–5 minutes on GitHub runners. Changes confined to docs, guides, the website, or Docker assets do not affect Kotlin build output, so there's no reason to exercise the Gradle path for them.

Add `paths-ignore` so the CI job does not trigger when the change is limited to:

- `website/**` — already covered by `website-ci.yml`
- `guides/**` — separate npm / vite ecosystems with their own tooling
- `docker/**` — image assets built by release workflows
- `**/*.md` / `CNAME` — documentation and deploy metadata
- `.github/workflows/{deploy-website,website-ci,translation}.yml` — non-Gradle workflow changes

## Behavior

Mixed changes (e.g. `website/` + `core/`) still trigger CI because GitHub's `paths-ignore` only skips when every changed path matches.

## Test plan

- Verify on this PR itself: diff is only `.github/workflows/continuous-integration.yml`, which is not in `paths-ignore`, so the `Build` check should still run
- Next doc-only PR should show `Build` skipped
