### PR TITLE
Work around V2 user properties shadowing V3 system fields in toV3

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -12,6 +12,7 @@ import com.kakao.actionbase.engine.query.ActionbaseQueryExecutor
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
+
 import reactor.core.publisher.Mono
 
 class QueryService(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -12,7 +12,6 @@ import com.kakao.actionbase.engine.query.ActionbaseQueryExecutor
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
-
 import reactor.core.publisher.Mono
 
 class QueryService(
@@ -171,14 +170,13 @@ class QueryService(
                     version = row[EdgeField.VERSION] as Long,
                     source = source,
                     target = target,
-                    // Strip the V2->V3 collision-escape backticks: backticks are an
-                    // internal disambiguation for the DataFrame row map, but
+                    // Backticks are an internal disambiguation for the V3 DataFrame row map.
                     // EdgePayload.properties is its own namespace separate from the
-                    // version/source/target fields, so the natural names are safe to use.
+                    // version/source/target fields, so the natural names are safe to use here.
                     properties =
                         row.data
                             .filterKeys { it !in EDGE_FIELDS }
-                            .mapKeys { (k, _) -> k.removeSurrounding("`") },
+                            .mapKeys { (k, _) -> unescapeV3Keyword(k) },
                     context = emptyMap(),
                 )
             }
@@ -223,5 +221,9 @@ class QueryService(
                 count = 0L,
                 context = emptyMap(),
             )
+
+        internal fun escapeV3Keyword(fieldName: String): String = if (fieldName in EDGE_FIELDS) "`$fieldName`" else EdgeField.toV3(fieldName)
+
+        private fun unescapeV3Keyword(name: String): String = name.removeSurrounding("`")
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -171,7 +171,14 @@ class QueryService(
                     version = row[EdgeField.VERSION] as Long,
                     source = source,
                     target = target,
-                    properties = row.data.filterKeys { it !in EDGE_FIELDS },
+                    // Strip the V2->V3 collision-escape backticks: backticks are an
+                    // internal disambiguation for the DataFrame row map, but
+                    // EdgePayload.properties is its own namespace separate from the
+                    // version/source/target fields, so the natural names are safe to use.
+                    properties =
+                        row.data
+                            .filterKeys { it !in EDGE_FIELDS }
+                            .mapKeys { (k, _) -> k.removeSurrounding("`") },
                     context = emptyMap(),
                 )
             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -544,12 +544,20 @@ class V2BackedTableBinding(
     }
 }
 
+/**
+ * Converts a V2 DataFrame to a V3 DataFrame.
+ *
+ * User property fields whose names match V3 system fields (`version`, `source`, `target`,
+ * `direction`) are wrapped in backticks (e.g. `` `version` ``) so they do not shadow the
+ * edge metadata at those keys. This is a workaround; remove it once V3 DataFrame supports
+ * a nested row form that gives user properties their own namespace.
+ */
 internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
     val v3Schema =
         com.kakao.actionbase.core.metadata.common.StructType(
             schema.fields.map { field ->
                 com.kakao.actionbase.core.metadata.common.StructField(
-                    name = EdgeField.toV3(field.name),
+                    name = escapeIfCollides(field.name),
                     type = field.type.toV3PrimitiveType(),
                     comment = field.desc,
                     nullable = field.isNullable,
@@ -562,7 +570,7 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
                 data =
                     schema.fieldNames
                         .mapIndexed { i, name ->
-                            EdgeField.toV3(name) to row.array[i]
+                            escapeIfCollides(name) to row.array[i]
                         }.toMap(),
                 schema = v3Schema,
             )
@@ -578,6 +586,11 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
         hasNext = hasNext,
     )
 }
