### PR TITLE
Add root-list and pipe-delimited row shapes to @TableSource

### DIFF
--- a/core/src/test/kotlin/com/kakao/actionbase/test/TableSourceTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/test/TableSourceTest.kt
@@ -15,14 +15,12 @@ class TableSourceTest {
     @ObjectSourceParameterizedTest
     @TableSource(
         """
-        columns: [number, string]
-        rows:
-          - [1, foo]
-          - [2, bar]
-          - [3, baz]
+        - [1, foo]
+        - [2, bar]
+        - [3, baz]
         """,
     )
-    fun `columns become parameter names`(
+    fun `flow rows bind by parameter position`(
         number: Int,
         string: String,
     ) {
@@ -40,10 +38,8 @@ class TableSourceTest {
     @ObjectSourceParameterizedTest
     @TableSource(
         """
-        columns: [a, b, c]
-        rows:
-          - [1, 2, 3]
-          - [4, ~, 6]
+        - [1, 2, 3]
+        - [4, ~, 6]
         """,
     )
     fun `tilde maps to null for nullable parameters`(
@@ -62,13 +58,11 @@ class TableSourceTest {
     @ObjectSourceParameterizedTest
     @TableSource(
         """
-        columns: [from, event, expected]
-        rows:
-          - [IDLE,    START, RUNNING]
-          - [RUNNING, STOP,  IDLE]
+        - [IDLE,    START, RUNNING]
+        - [RUNNING, STOP,  IDLE]
         """,
     )
-    fun `enum columns bind by name`(
+    fun `enum cells bind by name`(
         from: Status,
         event: Event,
         expected: Status,
@@ -82,14 +76,58 @@ class TableSourceTest {
         assertEquals(expected, result)
     }
 
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        - 1 | foo
+        - 2 | bar
+        - 3 | baz
+        """,
+    )
+    fun `pipe rows split each item by '|'`(
+        number: Int,
+        string: String,
+    ) {
+        assertEquals(
+            when (number) {
+                1 -> "foo"
+                2 -> "bar"
+                3 -> "baz"
+                else -> error("unexpected number $number")
+            },
+            string,
+        )
+    }
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        # category one
+        - 1 | 2 | 3
+
+        # category two
+        - 4 | ~ | 6
+        """,
+    )
+    fun `pipe rows allow yaml comments and blank lines, ~ maps to null`(
+        a: Int,
+        b: Int?,
+        c: Int,
+    ) {
+        when (a) {
+            1 -> assertEquals(2, b)
+            4 -> assertNull(b)
+            else -> error("unexpected a=$a")
+        }
+        assertEquals(a + 2, c)
+    }
+
     @Nested
     inner class NestedClassTest {
         @ObjectSourceParameterizedTest
         @TableSource(
             """
-            columns: [a, b]
-            rows:
-              - [1, 2]
+            - [1, 2]
             """,
         )
         fun `nested test classes work`(
@@ -105,109 +143,111 @@ class TableSourceTest {
     inner class ErrorTest {
         private val extension = ObjectSourceExtension()
 
+        private val twoCols = listOf("a", "b")
+        private val threeCols = listOf("a", "b", "c")
+
         @Test
         fun `blank value is rejected`() {
             val e =
                 assertThrows<IllegalArgumentException> {
-                    extension.parseTableSource(TableSource(""))
+                    extension.parseTableSource(TableSource(""), twoCols)
                 }
             assertTrue(e.message!!.contains("value"))
         }
 
         @Test
-        fun `missing columns is rejected`() {
+        fun `empty method parameters is rejected`() {
+            val e =
+                assertThrows<IllegalArgumentException> {
+                    extension.parseTableSource(
+                        TableSource(
+                            """
+                            - [1, 2]
+                            """.trimIndent(),
+                        ),
+                        emptyList(),
+                    )
+                }
+            assertTrue(e.message!!.contains("method"))
+        }
+
+        @Test
+        fun `non-list root is rejected`() {
+            assertThrows<Exception> {
+                extension.parseTableSource(TableSource("columns: [a, b]"), twoCols)
+            }
+        }
+
+        @Test
+        fun `flow row size mismatch is rejected`() {
+            val e =
+                assertThrows<IllegalArgumentException> {
+                    extension.parseTableSource(
+                        TableSource(
+                            """
+                            - [1, 2]
+                            """.trimIndent(),
+                        ),
+                        threeCols,
+                    )
+                }
+            assertTrue(e.message!!.contains("2 cells"))
+            assertTrue(e.message!!.contains("expected 3"))
+        }
+
+        @Test
+        fun `pipe row with wrong cell count is rejected`() {
+            val e =
+                assertThrows<IllegalArgumentException> {
+                    extension.parseTableSource(
+                        TableSource(
+                            """
+                            - 1 | 2
+                            """.trimIndent(),
+                        ),
+                        threeCols,
+                    )
+                }
+            assertTrue(e.message!!.contains("2 cells"))
+            assertTrue(e.message!!.contains("expected 3"))
+        }
+
+        @Test
+        fun `pipe row with empty cell is rejected`() {
+            val e =
+                assertThrows<IllegalArgumentException> {
+                    extension.parseTableSource(
+                        TableSource(
+                            """
+                            - 1 |
+                            """.trimIndent(),
+                        ),
+                        twoCols,
+                    )
+                }
+            assertTrue(e.message!!.contains("empty cell"))
+            assertTrue(e.message!!.contains("Use ~"))
+        }
+
+        @Test
+        fun `unsupported row type is rejected`() {
             val e =
                 assertThrows<IllegalStateException> {
                     extension.parseTableSource(
                         TableSource(
                             """
-                            rows:
-                              - [1, 2]
+                            - 42
                             """.trimIndent(),
                         ),
+                        twoCols,
                     )
                 }
-            assertTrue(e.message!!.contains("columns"))
+            assertTrue(e.message!!.contains("list or a pipe-delimited string"))
         }
 
         @Test
-        fun `missing rows is rejected`() {
-            val e =
-                assertThrows<IllegalStateException> {
-                    extension.parseTableSource(
-                        TableSource(
-                            """
-                            columns: [a, b]
-                            """.trimIndent(),
-                        ),
-                    )
-                }
-            assertTrue(e.message!!.contains("rows"))
-        }
-
-        @Test
-        fun `row size mismatch is rejected`() {
-            val e =
-                assertThrows<IllegalArgumentException> {
-                    extension.parseTableSource(
-                        TableSource(
-                            """
-                            columns: [a, b, c]
-                            rows:
-                              - [1, 2]
-                            """.trimIndent(),
-                        ),
-                    )
-                }
-            assertTrue(e.message!!.contains("row size"))
-            assertTrue(e.message!!.contains("columns size"))
-        }
-
-        @Test
-        fun `non-string column entry is rejected`() {
-            val e =
-                assertThrows<IllegalArgumentException> {
-                    extension.parseTableSource(
-                        TableSource(
-                            """
-                            columns: [a, 2]
-                            rows:
-                              - [1, 2]
-                            """.trimIndent(),
-                        ),
-                    )
-                }
-            assertTrue(e.message!!.contains("must be strings"))
-        }
-
-        @Test
-        fun `row that is not a list is rejected`() {
-            val e =
-                assertThrows<IllegalArgumentException> {
-                    extension.parseTableSource(
-                        TableSource(
-                            """
-                            columns: [a, b]
-                            rows:
-                              - not-a-list
-                            """.trimIndent(),
-                        ),
-                    )
-                }
-            assertTrue(e.message!!.contains("must be a list"))
-        }
-
-        @Test
-        fun `empty rows list produces no test cases`() {
-            val result =
-                extension.parseTableSource(
-                    TableSource(
-                        """
-                        columns: [a, b]
-                        rows: []
-                        """.trimIndent(),
-                    ),
-                )
+        fun `empty list produces no test cases`() {
+            val result = extension.parseTableSource(TableSource("[]"), twoCols)
             assertEquals(0, result.size)
         }
     }

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceExtension.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceExtension.kt
@@ -28,14 +28,14 @@ class ObjectSourceExtension : TestTemplateInvocationContextProvider {
             "@ObjectSource and @TableSource cannot be applied to the same method"
         }
 
+        val parameterNames = getParameterNames(context.requiredTestClass, context.requiredTestMethod.name)
+
         val testCases: List<Map<String, Any?>> =
             when {
                 objectSource != null -> parseObjectSource(objectSource)
-                tableSource != null -> parseTableSource(tableSource)
+                tableSource != null -> parseTableSource(tableSource, parameterNames)
                 else -> error("Either @ObjectSource or @TableSource must be present")
             }
-
-        val parameterNames = getParameterNames(context.requiredTestClass, context.requiredTestMethod.name)
 
         return testCases
             .mapIndexed { index, testCase ->
@@ -64,29 +64,40 @@ class ObjectSourceExtension : TestTemplateInvocationContextProvider {
         }
     }
 
-    fun parseTableSource(annotation: TableSource): List<Map<String, Any?>> {
+    fun parseTableSource(
+        annotation: TableSource,
+        methodParameters: List<String>,
+    ): List<Map<String, Any?>> {
         require(annotation.value.isNotBlank()) { "@TableSource: 'value' must be provided" }
-
-        val parsed: Map<String, Any?> = ObjectMappers.YAML.readValue(annotation.value)
-
-        val columns =
-            (parsed["columns"] as? List<*>)?.map {
-                require(it is String) { "@TableSource: 'columns' entries must be strings, got ${it?.javaClass}" }
-                it
-            } ?: error("@TableSource: 'columns' key is required and must be a list of strings")
-
-        val rows =
-            (parsed["rows"] as? List<*>)?.map {
-                require(it is List<*>) { "@TableSource: each row must be a list, got ${it?.javaClass}" }
-                it
-            } ?: error("@TableSource: 'rows' key is required and must be a list of lists")
-
-        return rows.map { row ->
-            require(row.size == columns.size) {
-                "@TableSource: row size ${row.size} does not match columns size ${columns.size}: $row"
-            }
-            columns.zip(row).toMap()
+        require(methodParameters.isNotEmpty()) {
+            "@TableSource: requires the test method to declare parameters; row cells map by position"
         }
+
+        val rows: List<Any?> = ObjectMappers.YAML.readValue(annotation.value)
+        return rows.map { row -> parseRow(row, methodParameters) }
+    }
+
+    private fun parseRow(
+        row: Any?,
+        columns: List<String>,
+    ): Map<String, Any?> {
+        val cells: List<Any?> =
+            when (row) {
+                is List<*> -> row
+                is String ->
+                    row.split("|").map { cell ->
+                        val trimmed = cell.trim()
+                        require(trimmed.isNotEmpty()) {
+                            "@TableSource: empty cell in row '$row'. Use ~ for null."
+                        }
+                        ObjectMappers.YAML.readValue<Any?>(trimmed)
+                    }
+                else -> error("@TableSource: each row must be a list or a pipe-delimited string, got ${row?.javaClass}")
+            }
+        require(cells.size == columns.size) {
+            "@TableSource: row has ${cells.size} cells, expected ${columns.size} (test method parameters): $row"
+        }
+        return columns.zip(cells).toMap()
     }
 
     private fun getParameterNames(

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/TableSource.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/TableSource.kt
@@ -3,24 +3,38 @@ package com.kakao.actionbase.test.documentations.params
 /**
  * Dense-matrix data source for `@ObjectSourceParameterizedTest`.
  *
- * Body is YAML with two top-level keys — `columns` (list of parameter names)
- * and `rows` (list of value lists). Each row is expanded into a test case
- * whose keys come from `columns`. Use this when a test is a table of
- * primitives where repeating YAML keys per case would hurt readability.
+ * The annotation value is a YAML list. Each item is one row; cells map to
+ * the test method's parameters by position. Use this when a test is a table
+ * of primitives where repeating YAML keys per case would hurt readability.
+ *
+ * A row item can be either shape:
+ *
+ * 1. **Flow list** `[a, b, c]` — concise for short, simple tables.
+ *
+ *    ```
+ *    @TableSource("""
+ *        - [IDLE,    START, RUNNING]
+ *        - [RUNNING, STOP,  IDLE]
+ *    """)
+ *    fun `transition`(from: State, event: Event, expected: State) { ... }
+ *    ```
+ *
+ * 2. **Pipe-delimited string** `a | b | c` — recommended for wide matrices
+ *    where column-by-column scannability matters. Each cell is parsed as a
+ *    YAML scalar (so `~` is null, bare numbers are typed, single-quoted
+ *    strings keep their content). YAML strips `#` comments and blank lines
+ *    between items naturally.
+ *
+ *    ```
+ *    @TableSource("""
+ *        # state machine transitions
+ *        - IDLE    | START | RUNNING
+ *        - RUNNING | STOP  | IDLE
+ *    """)
+ *    fun `transition`(from: State, event: Event, expected: State) { ... }
+ *    ```
  *
  * For nested or heterogeneous data, use `@ObjectSource` instead.
- *
- * Example:
- * ```
- * @ObjectSourceParameterizedTest
- * @TableSource("""
- *     columns: [from, event, expected]
- *     rows:
- *       - [IDLE,    START, RUNNING]
- *       - [RUNNING, STOP,  IDLE]
- * """)
- * fun `transition moves state`(from: State, event: Event, expected: State) { ... }
- * ```
  */
 @Retention
 @Target(AnnotationTarget.FUNCTION)

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/hbase/PerCellTTLTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/hbase/PerCellTTLTest.kt
@@ -26,22 +26,20 @@ class PerCellTTLTest(
     @ObjectSourceParameterizedTest
     @TableSource(
         """
-        columns: [name, operations, expected]
-        rows:
-          - [Basic TTL expired,      'Put(20), Delay(50)',              ~]
-          - [Basic TTL active,       'Put(50), Delay(20)',              value_0]
-          - [Put then TTL expired,   'Put, Put(20), Delay(50)',         value_0]
-          - [Put then TTL active,    'Put, Put(50), Delay(20)',         value_1]
-          - [TTL then Put,           'Put(20), Put, Delay(50)',         value_1]
-          - [Multiple Puts TTL,      'Put, Put, Put(20), Delay(50)',    value_1]
-          - [Put TTL Delete,         'Put, Put(20), Delete, Delay(50)', ~]
-          - [Put Delete no delay,    'Put, Delete',                     ~]
-          - [TTL Delete immediate,   'Put(20), Delete',                 ~]
-          - [Delete then Put,        'Delete, Put',                     value_1]
-          - [Delete then TTL,        'Delete, Put(20), Delay(50)',      ~]
-          - [Short delay TTL active, 'Put(20), Delay(5)',               value_0]
-          - [Increment then Delete,  'Increment, Delete',               ~]
-          - [Multiple Increments,    'Increment, Increment, Increment', '3']
+        - Basic TTL expired      | Put(20), Delay(50)              | ~
+        - Basic TTL active       | Put(50), Delay(20)              | value_0
+        - Put then TTL expired   | Put, Put(20), Delay(50)         | value_0
+        - Put then TTL active    | Put, Put(50), Delay(20)         | value_1
+        - TTL then Put           | Put(20), Put, Delay(50)         | value_1
+        - Multiple Puts TTL      | Put, Put, Put(20), Delay(50)    | value_1
+        - Put TTL Delete         | Put, Put(20), Delete, Delay(50) | ~
+        - Put Delete no delay    | Put, Delete                     | ~
+        - TTL Delete immediate   | Put(20), Delete                 | ~
+        - Delete then Put        | Delete, Put                     | value_1
+        - Delete then TTL        | Delete, Put(20), Delay(50)      | ~
+        - Short delay TTL active | Put(20), Delay(5)               | value_0
+        - Increment then Delete  | Increment, Delete               | ~
+        - Multiple Increments    | Increment, Increment, Increment | '3'
         """,
     )
     fun testHBaseTTLOperations(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatusTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/MetadataStatusTest.kt
@@ -12,14 +12,12 @@ class MetadataStatusTest {
         @ObjectSourceParameterizedTest
         @TableSource(
             """
-            columns: [status, active, expected]
-            rows:
-              - [ACTIVE,   true,  true]
-              - [ACTIVE,   false, false]
-              - [INACTIVE, true,  false]
-              - [INACTIVE, false, true]
-              - [ALL,      true,  true]
-              - [ALL,      false, true]
+            - ACTIVE   | true  | true
+            - ACTIVE   | false | false
+            - INACTIVE | true  | false
+            - INACTIVE | false | true
+            - ALL      | true  | true
+            - ALL      | false | true
             """,
         )
         fun `matches reflects status against active flag`(


### PR DESCRIPTION
## Summary

Simplifies `@TableSource` to a single canonical shape: the annotation value is a YAML list of rows; cells map to test method parameters by position via Kotlin reflection. The previous map-with-`columns:`-and-`rows:` wrapper is removed — `columns:` was always redundant with the method signature, and the `rows:` wrapper added a layer that didn't earn its keep.

This is a precondition for the Phase 1 migration in #271 / #292: state-machine tests like `SingleTransitionTest` (41 × 32) read poorly without column-by-column scannability.

## Changes

Each row item is one of two shapes:

**1. Flow list** `[a, b, c]` — concise for short, simple tables.

```kotlin
@TableSource("""
    - [IDLE,    START, RUNNING]
    - [RUNNING, STOP,  IDLE]
""")
fun `transition`(from: State, event: Event, expected: State) { ... }
```

**2. Pipe-delimited string** `a | b | c` — recommended for wide matrices where column-by-column scannability matters. Each cell is parsed as a YAML scalar, so `~` is null, bare numbers are typed, and single-quoted strings keep their content. YAML strips `#` comments and blank lines naturally.

```kotlin
@TableSource("""
    # state machine transitions
    - IDLE    | START | RUNNING
    - RUNNING | STOP  | IDLE
""")
fun `transition`(from: State, event: Event, expected: State) { ... }
```

## Implementation

- `core/src/testFixtures/.../params/ObjectSourceExtension.kt` — `parseTableSource` now takes `methodParameters: List<String>` (supplied from reflection at call time). The annotation value parses as a YAML list directly; each row item is dispatched to `parseRow` which handles `List` (flow) or `String` (pipe).
- `core/src/testFixtures/.../params/TableSource.kt` — KDoc updated.
- `core/src/test/.../test/TableSourceTest.kt` — covers both shapes plus error paths.

## Phase 0 callers updated

The two callers that already used `@TableSource` are converted to the new shape:

- `engine/.../experiments/hbase/PerCellTTLTest.kt` (14 rows × 3 cols)
- `server/.../v3/metadata/MetadataStatusTest.kt` (6 rows × 3 cols)

Both retain their original test counts.

## Breaking change

The legacy map-with-`columns:`-and-`rows:` shape no longer parses. Any consumer outside this PR that uses `@TableSource` must adopt the new shape; #292 (Phase 1 migration) will rebase on this PR.

## How to Test

```bash
./gradlew :core:test --tests '*TableSourceTest'                  # 12 cases
./gradlew :server:test --tests '*MetadataStatusTest'             # 6 cases
./gradlew :engine:test --tests '*PerCellTTLTest'                 # 14 cases (HBase)
./gradlew :core:test :server:test                                # full sweep, no regression
./gradlew spotlessKotlinCheck
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code with Claude Opus 4.7 (1M context)
