### PR TITLE
Renumber codec-java open-source line to 0.1.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -131,6 +131,6 @@ Each module releases independently.
 | codec-java                              | Actionbase (server) |
 | --------------------------------------- | ------------------- |
 | `v2-core:1.0.14-SNAPSHOT` (source only) | 0.1.x, 0.2.x        |
-| `codec-java:0.0.1`                      | 0.3.x (upcoming)    |
+| `codec-java:0.1.0`                      | 0.3.x (upcoming)    |
 
 Release announcements are posted in [GitHub Releases](https://github.com/kakao/actionbase/releases).

--- a/codec-java/build.gradle.kts
+++ b/codec-java/build.gradle.kts
@@ -1,7 +1,7 @@
 import actionbase.dependencies.Dependencies
 
 group = "com.kakao.actionbase"
-version = "0.0.1-SNAPSHOT"
+version = "0.1.0-SNAPSHOT"
 
 plugins {
     id("actionbase.java8-conventions")


### PR DESCRIPTION
## Summary
Renumber the codec-java open-source line from `0.0.1-SNAPSHOT` to `0.1.0-SNAPSHOT` before its first release.

- `codec-java/build.gradle.kts`: `version = "0.0.1-SNAPSHOT"` → `"0.1.0-SNAPSHOT"`
- `RELEASES.md` compatibility table: `codec-java:0.0.1` → `codec-java:0.1.0` for Actionbase `0.3.x`

## Why
- `0.1.0` is a more confident first-release number than `0.0.1` and follows the common "first minor release" convention in open-source projects.
- Aligns with the root's `X.Y.0-SNAPSHOT` cadence pattern.
- Nothing was published at `0.0.1` yet, so there is no consumer impact.

## Test plan
- [x] `./gradlew :codec-java:build` passes.
- [ ] Confirm the resulting `mavenJava` publication coordinate is `com.kakao.actionbase:codec-java:0.1.0-SNAPSHOT`.