+
+private val V3_SYSTEM_FIELD_NAMES =
+    setOf(EdgeField.VERSION, EdgeField.SOURCE, EdgeField.TARGET, EdgeField.DIRECTION)
+
+private fun escapeIfCollides(v2Name: String): String = if (v2Name in V3_SYSTEM_FIELD_NAMES) "`$v2Name`" else EdgeField.toV3(v2Name)
 
 // TODO: dedupe with V3MetadataConverter.toV3PrimitiveType once a shared
 // home for V2<->V3 type conversions exists (engine can't depend on server).

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -3,9 +3,7 @@ package com.kakao.actionbase.v2.engine.v3
 import com.kakao.actionbase.v2.core.code.hbase.Constants as HBaseConstants
 import com.kakao.actionbase.v2.core.types.DataType as V2DataType
 import com.kakao.actionbase.v2.engine.sql.DataFrame as V2DataFrame
-
 import com.kakao.actionbase.core.Constants
-import com.kakao.actionbase.core.edge.EdgeField
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.mapper.EdgeGroupRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
@@ -24,6 +22,7 @@ import com.kakao.actionbase.core.types.PrimitiveType
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.service.QueryService.Companion.escapeV3Keyword
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.engine.sql.Row
 import com.kakao.actionbase.engine.storage.StorageOpCollector
@@ -35,14 +34,12 @@ import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
 import com.kakao.actionbase.v2.engine.sql.WherePredicate
 import com.kakao.actionbase.v2.engine.sql.toJsonFormat
-
 import org.apache.hadoop.hbase.client.Delete
 import org.apache.hadoop.hbase.client.Get
 import org.apache.hadoop.hbase.client.Increment
 import org.apache.hadoop.hbase.client.Mutation
 import org.apache.hadoop.hbase.client.Put
 import org.slf4j.LoggerFactory
-
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
@@ -586,11 +583,6 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
         hasNext = hasNext,
     )
 }
-
-private val V3_SYSTEM_FIELD_NAMES =
-    setOf(EdgeField.VERSION, EdgeField.SOURCE, EdgeField.TARGET, EdgeField.DIRECTION)
-
-private fun escapeV3Keyword(v2Name: String): String = if (v2Name in V3_SYSTEM_FIELD_NAMES) "`$v2Name`" else EdgeField.toV3(v2Name)
 
 // TODO: dedupe with V3MetadataConverter.toV3PrimitiveType once a shared
 // home for V2<->V3 type conversions exists (engine can't depend on server).

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -3,6 +3,7 @@ package com.kakao.actionbase.v2.engine.v3
 import com.kakao.actionbase.v2.core.code.hbase.Constants as HBaseConstants
 import com.kakao.actionbase.v2.core.types.DataType as V2DataType
 import com.kakao.actionbase.v2.engine.sql.DataFrame as V2DataFrame
+
 import com.kakao.actionbase.core.Constants
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.mapper.EdgeGroupRecordMapper
@@ -34,12 +35,14 @@ import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
 import com.kakao.actionbase.v2.engine.sql.WherePredicate
 import com.kakao.actionbase.v2.engine.sql.toJsonFormat
+
 import org.apache.hadoop.hbase.client.Delete
 import org.apache.hadoop.hbase.client.Get
 import org.apache.hadoop.hbase.client.Increment
 import org.apache.hadoop.hbase.client.Mutation
 import org.apache.hadoop.hbase.client.Put
 import org.slf4j.LoggerFactory
