### PR TITLE
Add Bump codec-java Version workflow

### DIFF
--- a/.github/workflows/bump-codec-java-version.yml
+++ b/.github/workflows/bump-codec-java-version.yml
@@ -1,0 +1,80 @@
+name: Bump codec-java Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 0.1.0 for minor, 0.1.1 for patch)'
+        required: true
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION. Expected: X.Y.Z"
+            exit 1
+          fi
+
+      - name: Determine target branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          patch=${VERSION##*.}
+          minor_prefix=${VERSION%.*}
+          if [[ "$patch" == "0" ]]; then
+            target_branch=main
+          else
+            target_branch="codec-java/${minor_prefix}.x"
+          fi
+          echo "target_branch=$target_branch" >> $GITHUB_ENV
+          echo "minor_prefix=$minor_prefix" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.target_branch }}
+
+      - name: Check current version matches target branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          current=$(grep '^version = ' codec-java/build.gradle.kts | head -1 | cut -d'"' -f2)
+          if [[ "$current" != *-SNAPSHOT ]]; then
+            echo "::error::Current codec-java version ($current) on ${{ env.target_branch }} is not a SNAPSHOT"
+            exit 1
+          fi
+          if [[ "$current" != ${{ env.minor_prefix }}.*-SNAPSHOT ]]; then
+            echo "::error::Version $VERSION does not match branch ${{ env.target_branch }} (current: $current)"
+            exit 1
+          fi
+          echo "current_version=$current" >> $GITHUB_ENV
+
+      - name: Update codec-java/build.gradle.kts
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" codec-java/build.gradle.kts
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ env.target_branch }}
+          branch: release/codec-java/v${{ inputs.version }}
+          commit-message: "Bump codec-java version to ${{ inputs.version }}"
+          title: "Bump codec-java version to ${{ inputs.version }}"
+          body: |
+            Bump codec-java version from `${{ env.current_version }}` to `${{ inputs.version }}`.
+            Target: `${{ env.target_branch }}`
+
+            After merging, the following will happen automatically:
+            - Tag `codec-java/v${{ inputs.version }}` will be created
+            - Version will be bumped to the next SNAPSHOT
+          labels: release

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - '*.x'
+      - 'codec-java/*.x'
     paths-ignore:
       - 'website/**'
       - 'guides/**'
@@ -19,6 +20,7 @@ on:
     branches:
       - main
       - '*.x'
+      - 'codec-java/*.x'
     types:
       - opened
       - reopened

--- a/.github/workflows/post-release-codec-java.yml
+++ b/.github/workflows/post-release-codec-java.yml
@@ -1,0 +1,87 @@
+name: Post Release codec-java
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - 'codec-java/*.x'
+
+jobs:
+  release:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/codec-java/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version
+        run: |
+          version=$(grep '^version = ' codec-java/build.gradle.kts | head -1 | cut -d'"' -f2)
+          major=${version%%.*}
+          rest=${version#*.}
+          minor=${rest%%.*}
+          patch=${version##*.}
+          base=${{ github.event.pull_request.base.ref }}
+
+          echo "version=$version" >> $GITHUB_ENV
+          echo "base_branch=$base" >> $GITHUB_ENV
+          echo "is_patch=$([[ "$base" != "main" ]] && echo true || echo false)" >> $GITHUB_ENV
+          echo "release_branch=codec-java/${major}.${minor}.x" >> $GITHUB_ENV
+          echo "next_minor=${major}.$((minor + 1)).0-SNAPSHOT" >> $GITHUB_ENV
+          echo "next_patch=${major}.${minor}.$((patch + 1))-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Create tag
+        run: |
+          git tag "codec-java/v${{ env.version }}"
+          git push origin "codec-java/v${{ env.version }}"
+
+      - name: Create release branch (minor release only)
+        if: env.is_patch == 'false'
+        run: |
+          git checkout -b "${{ env.release_branch }}" "codec-java/v${{ env.version }}"
+          sed -i "s/^version = \".*\"/version = \"${{ env.next_patch }}\"/" codec-java/build.gradle.kts
+          git add codec-java/build.gradle.kts
+          git commit -m "Bump codec-java version to ${{ env.next_patch }}"
+          git push origin "${{ env.release_branch }}"
+
+      - name: Bump release branch (patch release only)
+        if: env.is_patch == 'true'
+        run: |
+          git checkout "${{ env.base_branch }}"
+          sed -i "s/^version = \".*\"/version = \"${{ env.next_patch }}\"/" codec-java/build.gradle.kts
+          git add codec-java/build.gradle.kts
+          git commit -m "Bump codec-java version to ${{ env.next_patch }}"
+          git push origin "${{ env.base_branch }}"
+
+      - name: Prepare main for next SNAPSHOT (minor release only)
+        if: env.is_patch == 'false'
+        run: |
+          git checkout main
+          sed -i "s/^version = \".*\"/version = \"${{ env.next_minor }}\"/" codec-java/build.gradle.kts
+
+      - name: Create PR to bump main (minor release only)
+        if: env.is_patch == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bump-main/codec-java/v${{ env.version }}
+          commit-message: "Bump codec-java version to ${{ env.next_minor }}"
+          title: "Bump codec-java version to ${{ env.next_minor }}"
+          body: |
+            Post-release version bump from `${{ env.version }}` to `${{ env.next_minor }}`.
+
+            Released:
+            - Tag `codec-java/v${{ env.version }}` created
+            - Branch `${{ env.release_branch }}` created with `${{ env.next_patch }}`
+          labels: release


### PR DESCRIPTION
Apply the existing bump-version flow to codec-java.

Refs #275

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)