### PR TITLE
Restructure Release artifacts around independent per-module versioning

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -115,12 +115,22 @@ As the project matures, we may introduce Long-Term Support (LTS) releases with e
 
 ## Release artifacts
 
-All modules share the same version and are released together.
+Each module releases independently.
 
-| Module     | Artifact     | Distribution                                |
-| ---------- | ------------ | ------------------------------------------- |
-| **core**   | Java library | GitHub Packages (Maven Central after 1.0.0) |
-| **server** | Docker image | `ghcr.io/kakao/actionbase`                  |
-| **cli**    | Binary       | GitHub Releases                             |
+| Module         | Artifact     | Distribution               |
+| -------------- | ------------ | -------------------------- |
+| **codec-java** | Java library | Maven (Central planned)    |
+| **core**       | Java library | Not yet published          |
+| **server**     | Docker image | `ghcr.io/kakao/actionbase` |
+| **cli**        | Binary       | GitHub Releases            |
+
+`codec-java` is slated for deprecation and will be absorbed into the Kotlin `core` module.
+
+### Compatibility
+
+| codec-java                              | Actionbase (server) |
+| --------------------------------------- | ------------------- |
+| `v2-core:1.0.14-SNAPSHOT` (source only) | 0.1.x, 0.2.x        |
+| `codec-java:0.0.1`                      | 0.3.x (upcoming)    |
 
 Release announcements are posted in [GitHub Releases](https://github.com/kakao/actionbase/releases).


### PR DESCRIPTION
## Summary
- Replace the "all modules share the same version" framing with per-module independent release cadences.
- Add `codec-java` to the Release artifacts table alongside `core`, `server`, and `cli`.
- Mark `core` as not yet published (removes the prior "GitHub Packages (Maven Central after 1.0.0)" claim, which is not reflected by the current distribution state).
- Add a compatibility table mapping `codec-java` versions to Actionbase server versions:
  - `v2-core:1.0.14-SNAPSHOT` (source only) → 0.1.x, 0.2.x
  - `codec-java:0.0.1` → 0.3.x (upcoming)
- Note that `codec-java` is slated for deprecation and will be absorbed into the Kotlin `core` module.

## Test plan
- [ ] Preview the rendered Markdown on the PR to confirm the tables and layout read cleanly.