+
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -557,7 +557,7 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
         com.kakao.actionbase.core.metadata.common.StructType(
             schema.fields.map { field ->
                 com.kakao.actionbase.core.metadata.common.StructField(
-                    name = escapeIfCollides(field.name),
+                    name = escapeV3Keyword(field.name),
                     type = field.type.toV3PrimitiveType(),
                     comment = field.desc,
                     nullable = field.isNullable,
@@ -570,7 +570,7 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
                 data =
                     schema.fieldNames
                         .mapIndexed { i, name ->
-                            escapeIfCollides(name) to row.array[i]
+                            escapeV3Keyword(name) to row.array[i]
                         }.toMap(),
                 schema = v3Schema,
             )
@@ -590,7 +590,7 @@ internal fun V2DataFrame.toV3(total: Long? = null): DataFrame {
 private val V3_SYSTEM_FIELD_NAMES =
     setOf(EdgeField.VERSION, EdgeField.SOURCE, EdgeField.TARGET, EdgeField.DIRECTION)
 
-private fun escapeIfCollides(v2Name: String): String = if (v2Name in V3_SYSTEM_FIELD_NAMES) "`$v2Name`" else EdgeField.toV3(v2Name)
+private fun escapeV3Keyword(v2Name: String): String = if (v2Name in V3_SYSTEM_FIELD_NAMES) "`$v2Name`" else EdgeField.toV3(v2Name)
 
 // TODO: dedupe with V3MetadataConverter.toV3PrimitiveType once a shared
 // home for V2<->V3 type conversions exists (engine can't depend on server).

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
@@ -237,7 +237,7 @@ class QueryServiceSpec :
                 .verifyComplete()
         }
 
-        "get: colliding user property fields surface under backticked keys" {
+        "get: colliding user property fields surface in properties without leaking backticks" {
             setupCollisionLabel()
             queryService
                 .gets(GraphFixtures.serviceName, collisionTable, listOf(collisionEdge.src), listOf(collisionEdge.tgt))
@@ -248,9 +248,9 @@ class QueryServiceSpec :
                     payload.version shouldBe collisionEdge.ts
                     payload.source.toString() shouldBe collisionEdge.src.toString()
                     payload.target.toString() shouldBe collisionEdge.tgt.toString()
-                    payload.properties["`version`"] shouldBe 999L
-                    payload.properties["`source`"] shouldBe "userSrcValue"
-                    payload.properties["`target`"] shouldBe "userTgtValue"
+                    payload.properties["version"] shouldBe 999L
+                    payload.properties["source"] shouldBe "userSrcValue"
+                    payload.properties["target"] shouldBe "userTgtValue"
                     payload.properties["createdAt"] shouldBe 50L
                 }.verifyComplete()
         }
@@ -264,7 +264,7 @@ class QueryServiceSpec :
                 .verifyComplete()
         }
 
-        "scan: colliding user property fields surface under backticked keys" {
+        "scan: colliding user property fields surface in properties without leaking backticks" {
             setupCollisionLabel()
             queryService
                 .scan(GraphFixtures.serviceName, collisionTable, collisionIndex, collisionEdge.src, Direction.OUT, limit = 10)
@@ -275,9 +275,9 @@ class QueryServiceSpec :
                     payload.version shouldBe collisionEdge.ts
                     payload.source.toString() shouldBe collisionEdge.src.toString()
                     payload.target.toString() shouldBe collisionEdge.tgt.toString()
-                    payload.properties["`version`"] shouldBe 999L
-                    payload.properties["`source`"] shouldBe "userSrcValue"
-                    payload.properties["`target`"] shouldBe "userTgtValue"
+                    payload.properties["version"] shouldBe 999L
+                    payload.properties["source"] shouldBe "userSrcValue"
+                    payload.properties["target"] shouldBe "userTgtValue"
                     payload.properties["createdAt"] shouldBe 50L
                 }.verifyComplete()
         }

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
@@ -2,9 +2,24 @@ package com.kakao.actionbase.v2.engine.v3
 
 import com.kakao.actionbase.core.edge.payload.EdgePayload
 import com.kakao.actionbase.engine.service.QueryService
+import com.kakao.actionbase.v2.core.code.Index
+import com.kakao.actionbase.v2.core.code.hbase.Order
+import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.core.types.DataType
+import com.kakao.actionbase.v2.core.types.EdgeSchema
+import com.kakao.actionbase.v2.core.types.Field
+import com.kakao.actionbase.v2.core.types.VertexField
+import com.kakao.actionbase.v2.core.types.VertexType
 import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
+import com.kakao.actionbase.v2.engine.service.ddl.DdlStatus
 import com.kakao.actionbase.v2.engine.test.GraphFixtures
+import com.kakao.actionbase.v2.engine.test.toRequest
 
 import org.junit.jupiter.api.assertThrows
 
@@ -162,6 +177,112 @@ class QueryServiceSpec :
                     it.total shouldBe -1L // total is not provided in this case
                 }.verifyComplete()
         }
