### PR TITLE
Move codec-java to independent open-source coordinate

### DIFF
--- a/codec-java/build.gradle.kts
+++ b/codec-java/build.gradle.kts
@@ -1,7 +1,7 @@
 import actionbase.dependencies.Dependencies
 
 group = "com.kakao.actionbase"
-version = "1.0.14-SNAPSHOT"
+version = "0.0.1-SNAPSHOT"
 
 plugins {
     id("actionbase.java8-conventions")
@@ -35,7 +35,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
             groupId = "com.kakao.actionbase"
-            artifactId = "v2-core"
+            artifactId = "codec-java"
         }
     }
 


### PR DESCRIPTION
## Summary
Switch the `codec-java` module's published coordinate:

- `version`: `1.0.14-SNAPSHOT` → `0.0.1-SNAPSHOT`
- `artifactId`: `v2-core` → `codec-java`
- `groupId`: unchanged (`com.kakao.actionbase`)

New published coordinate: `com.kakao.actionbase:codec-java:0.0.1-SNAPSHOT`.

This follows the per-module independent versioning policy documented in #269. It cuts cleanly from the internal `v2-core` line (last release `1.0.13` on internal Maven) to the open-source `codec-java` line starting fresh at `0.0.1`, and matches the compatibility table already in `RELEASES.md`.

Internal module dependencies (`server`, `engine`) reference codec-java via `project(":codec-java")`, so they are unaffected by the coordinate change.

## Test plan
- [x] `./gradlew :codec-java:build` passes.
- [ ] Confirm the resulting `mavenJava` publication coordinate is `com.kakao.actionbase:codec-java:0.0.1-SNAPSHOT` (e.g., `./gradlew :codec-java:generatePomFileForMavenJavaPublication`).

## Follow-ups
- Server-side `LabelDTO` / Table Schema PR (adds `caches` field) — separate PR, targets 0.3.0.
- PR #249 merge (codec-java EdgeCache bulk encoding).
- Cut the `codec-java:0.0.1` release alongside Actionbase `0.3.0`.
