### PR TITLE
Add AI-Assisted Pull Requests policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,8 @@ Closes #
 ## How to Test
 
 
+## AI Assistance
+
+- [ ] This PR was written largely with AI assistance.
+  - Tool / model:
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,24 @@ git remote add origin https://github.com/YOUR_USERNAME/actionbase.git
 5. Commit: `git commit -m "feat(scope): description"`
 6. Push & create PR
 
+## AI-Assisted Pull Requests
+
+AI-assisted pull requests are welcome, provided that you:
+
+- Note in the PR description if the changes were largely written by AI.
+- Name the AI tool and model that produced them (e.g., Claude Code, Cursor,
+  Codex, ChatGPT).
+- Understand the changes — be ready to discuss any line.
+- Write the PR description and reply to reviewers in your own voice. Do not
+  paste AI-generated text into review threads.
+- Read through the diff yourself before opening the PR.
+- Run a code-review pass with your AI tool (e.g., `/review` in Claude Code
+  or Codex CLI) before submitting.
+- Follow the conventions in [`CODING_STYLE.md`](CODING_STYLE.md) and the
+  test rules in [`TESTING.md`](TESTING.md).
+
+_Inspired by [SlateDB's contribution policy](https://github.com/slatedb/slatedb/blob/main/CONTRIBUTING.md) — thanks to the SlateDB team for codifying these norms._
+
 ## Translations
 
 Translations are managed through Translation Memory (TM) files. Here's how to contribute:


### PR DESCRIPTION
## Summary

Codify how AI tools may participate in contributions and capture the
disclosure structurally in the PR template, so AI use is openly tracked
rather than implicit.

The policy is inspired by SlateDB's contribution policy, with attribution.

Closes #

## Changes

- `CONTRIBUTING.md`: new "AI-Assisted Pull Requests" section after the PR
  workflow section.
- `.github/PULL_REQUEST_TEMPLATE.md`: new "AI Assistance" section with a
  disclosure checkbox and a tool/model field.

## How to Test

- Markdown renders correctly on GitHub.
- The PR template appears with the new "AI Assistance" section when
  opening a new PR (this PR uses the new template format itself).

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code Opus 4.7
