### PR TITLE
Lock in LabelEntity caches JSON serialization contract

### DIFF
--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelEntitySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelEntitySpec.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.label
 
+import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.v2.core.metadata.Active
 import com.kakao.actionbase.v2.core.types.DataType
 import com.kakao.actionbase.v2.core.types.Field
@@ -12,7 +13,11 @@ import com.kakao.actionbase.v2.engine.sql.Row
 import com.kakao.actionbase.v2.engine.sql.RowWithSchema
 import com.kakao.actionbase.v2.engine.test.GraphFixtures
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 class LabelEntitySpec :
     StringSpec({
@@ -106,5 +111,20 @@ class LabelEntitySpec :
             val rowWithSchema = RowWithSchema(row, structType)
 
             LabelEntity.toEntity(rowWithSchema)
+        }
+
+        "LabelEntity JSON serializes caches field" {
+            val entity =
+                Metadata.serviceLabelEntity.copy(
+                    caches = listOf(Cache(cache = "c1", fields = emptyList())),
+                )
+
+            val json = jacksonObjectMapper().writeValueAsString(entity)
+            json shouldContain "\"caches\""
+            json shouldContain "\"c1\""
+
+            val roundTripped = jacksonObjectMapper().readValue(json, LabelEntity::class.java)
+            roundTripped.caches.size shouldBe 1
+            roundTripped.caches[0].cache shouldBe "c1"
         }
     })


### PR DESCRIPTION
## Summary
Add a regression test in `LabelEntitySpec` that locks in the JSON serialization contract for `LabelEntity.caches`:

- Asserts that `jacksonObjectMapper().writeValueAsString(LabelEntity(...))` emits a `"caches"` field.
- Round-trips the JSON back to `LabelEntity` and asserts the `caches` list survives.

This guards the wire format that codec-java `0.0.1+` clients depend on. `GET /graph/v2/service/{service}/label/{label}` returns `LabelEntity` directly, and its JSON response must include the `caches` field so clients that deserialize into a DTO with a `caches` property do not fail (e.g., when `FAIL_ON_NULL_CREATOR_PROPERTIES=true` is configured on the consumer side).

No production change — `LabelEntity` already declares `caches: List<Cache> = emptyList()` and Jackson serializes it by default. This PR only prevents accidental future regressions (e.g., an `@JsonIgnore` slip, a field rename, or a custom serializer that omits it).

## Test plan
- [x] `./gradlew :engine:test --tests "*LabelEntitySpec*"` — all 4 cases pass (`materialize LabelEntity`, two backward-compatibility cases, and the new `LabelEntity JSON serializes caches field`).

## Context
This enables the codec-java `0.0.1` release (paired with Actionbase `0.3.x`) to land PR #249's `BulkEdgeEncoder` cache-encoding changes safely — the contract guarded here is precisely the server-side half of the "new client ↔ server" compatibility story.