+
+        // region V3 system property name collision (e2e)
+
+        // A user-defined property field whose name collides with a V3 system field
+        // (`version` / `source` / `target` / `direction`) is escaped with backticks at the
+        // V2 -> V3 conversion boundary, so it cannot shadow the actual edge metadata.
+        // (Multi-hop usage on such tables is not supported -- see operational guide.)
+        val collisionTable = "system_prop_collision"
+        val collisionIndex = "created_at_desc"
+        val collisionEdge =
+            Edge(
+                100L,
+                1L,
+                2L,
+                mapOf(
+                    "createdAt" to 50L,
+                    "version" to 999L,
+                    "source" to "userSrcValue",
+                    "target" to "userTgtValue",
+                ),
+            )
+
+        fun setupCollisionLabel() {
+            val schema =
+                EdgeSchema(
+                    VertexField(VertexType.LONG),
+                    VertexField(VertexType.LONG),
+                    listOf(
+                        Field("createdAt", DataType.LONG, false),
+                        Field("version", DataType.LONG, true),
+                        Field("source", DataType.STRING, true),
+                        Field("target", DataType.STRING, true),
+                    ),
+                )
+            val name = EntityName(GraphFixtures.serviceName, collisionTable)
+            val entity =
+                LabelEntity(
+                    active = true,
+                    name = name,
+                    desc = "v3 system property collision",
+                    type = LabelType.INDEXED,
+                    schema = schema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = listOf(Index(collisionIndex, listOf(Index.Field("createdAt", Order.DESC)))),
+                )
+            graph.labelDdl
+                .create(name, entity.toRequest())
+                .test()
+                .assertNext { it.status shouldBe DdlStatus.Status.CREATED }
+                .verifyComplete()
+            graph.updateAllMetadata().test().verifyComplete()
+            val label = graph.getLabel(name)
+            graph
+                .mutate(label.name, label, listOf(collisionEdge.toTraceEdge()), EdgeOperation.INSERT)
+                .test()
+                .assertNext { }
+                .verifyComplete()
+        }
+
+        "get: colliding user property fields surface under backticked keys" {
+            setupCollisionLabel()
+            queryService
+                .gets(GraphFixtures.serviceName, collisionTable, listOf(collisionEdge.src), listOf(collisionEdge.tgt))
+                .test()
+                .assertNext {
+                    it.edges.size shouldBe 1
+                    val payload = it.edges.first()
+                    payload.version shouldBe collisionEdge.ts
+                    payload.source.toString() shouldBe collisionEdge.src.toString()
+                    payload.target.toString() shouldBe collisionEdge.tgt.toString()
+                    payload.properties["`version`"] shouldBe 999L
+                    payload.properties["`source`"] shouldBe "userSrcValue"
+                    payload.properties["`target`"] shouldBe "userTgtValue"
+                    payload.properties["createdAt"] shouldBe 50L
+                }.verifyComplete()
+        }
+
+        "count: a label with colliding user property names still counts correctly" {
+            setupCollisionLabel()
+            queryService
+                .count(GraphFixtures.serviceName, collisionTable, collisionEdge.src, Direction.OUT)
+                .test()
+                .assertNext { it.count shouldBe 1L }
+                .verifyComplete()
+        }
+
+        "scan: colliding user property fields surface under backticked keys" {
+            setupCollisionLabel()
+            queryService
+                .scan(GraphFixtures.serviceName, collisionTable, collisionIndex, collisionEdge.src, Direction.OUT, limit = 10)
+                .test()
+                .assertNext {
+                    it.edges.size shouldBe 1
+                    val payload = it.edges.first()
+                    payload.version shouldBe collisionEdge.ts
+                    payload.source.toString() shouldBe collisionEdge.src.toString()
+                    payload.target.toString() shouldBe collisionEdge.tgt.toString()
+                    payload.properties["`version`"] shouldBe 999L
+                    payload.properties["`source`"] shouldBe "userSrcValue"
+                    payload.properties["`target`"] shouldBe "userTgtValue"
+                    payload.properties["createdAt"] shouldBe 50L
+                }.verifyComplete()
+        }
+
+        // endregion
 
         "scan with invalid ranges" {
             val database = GraphFixtures.serviceName

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBindingTest.kt
@@ -454,6 +454,63 @@ class V2BackedTableBindingTest {
         }
 
         @Test
+        fun `user property fields whose name collides with a v3 system field are escaped with backticks`() {
+            val v2Schema =
+                V2StructType(
+                    arrayOf(
+                        Field("ts", DataType.LONG, false, ""),
+                        Field("src", DataType.STRING, false, ""),
+                        Field("tgt", DataType.STRING, false, ""),
+                        // User properties whose names collide with V3 system fields.
+                        Field("version", DataType.LONG, true, ""),
+                        Field("source", DataType.STRING, true, ""),
+                        Field("target", DataType.STRING, true, ""),
+                        Field("direction", DataType.STRING, true, ""),
+                    ),
+                )
+            val v2 =
+                V2DataFrame(
+                    rows = listOf(V2Row(arrayOf(100L, "edgeSrc", "edgeTgt", 999L, "userSrc", "userTgt", "userDir"))),
+                    schema = v2Schema,
+                )
+
+            val v3 = v2.toV3()
+
+            // Edge fields keep their natural V3 names.
+            assertEquals(
+                listOf("version", "source", "target", "`version`", "`source`", "`target`", "`direction`"),
+                v3.schema.fields.map { it.name },
+            )
+            // System values at natural keys.
+            assertEquals(100L, v3.rows[0].data["version"])
+            assertEquals("edgeSrc", v3.rows[0].data["source"])
+            assertEquals("edgeTgt", v3.rows[0].data["target"])
+            // User values at backticked keys.
+            assertEquals(999L, v3.rows[0].data["`version`"])
+            assertEquals("userSrc", v3.rows[0].data["`source`"])
+            assertEquals("userTgt", v3.rows[0].data["`target`"])
+            assertEquals("userDir", v3.rows[0].data["`direction`"])
+        }
+
+        @Test
+        fun `non-colliding user property fields are not escaped`() {
+            val v2Schema =
+                V2StructType(
+                    arrayOf(
+                        Field("createdAt", DataType.LONG, false, ""),
+                        Field("permission", DataType.STRING, true, ""),
+                    ),
+                )
+            val v2 = V2DataFrame(rows = listOf(V2Row(arrayOf(50L, "na"))), schema = v2Schema)
+
+            val v3 = v2.toV3()
+
+            assertEquals(listOf("createdAt", "permission"), v3.schema.fields.map { it.name })
+            assertEquals(50L, v3.rows[0].data["createdAt"])
+            assertEquals("na", v3.rows[0].data["permission"])
+        }
+
+        @Test
         fun `each v2 DataType maps to the corresponding v3 PrimitiveType`() {
             val v2Schema =
                 V2StructType(


### PR DESCRIPTION
## Summary

When a V2 user-defined property has a name that matches a V3 system field (`version`, `source`, `target`, `direction`), the V2→V3 DataFrame conversion silently overwrites the edge metadata with the user value, so callers see the wrong `version`/`source`/`target` on the edge.

Wrap colliding user property names with backticks (e.g. `` `version` ``) at the V2→V3 conversion boundary so both the system and user values remain accessible inside the V3 row map. The backticks are an internal disambiguation: at the `EdgePayload` boundary they are stripped, since `EdgePayload.properties` is its own namespace separate from the `version`/`source`/`target` fields. Callers see the natural property names.

This is a stop-gap. The proper fix is a nested row form in V3 DataFrame that gives user properties their own namespace; once that lands the escape can be removed. Multi-hop on labels with colliding property names is still unsupported.

## Test plan

- `./gradlew :engine:test --tests V2BackedTableBindingTest` — unit coverage for `V2DataFrame.toV3`: colliding user fields get backticked keys in the V3 row, edge fields keep their natural names, non-colliding fields are untouched.
- `./gradlew :engine:test --tests QueryServiceSpec` — e2e coverage on a label whose schema declares `version`/`source`/`target` as user properties: `get`, `count`, and `scan` return the correct edge metadata and surface user values under their natural keys (no backticks leak to `EdgePayload.properties`).
