### PR TITLE
Migrate core data-driven tests to @ObjectSource/@TableSource

### DIFF
--- a/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategyTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategyTest.kt
@@ -6,82 +6,98 @@ import com.kakao.actionbase.core.edge.record.EdgeCountRecord
 import com.kakao.actionbase.core.edge.record.EdgeStateRecord
 import com.kakao.actionbase.core.metadata.common.Direction
 import com.kakao.actionbase.core.metadata.common.DirectionType
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.test.documentations.params.TableSource
 
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class EdgeMutationStrategyTest {
+    private fun strategyOf(name: String): EdgeMutationStrategy =
+        when (name) {
+            "Edge" -> EdgeMutationStrategy.Edge
+            "MultiEdge" -> EdgeMutationStrategy.MultiEdge
+            else -> error("unknown strategy: $name")
+        }
+
+    private fun recordOf(
+        strategy: String,
+        source: Any = "userA",
+        target: Any = "postX",
+        active: Boolean = true,
+        version: Long = 1L,
+    ): EdgeStateRecord =
+        when (strategy) {
+            "Edge" -> edgeRecord(source = source, target = target, active = active, version = version)
+            "MultiEdge" -> multiEdgeRecord(id = "edgeId1", source = source, target = target, active = active, version = version)
+            else -> error("unknown strategy: $strategy")
+        }
+
     @Nested
     inner class DirectedSource {
-        @Test
-        fun `Edge OUT returns key source`() {
-            val record = edgeRecord(source = "userA", target = "postX", active = true)
-            assertEquals("userA", EdgeMutationStrategy.Edge.directedSource(record, Direction.OUT))
-        }
-
-        @Test
-        fun `Edge IN returns key target`() {
-            val record = edgeRecord(source = "userA", target = "postX", active = true)
-            assertEquals("postX", EdgeMutationStrategy.Edge.directedSource(record, Direction.IN))
-        }
-
-        @Test
-        fun `MultiEdge OUT returns properties _source`() {
-            val record = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true)
-            assertEquals("userA", EdgeMutationStrategy.MultiEdge.directedSource(record, Direction.OUT))
-        }
-
-        @Test
-        fun `MultiEdge IN returns properties _target`() {
-            val record = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true)
-            assertEquals("postX", EdgeMutationStrategy.MultiEdge.directedSource(record, Direction.IN))
+        @ObjectSourceParameterizedTest
+        @TableSource(
+            """
+            # strategy   | direction | expected
+            - Edge       | OUT       | userA   # Edge OUT  → key.source
+            - Edge       | IN        | postX   # Edge IN   → key.target
+            - MultiEdge  | OUT       | userA   # MultiEdge → properties._source
+            - MultiEdge  | IN        | postX   # MultiEdge → properties._target
+            """,
+        )
+        fun `returns the configured source for the direction`(
+            strategy: String,
+            direction: Direction,
+            expected: String,
+        ) {
+            val record = recordOf(strategy)
+            assertEquals(expected, strategyOf(strategy).directedSource(record, direction))
         }
     }
 
     @Nested
     inner class DirectedTarget {
-        @Test
-        fun `Edge OUT returns key target`() {
-            val record = edgeRecord(source = "userA", target = "postX", active = true)
-            assertEquals("postX", EdgeMutationStrategy.Edge.directedTarget(record, Direction.OUT))
-        }
-
-        @Test
-        fun `Edge IN returns key source`() {
-            val record = edgeRecord(source = "userA", target = "postX", active = true)
-            assertEquals("userA", EdgeMutationStrategy.Edge.directedTarget(record, Direction.IN))
-        }
-
-        @Test
-        fun `MultiEdge OUT returns key source (id)`() {
-            val record = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true)
-            assertEquals("edgeId1", EdgeMutationStrategy.MultiEdge.directedTarget(record, Direction.OUT))
-        }
-
-        @Test
-        fun `MultiEdge IN returns key source (id)`() {
-            val record = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true)
-            assertEquals("edgeId1", EdgeMutationStrategy.MultiEdge.directedTarget(record, Direction.IN))
+        @ObjectSourceParameterizedTest
+        @TableSource(
+            """
+            # strategy   | direction | expected
+            - Edge       | OUT       | postX    # Edge swaps source/target
+            - Edge       | IN        | userA
+            - MultiEdge  | OUT       | edgeId1  # MultiEdge always uses key.source (id)
+            - MultiEdge  | IN        | edgeId1
+            """,
+        )
+        fun `returns the configured target for the direction`(
+            strategy: String,
+            direction: Direction,
+            expected: String,
+        ) {
+            val record = recordOf(strategy)
+            assertEquals(expected, strategyOf(strategy).directedTarget(record, direction))
         }
     }
 
     @Nested
     inner class CountRecordOnDelete {
-        @Test
-        fun `Edge returns after record`() {
-            val before = edgeRecord(source = "userA", target = "postX", active = true, version = 1)
-            val after = edgeRecord(source = "userA", target = "postX", active = false, version = 2)
-            assertEquals(after, EdgeMutationStrategy.Edge.countRecordOnDelete(before, after))
-        }
-
-        @Test
-        fun `MultiEdge returns before record`() {
-            val before = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 1)
-            val after = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = false, version = 2)
-            assertEquals(before, EdgeMutationStrategy.MultiEdge.countRecordOnDelete(before, after))
+        @ObjectSourceParameterizedTest
+        @TableSource(
+            """
+            # Edge counts the after record (because source/target are stable across the
+            # delete); MultiEdge counts the before record (after's properties are nulled).
+            - Edge      | after
+            - MultiEdge | before
+            """,
+        )
+        fun `picks the count record by strategy`(
+            strategy: String,
+            which: String,
+        ) {
+            val before = recordOf(strategy, active = true, version = 1)
+            val after = recordOf(strategy, active = false, version = 2)
+            val expected = if (which == "before") before else after
+            assertEquals(expected, strategyOf(strategy).countRecordOnDelete(before, after))
         }
     }
 
@@ -102,43 +118,39 @@ class EdgeMutationStrategyTest {
                 }
             }
 
-        @Test
-        fun `Edge always returns empty list`() {
-            val before = edgeRecord(source = "userA", target = "postX", active = true, version = 1)
-            val after = edgeRecord(source = "userB", target = "postY", active = true, version = 2)
-            val result = EdgeMutationStrategy.Edge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
-            assertTrue(result.isEmpty())
+        @ObjectSourceParameterizedTest
+        @TableSource(
+            """
+            # Edge never produces records on update; MultiEdge produces 4 (2 directions
+            # × decrement+increment) iff source or target changed.
+            # strategy    | beforeSrc | afterSrc | beforeTgt | afterTgt | expectedSize
+            - Edge        | userA     | userB    | postX     | postY    | 0   # Edge ignores changes
+            - MultiEdge   | userA     | userA    | postX     | postX    | 0   # unchanged
+            - MultiEdge   | userA     | userB    | postX     | postX    | 4   # source changed
+            - MultiEdge   | userA     | userA    | postX     | postY    | 4   # target changed
+            """,
+        )
+        fun `produces records only when MultiEdge source or target changed`(
+            strategy: String,
+            beforeSrc: String,
+            afterSrc: String,
+            beforeTgt: String,
+            afterTgt: String,
+            expectedSize: Int,
+        ) {
+            val before = recordOf(strategy, source = beforeSrc, target = beforeTgt, version = 1)
+            val after = recordOf(strategy, source = afterSrc, target = afterTgt, version = 2)
+            val result =
+                strategyOf(strategy).countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
+            assertEquals(expectedSize, result.size)
         }
 
         @Test
-        fun `MultiEdge returns records when source changes`() {
+        fun `MultiEdge change produces matching decrement and increment records`() {
             val before = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 1)
             val after = multiEdgeRecord(id = "edgeId1", source = "userB", target = "postX", active = true, version = 2)
-            val result = EdgeMutationStrategy.MultiEdge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
-            assertEquals(4, result.size)
-        }
-
-        @Test
-        fun `MultiEdge returns records when target changes`() {
-            val before = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 1)
-            val after = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postY", active = true, version = 2)
-            val result = EdgeMutationStrategy.MultiEdge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
-            assertEquals(4, result.size)
-        }
-
-        @Test
-        fun `MultiEdge returns empty when source and target unchanged`() {
-            val before = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 1)
-            val after = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 2)
-            val result = EdgeMutationStrategy.MultiEdge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
-            assertTrue(result.isEmpty())
-        }
-
-        @Test
-        fun `MultiEdge decrement records use -1 and increment records use 1`() {
-            val before = multiEdgeRecord(id = "edgeId1", source = "userA", target = "postX", active = true, version = 1)
-            val after = multiEdgeRecord(id = "edgeId1", source = "userB", target = "postX", active = true, version = 2)
-            val result = EdgeMutationStrategy.MultiEdge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
+            val result =
+                EdgeMutationStrategy.MultiEdge.countRecordsOnUpdate(before, after, DirectionType.BOTH, stubBuildCountRecords)
             val decrementRecords = result.filter { it.value == -1L }
             val incrementRecords = result.filter { it.value == 1L }
             assertEquals(2, decrementRecords.size)

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/AliasSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/AliasSerializationTest.kt
@@ -16,11 +16,12 @@ class AliasSerializationTest {
     @ObjectSourceParameterizedTest
     @ObjectSource(
         """
-        - descriptor:
-            tenant: test_tenant
-            database: test_database
-            alias: test_alias
-            table: test_table
+        - descriptor: {
+              "tenant": "test_tenant",
+              "database": "test_database",
+              "alias": "test_alias",
+              "table": "test_table"
+            }
           expected: |-
             {
               "tenant": "test_tenant",
@@ -48,11 +49,12 @@ class AliasSerializationTest {
     @ObjectSource(
         """
         - input: '{"tenant":"test_tenant","database":"test_database","alias":"test_alias","table":"test_table"}'
-          expected:
-            tenant: test_tenant
-            database: test_database
-            alias: test_alias
-            table: test_table
+          expected: {
+              "tenant": "test_tenant",
+              "database": "test_database",
+              "alias": "test_alias",
+              "table": "test_table"
+            }
         """,
     )
     fun `deserializes from JSON`(

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/DatabaseSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/DatabaseSerializationTest.kt
@@ -1,32 +1,26 @@
 package com.kakao.actionbase.core.metadata
 
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class DatabaseSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test database serialization`() {
-        // given
-        val databaseDescriptor =
-            DatabaseDescriptor(
-                tenant = "test_tenant",
-                database = "test_database",
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(databaseDescriptor)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "tenant": "test_tenant",
+              "database": "test_database"
+            }
+          expected: |-
             {
               "tenant": "test_tenant",
               "database": "test_database",
@@ -38,20 +32,29 @@ class DatabaseSerializationTest {
               "updatedAt": -1,
               "updatedBy": ""
             }
-            """.trimIndent()
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: DatabaseDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test database deserialization`() {
-        // given
-        val json = """{"tenant":"test_tenant","database":"test_database"}"""
-
-        // when
-        val actual = objectMapper.readValue<DatabaseDescriptor>(json)
-
-        // then
-        val expected = DatabaseDescriptor(tenant = "test_tenant", database = "test_database")
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: '{"tenant":"test_tenant","database":"test_database"}'
+          expected: {
+              "tenant": "test_tenant",
+              "database": "test_database"
+            }
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: DatabaseDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<DatabaseDescriptor>(input))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/DatastoreSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/DatastoreSerializationTest.kt
@@ -1,53 +1,49 @@
 package com.kakao.actionbase.core.metadata
 
-import com.kakao.actionbase.core.metadata.common.DatastoreType
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class DatastoreSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test database serialization`() {
-        // given
-        val datastoreDescriptor =
-            DatastoreDescriptor(
-                type = DatastoreType.HBASE,
-                configuration = mapOf("hbase.zookeeper.quorum" to "localhost"),
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(datastoreDescriptor)
-
-        // then
-        val expected =
-            """{"type": "HBASE", "configuration": {"hbase.zookeeper.quorum": "localhost"}}""".trimIndent()
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "type": "HBASE",
+              "configuration": {"hbase.zookeeper.quorum": "localhost"}
+            }
+          expected: '{"type": "HBASE", "configuration": {"hbase.zookeeper.quorum": "localhost"}}'
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: DatastoreDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test database deserialization`() {
-        // given
-        val json =
-            """
-            {"type": "HBASE", "configuration": {"hbase.zookeeper.quorum": "localhost"}}
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<DatastoreDescriptor>(json)
-
-        // then
-        val expected =
-            DatastoreDescriptor(
-                type = DatastoreType.HBASE,
-                configuration = mapOf("hbase.zookeeper.quorum" to "localhost"),
-            )
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: '{"type": "HBASE", "configuration": {"hbase.zookeeper.quorum": "localhost"}}'
+          expected: {
+              "type": "HBASE",
+              "configuration": {"hbase.zookeeper.quorum": "localhost"}
+            }
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: DatastoreDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<DatastoreDescriptor>(input))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/TableSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/TableSerializationTest.kt
@@ -1,86 +1,66 @@
 package com.kakao.actionbase.core.metadata
 
-import com.kakao.actionbase.core.java.codec.common.hbase.Order
-import com.kakao.actionbase.core.metadata.common.Bucket
-import com.kakao.actionbase.core.metadata.common.DirectionType
-import com.kakao.actionbase.core.metadata.common.Field
-import com.kakao.actionbase.core.metadata.common.Group
-import com.kakao.actionbase.core.metadata.common.GroupType
-import com.kakao.actionbase.core.metadata.common.Index
-import com.kakao.actionbase.core.metadata.common.IndexField
-import com.kakao.actionbase.core.metadata.common.ModelSchema
-import com.kakao.actionbase.core.metadata.common.MutationMode
-import com.kakao.actionbase.core.metadata.common.StructField
-import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class TableSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test edge table serialization`() {
-        // given
-        val edgeTableDescriptor =
-            TableDescriptor.Edge(
-                tenant = "test_tenant",
-                database = "test_database",
-                table = "test_table",
-                schema =
-                    ModelSchema.Edge(
-                        source =
-                            Field(
-                                type = PrimitiveType.LONG,
-                                comment = "Source node ID",
-                            ),
-                        target =
-                            Field(
-                                type = PrimitiveType.LONG,
-                                comment = "Target node ID",
-                            ),
-                        properties =
-                            listOf(
-                                StructField(name = "id", type = PrimitiveType.LONG, comment = "Identifier", nullable = false),
-                                StructField(name = "name", type = PrimitiveType.STRING, comment = "name", nullable = false),
-                            ),
-                        direction = DirectionType.BOTH,
-                        groups =
-                            listOf(
-                                Group(
-                                    group = "by_day",
-                                    type = GroupType.COUNT,
-                                    fields =
-                                        listOf(
-                                            Group.Field(name = "version", bucket = Bucket.Date("date_id", Bucket.ValueUnit.MILLISECOND, "+09:00", "yyyy-MM-dd")),
-                                        ),
-                                    comment = "group by day",
-                                ),
-                            ),
-                        indexes =
-                            listOf(
-                                Index(
-                                    index = "updated_at_desc",
-                                    fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                                    comment = "recent updates",
-                                ),
-                            ),
-                    ),
-                mode = MutationMode.SYNC,
-                storage = "datastore://test_namespace/test_tenant:test_table",
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(edgeTableDescriptor)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "type": "edge",
+              "tenant": "test_tenant",
+              "database": "test_database",
+              "table": "test_table",
+              "schema": {
+                "type": "edge",
+                "source": {"type": "long", "comment": "Source node ID"},
+                "target": {"type": "long", "comment": "Target node ID"},
+                "properties": [
+                  {"name": "id", "type": "long", "comment": "Identifier", "nullable": false},
+                  {"name": "name", "type": "string", "comment": "name", "nullable": false}
+                ],
+                "direction": "BOTH",
+                "groups": [
+                  {
+                    "group": "by_day",
+                    "type": "COUNT",
+                    "fields": [
+                      {
+                        "name": "version",
+                        "bucket": {
+                          "type": "date",
+                          "name": "date_id",
+                          "unit": "MILLISECOND",
+                          "timezone": "+09:00",
+                          "format": "yyyy-MM-dd"
+                        }
+                      }
+                    ],
+                    "comment": "group by day"
+                  }
+                ],
+                "indexes": [
+                  {
+                    "index": "updated_at_desc",
+                    "fields": [{"field": "version", "order": "DESC"}],
+                    "comment": "recent updates"
+                  }
+                ]
+              },
+              "mode": "SYNC",
+              "storage": "datastore://test_namespace/test_tenant:test_table"
+            }
+          expected: |-
             {
               "type": "edge",
               "tenant": "test_tenant",
@@ -148,15 +128,19 @@ class TableSerializationTest {
               "updatedAt": -1,
               "updatedBy": ""
             }
-            """.trimIndent()
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes edge table to JSON`(
+        descriptor: TableDescriptor<*>,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test edge table deserialization`() {
-        // given
-        val json =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: |-
             {
               "type": "edge",
               "tenant": "test_tenant",
@@ -211,59 +195,56 @@ class TableSerializationTest {
               "mode": "SYNC",
               "storage": "datastore://test_namespace/test_tenant:test_table"
             }
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<TableDescriptor<*>>(json)
-
-        // then
-        val expected =
-            TableDescriptor.Edge(
-                tenant = "test_tenant",
-                database = "test_database",
-                table = "test_table",
-                schema =
-                    ModelSchema.Edge(
-                        source =
-                            Field(
-                                type = PrimitiveType.LONG,
-                                comment = "Source node ID",
-                            ),
-                        target =
-                            Field(
-                                type = PrimitiveType.LONG,
-                                comment = "Target node ID",
-                            ),
-                        properties =
-                            listOf(
-                                StructField(name = "id", type = PrimitiveType.LONG, comment = "Identifier", nullable = false),
-                                StructField(name = "name", type = PrimitiveType.STRING, comment = "name", nullable = false),
-                            ),
-                        direction = DirectionType.BOTH,
-                        groups =
-                            listOf(
-                                Group(
-                                    group = "by_day",
-                                    type = GroupType.COUNT,
-                                    fields =
-                                        listOf(
-                                            Group.Field(name = "version", bucket = Bucket.Date("date_id", Bucket.ValueUnit.MILLISECOND, "+09:00", "yyyy-MM-dd")),
-                                        ),
-                                    comment = "group by day",
-                                ),
-                            ),
-                        indexes =
-                            listOf(
-                                Index(
-                                    index = "updated_at_desc",
-                                    fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                                    comment = "recent updates",
-                                ),
-                            ),
-                    ),
-                mode = MutationMode.SYNC,
-                storage = "datastore://test_namespace/test_tenant:test_table",
-            )
-        assertEquals(expected, actual)
+          expected: {
+              "type": "edge",
+              "tenant": "test_tenant",
+              "database": "test_database",
+              "table": "test_table",
+              "schema": {
+                "type": "edge",
+                "source": {"type": "long", "comment": "Source node ID"},
+                "target": {"type": "long", "comment": "Target node ID"},
+                "properties": [
+                  {"name": "id", "type": "long", "comment": "Identifier", "nullable": false},
+                  {"name": "name", "type": "string", "comment": "name", "nullable": false}
+                ],
+                "direction": "BOTH",
+                "groups": [
+                  {
+                    "group": "by_day",
+                    "type": "COUNT",
+                    "fields": [
+                      {
+                        "name": "version",
+                        "bucket": {
+                          "type": "date",
+                          "name": "date_id",
+                          "unit": "MILLISECOND",
+                          "timezone": "+09:00",
+                          "format": "yyyy-MM-dd"
+                        }
+                      }
+                    ],
+                    "comment": "group by day"
+                  }
+                ],
+                "indexes": [
+                  {
+                    "index": "updated_at_desc",
+                    "fields": [{"field": "version", "order": "DESC"}],
+                    "comment": "recent updates"
+                  }
+                ]
+              },
+              "mode": "SYNC",
+              "storage": "datastore://test_namespace/test_tenant:test_table"
+            }
+        """,
+    )
+    fun `deserializes edge table from JSON`(
+        input: String,
+        expected: TableDescriptor<*>,
+    ) {
+        assertEquals(expected, objectMapper.readValue<TableDescriptor<*>>(input))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -1,25 +1,23 @@
 package com.kakao.actionbase.core.metadata.common
 
-import com.kakao.actionbase.core.java.codec.common.hbase.Order
-import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.assertEquals
 
-import org.junit.jupiter.api.Test
-
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class EdgeSchemaSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `deserialize struct type`() {
-        // given
-        val schemaJson =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - name: struct type
+          input: |-
             {
               "type": "edge",
               "source": {"type": "long", "comment": "Source node ID"},
@@ -48,39 +46,26 @@ class EdgeSchemaSerializationTest {
               ],
               "groups": []
             }
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<ModelSchema>(schemaJson)
-
-        // then
-        val expected =
-            ModelSchema.Edge(
-                source = Field(type = PrimitiveType.LONG, comment = "Source node ID"),
-                target = Field(type = PrimitiveType.LONG, comment = "Target node ID"),
-                properties =
-                    listOf(
-                        StructField(name = "id", type = PrimitiveType.LONG, comment = "Identifier", nullable = false),
-                        StructField(name = "name", type = PrimitiveType.STRING, comment = "name", nullable = false),
-                    ),
-                direction = DirectionType.BOTH,
-                groups = emptyList(),
-                indexes =
-                    listOf(
-                        Index(
-                            index = "updated_at_desc",
-                            fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                            comment = "recent updates",
-                        ),
-                    ),
-            )
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `deserialize edge schema with caches`() {
-        val schemaJson =
-            """
+          expected: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [
+                {"name": "id", "type": "long", "comment": "Identifier", "nullable": false},
+                {"name": "name", "type": "string", "comment": "name", "nullable": false}
+              ],
+              "direction": "BOTH",
+              "groups": [],
+              "indexes": [
+                {
+                  "index": "updated_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "comment": "recent updates"
+                }
+              ]
+            }
+        - name: with caches
+          input: |-
             {
               "type": "edge",
               "source": {"type": "long", "comment": "Source node ID"},
@@ -102,65 +87,58 @@ class EdgeSchemaSerializationTest {
                 }
               ]
             }
-            """.trimIndent()
-
-        val actual = objectMapper.readValue<ModelSchema>(schemaJson)
-
-        val expected =
-            ModelSchema.Edge(
-                source = Field(type = PrimitiveType.LONG, comment = "Source node ID"),
-                target = Field(type = PrimitiveType.LONG, comment = "Target node ID"),
-                properties = emptyList(),
-                direction = DirectionType.OUT,
-                indexes =
-                    listOf(
-                        Index(
-                            index = "created_at_desc",
-                            fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                        ),
-                    ),
-                caches =
-                    listOf(
-                        Cache(
-                            cache = "created_at_desc",
-                            fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                            limit = 1,
-                        ),
-                    ),
-            )
-        assertEquals(expected, actual)
+          expected: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "indexes": [
+                {
+                  "index": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}]
+                }
+              ],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "limit": 1
+                }
+              ]
+            }
+        """,
+    )
+    fun `deserializes edge schema from JSON`(
+        name: String,
+        input: String,
+        expected: ModelSchema,
+    ) {
+        assertEquals(expected, objectMapper.readValue<ModelSchema>(input))
     }
 
-    @Test
-    fun `serialize edge schema`() {
-        // given
-        val edgeSchema =
-            ModelSchema.Edge(
-                source = Field(type = PrimitiveType.LONG, comment = "Source node ID"),
-                target = Field(type = PrimitiveType.LONG, comment = "Target node ID"),
-                properties =
-                    listOf(
-                        StructField(name = "id", type = PrimitiveType.LONG, comment = "Identifier", nullable = false),
-                        StructField(name = "name", type = PrimitiveType.STRING, comment = "name", nullable = false),
-                    ),
-                direction = DirectionType.BOTH,
-                groups = emptyList(),
-                indexes =
-                    listOf(
-                        Index(
-                            index = "updated_at_desc",
-                            fields = listOf(IndexField(field = "version", order = Order.DESC)),
-                            comment = "recent updates",
-                        ),
-                    ),
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(edgeSchema)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - schema: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [
+                {"name": "id", "type": "long", "comment": "Identifier", "nullable": false},
+                {"name": "name", "type": "string", "comment": "name", "nullable": false}
+              ],
+              "direction": "BOTH",
+              "groups": [],
+              "indexes": [
+                {
+                  "index": "updated_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "comment": "recent updates"
+                }
+              ]
+            }
+          expected: |-
             {
               "type": "edge",
               "source": {"type": "long", "comment": "Source node ID"},
@@ -192,7 +170,12 @@ class EdgeSchemaSerializationTest {
               "groups": [],
               "caches": []
             }
-            """.trimIndent()
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes edge schema to JSON`(
+        schema: ModelSchema,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(schema))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2AliasSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2AliasSerializationTest.kt
@@ -2,6 +2,8 @@ package com.kakao.actionbase.core.v2.metadata
 
 import com.kakao.actionbase.core.metadata.AliasDescriptor as V3AliasDescriptor
 
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.Ignore
@@ -11,42 +13,39 @@ import kotlin.test.assertEquals
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class V2AliasSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test service serialization`() {
-        // given
-        val v2AliasDescriptor =
-            V2AliasDescriptor(
-                name = "gift.gift_like_product_v1",
-                desc = "Gift Wish",
-                active = true,
-                target = "gift.gift_like_product_v1_20240605_102816",
-            )
-        // when
-        val actual = prettyWriter.writeValueAsString(v2AliasDescriptor)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "name": "gift.gift_like_product_v1",
+              "desc": "Gift Wish",
+              "active": true,
+              "target": "gift.gift_like_product_v1_20240605_102816"
+            }
+          expected: |-
             {
               "name": "gift.gift_like_product_v1",
               "target": "gift.gift_like_product_v1_20240605_102816",
               "desc": "Gift Wish",
               "active": true
             }
-            """.trimIndent()
-
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: V2AliasDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test alias deserialization`() {
-        // given
-        val json =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: |-
             {
               "active": true,
               "name": "gift.gift_like_product_v1",
@@ -58,52 +57,46 @@ class V2AliasSerializationTest {
                 "desc": "some redundant label information"
               }
             }
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<V2AliasDescriptor>(json)
-
-        // then
-        val expected =
-            V2AliasDescriptor(
-                name = "gift.gift_like_product_v1",
-                desc = "Gift Wish",
-                active = true,
-                target = "gift.gift_like_product_v1_20240605_102816",
-            )
-        assertEquals(expected, actual)
+          expected: {
+              "name": "gift.gift_like_product_v1",
+              "desc": "Gift Wish",
+              "active": true,
+              "target": "gift.gift_like_product_v1_20240605_102816"
+            }
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: V2AliasDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<V2AliasDescriptor>(input))
     }
 
-    @Test
-    fun `test service to v3 object`() {
-        // given
-        val v2AliasDescriptor =
-            V2AliasDescriptor(
-                name = "gift.gift_like_product_v1",
-                desc = "Gift Wish",
-                active = true,
-                target = "gift.gift_like_product_v1_20240605_102816",
-            )
-
-        // when
-        val actual = v2AliasDescriptor.toV3("test_tenant")
-
-        // then
-        val expected =
-            V3AliasDescriptor(
-                tenant = "test_tenant",
-                database = "gift",
-                alias = "gift_like_product_v1",
-                table = "gift_like_product_v1_20240605_102816",
-                comment = "Gift Wish",
-                active = true,
-                revision = -1,
-                createdAt = -1,
-                createdBy = "",
-                updatedAt = -1,
-                updatedBy = "",
-            )
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - tenant: test_tenant
+          descriptor: {
+              "name": "gift.gift_like_product_v1",
+              "desc": "Gift Wish",
+              "active": true,
+              "target": "gift.gift_like_product_v1_20240605_102816"
+            }
+          expected: {
+              "tenant": "test_tenant",
+              "database": "gift",
+              "alias": "gift_like_product_v1",
+              "table": "gift_like_product_v1_20240605_102816",
+              "comment": "Gift Wish"
+            }
+        """,
+    )
+    fun `converts to V3 object`(
+        tenant: String,
+        descriptor: V2AliasDescriptor,
+        expected: V3AliasDescriptor,
+    ) {
+        assertEquals(expected, descriptor.toV3(tenant))
     }
 
     @Ignore

--- a/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2LabelSerializationTest.kt
@@ -1,101 +1,58 @@
 package com.kakao.actionbase.core.v2.metadata
 
-import com.kakao.actionbase.core.java.codec.common.hbase.Order
-import com.kakao.actionbase.core.metadata.common.DirectionType
-import com.kakao.actionbase.core.v2.metadata.common.V2Field
-import com.kakao.actionbase.core.v2.metadata.common.V2Index
-import com.kakao.actionbase.core.v2.metadata.common.V2IndexField
-import com.kakao.actionbase.core.v2.metadata.common.V2MutationMode
-import com.kakao.actionbase.core.v2.metadata.common.V2Schema
-import com.kakao.actionbase.core.v2.metadata.common.V2StructField
-import com.kakao.actionbase.core.v2.types.V2PrimitiveType
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class V2LabelSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test service serialization`() {
-        // given
-        val v2LabelDescriptor =
-            V2LabelDescriptor(
-                name = "gift.gift_like_product_v1_20240605_102816",
-                desc = "Gift wish / gift_like_product_v1_20240521_185845",
-                active = true,
-                type = "INDEXED",
-                schema =
-                    V2Schema(
-                        src =
-                            V2Field(
-                                type = V2PrimitiveType.LONG,
-                                desc = "Commerce user ID (cuid)",
-                            ),
-                        tgt =
-                            V2Field(
-                                type = V2PrimitiveType.LONG,
-                                desc = "Gift product ID (product_id)",
-                            ),
-                        fields =
-                            listOf(
-                                V2StructField(
-                                    name = "createdAt",
-                                    type = V2PrimitiveType.LONG,
-                                    nullable = false,
-                                    desc = "Creation time={system.currentTimeMillis()}",
-                                ),
-                                V2StructField(
-                                    name = "permission",
-                                    type = V2PrimitiveType.STRING,
-                                    nullable = false,
-                                    desc = "View permission={me | others}",
-                                ),
-                                V2StructField(
-                                    name = "receivedFrom",
-                                    type = V2PrimitiveType.STRING,
-                                    nullable = false,
-                                    desc = "Source after successful order???={me | others | not_received}",
-                                ),
-                            ),
-                    ),
-                dirType = DirectionType.BOTH,
-                storage = "st3_gift_like_product_v1_20240605_102816",
-                indices =
-                    listOf(
-                        V2Index(
-                            name = "permission_created_at_desc",
-                            fields =
-                                listOf(
-                                    V2IndexField(name = "permission", order = Order.ASC),
-                                    V2IndexField(name = "createdAt", order = Order.DESC),
-                                ),
-                            desc = "Wish permission/creation time descending index",
-                        ),
-                        V2Index(
-                            name = "created_at_desc",
-                            fields =
-                                listOf(V2IndexField(name = "createdAt", order = Order.DESC)),
-                            desc = "Wish creation time descending index",
-                        ),
-                    ),
-                groups = emptyList(),
-                event = false,
-                readOnly = false,
-                mode = V2MutationMode.SYNC,
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(v2LabelDescriptor)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "active": true,
+              "name": "gift.gift_like_product_v1_20240605_102816",
+              "desc": "Gift wish / gift_like_product_v1_20240521_185845",
+              "type": "INDEXED",
+              "schema": {
+                "src": {"type": "LONG", "desc": "Commerce user ID (cuid)"},
+                "tgt": {"type": "LONG", "desc": "Gift product ID (product_id)"},
+                "fields": [
+                  {"name": "createdAt", "type": "LONG", "nullable": false, "desc": "Creation time={system.currentTimeMillis()}"},
+                  {"name": "permission", "type": "STRING", "nullable": false, "desc": "View permission={me | others}"},
+                  {"name": "receivedFrom", "type": "STRING", "nullable": false, "desc": "Source after successful order???={me | others | not_received}"}
+                ]
+              },
+              "dirType": "BOTH",
+              "storage": "st3_gift_like_product_v1_20240605_102816",
+              "indices": [
+                {
+                  "name": "permission_created_at_desc",
+                  "fields": [
+                    {"name": "permission", "order": "ASC"},
+                    {"name": "createdAt", "order": "DESC"}
+                  ],
+                  "desc": "Wish permission/creation time descending index"
+                },
+                {
+                  "name": "created_at_desc",
+                  "fields": [{"name": "createdAt", "order": "DESC"}],
+                  "desc": "Wish creation time descending index"
+                }
+              ],
+              "groups": [],
+              "event": false,
+              "readOnly": false,
+              "mode": "SYNC"
+            }
+          expected: |-
             {
               "active": true,
               "name": "gift.gift_like_product_v1_20240605_102816",
@@ -147,16 +104,19 @@ class V2LabelSerializationTest {
               "readOnly": false,
               "mode": "SYNC"
             }
-            """.trimIndent()
-
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: V2LabelDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test label deserialization`() {
-        // given
-        val json =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: |-
             {
               "active": true,
               "name": "gift.gift_like_product_v1_20240605_102816",
@@ -198,25 +158,14 @@ class V2LabelSerializationTest {
                 {
                   "name": "permission_created_at_desc",
                   "fields": [
-                    {
-                      "name": "permission",
-                      "order": "ASC"
-                    },
-                    {
-                      "name": "createdAt",
-                      "order": "DESC"
-                    }
+                    {"name": "permission", "order": "ASC"},
+                    {"name": "createdAt", "order": "DESC"}
                   ],
                   "desc": "Wish permission/creation time descending index"
                 },
                 {
                   "name": "created_at_desc",
-                  "fields": [
-                    {
-                      "name": "createdAt",
-                      "order": "DESC"
-                    }
-                  ],
+                  "fields": [{"name": "createdAt", "order": "DESC"}],
                   "desc": "Wish creation time descending index"
                 }
               ],
@@ -225,77 +174,48 @@ class V2LabelSerializationTest {
               "readOnly": false,
               "mode": "SYNC"
             }
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<V2LabelDescriptor>(json)
-
-        // then
-        val expected =
-            V2LabelDescriptor(
-                name = "gift.gift_like_product_v1_20240605_102816",
-                desc = "Gift wish / gift_like_product_v1_20240521_185845",
-                active = true,
-                type = "INDEXED",
-                schema =
-                    V2Schema(
-                        src =
-                            V2Field(
-                                type = V2PrimitiveType.LONG,
-                                desc = "Commerce user ID (cuid)",
-                            ),
-                        tgt =
-                            V2Field(
-                                type = V2PrimitiveType.LONG,
-                                desc = "Gift product ID (product_id)",
-                            ),
-                        fields =
-                            listOf(
-                                V2StructField(
-                                    name = "createdAt",
-                                    type = V2PrimitiveType.LONG,
-                                    nullable = false,
-                                    desc = "Creation time={system.currentTimeMillis()}",
-                                ),
-                                V2StructField(
-                                    name = "permission",
-                                    type = V2PrimitiveType.STRING,
-                                    nullable = false,
-                                    desc = "View permission={me | others}",
-                                ),
-                                V2StructField(
-                                    name = "receivedFrom",
-                                    type = V2PrimitiveType.STRING,
-                                    nullable = false,
-                                    desc = "Source after successful order???={me | others | not_received}",
-                                ),
-                            ),
-                    ),
-                dirType = DirectionType.BOTH,
-                storage = "st3_gift_like_product_v1_20240605_102816",
-                indices =
-                    listOf(
-                        V2Index(
-                            name = "permission_created_at_desc",
-                            fields =
-                                listOf(
-                                    V2IndexField(name = "permission", order = Order.ASC),
-                                    V2IndexField(name = "createdAt", order = Order.DESC),
-                                ),
-                            desc = "Wish permission/creation time descending index",
-                        ),
-                        V2Index(
-                            name = "created_at_desc",
-                            fields =
-                                listOf(V2IndexField(name = "createdAt", order = Order.DESC)),
-                            desc = "Wish creation time descending index",
-                        ),
-                    ),
-                groups = emptyList(),
-                event = false,
-                readOnly = false,
-                mode = V2MutationMode.SYNC,
-            )
-        assertEquals(expected, actual)
+          expected: {
+              "active": true,
+              "name": "gift.gift_like_product_v1_20240605_102816",
+              "desc": "Gift wish / gift_like_product_v1_20240521_185845",
+              "type": "INDEXED",
+              "schema": {
+                "src": {"type": "LONG", "desc": "Commerce user ID (cuid)"},
+                "tgt": {"type": "LONG", "desc": "Gift product ID (product_id)"},
+                "fields": [
+                  {"name": "createdAt", "type": "LONG", "nullable": false, "desc": "Creation time={system.currentTimeMillis()}"},
+                  {"name": "permission", "type": "STRING", "nullable": false, "desc": "View permission={me | others}"},
+                  {"name": "receivedFrom", "type": "STRING", "nullable": false, "desc": "Source after successful order???={me | others | not_received}"}
+                ]
+              },
+              "dirType": "BOTH",
+              "storage": "st3_gift_like_product_v1_20240605_102816",
+              "indices": [
+                {
+                  "name": "permission_created_at_desc",
+                  "fields": [
+                    {"name": "permission", "order": "ASC"},
+                    {"name": "createdAt", "order": "DESC"}
+                  ],
+                  "desc": "Wish permission/creation time descending index"
+                },
+                {
+                  "name": "created_at_desc",
+                  "fields": [{"name": "createdAt", "order": "DESC"}],
+                  "desc": "Wish creation time descending index"
+                }
+              ],
+              "groups": [],
+              "event": false,
+              "readOnly": false,
+              "mode": "SYNC"
+            }
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: V2LabelDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<V2LabelDescriptor>(input))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2ServiceSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2ServiceSerializationTest.kt
@@ -3,74 +3,71 @@ package com.kakao.actionbase.core.v2.metadata
 import com.kakao.actionbase.core.metadata.DatabaseDescriptor
 import com.kakao.actionbase.core.metadata.payload.DatabaseCreateRequest
 import com.kakao.actionbase.core.metadata.payload.DatabaseUpdateRequest
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.Ignore
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class V2ServiceSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test service serialization`() {
-        // given
-        val v2ServiceDescriptor = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-
-        // when
-        val actual = prettyWriter.writeValueAsString(v2ServiceDescriptor)
-
-        // then
-        val expected =
-            """{"name": "gift", "desc": "Gift", "active": true}"""
-
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {"name": "gift", "desc": "Gift", "active": true}
+          expected: '{"name": "gift", "desc": "Gift", "active": true}'
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: V2ServiceDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
     @Ignore
-    @Test
-    fun `test service deserialization`() {
-        // given
-        val json =
-            """{"active": true, "name": "gift", "desc": "Gift"}"""
-
-        // when
-        val actual = objectMapper.readValue<V2ServiceDescriptor>(json)
-
-        // then
-        val expected = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: '{"active": true, "name": "gift", "desc": "Gift"}'
+          expected: {"name": "gift", "desc": "Gift", "active": true}
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: V2ServiceDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<V2ServiceDescriptor>(input))
     }
 
-    @Test
-    fun `test service to database object`() {
-        // given
-        val v2ServiceDescriptor = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-
-        // when
-        val actual = v2ServiceDescriptor.toV3("test_tenant")
-
-        // then
-        val expected = DatabaseDescriptor(tenant = "test_tenant", database = "gift", comment = "Gift", active = true)
-        assertEquals(expected, actual)
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - tenant: test_tenant
+          descriptor: {"name": "gift", "desc": "Gift", "active": true}
+          expected: {"tenant": "test_tenant", "database": "gift", "comment": "Gift", "active": true}
+        """,
+    )
+    fun `converts to V3 database object`(
+        tenant: String,
+        descriptor: V2ServiceDescriptor,
+        expected: DatabaseDescriptor,
+    ) {
+        assertEquals(expected, descriptor.toV3(tenant))
     }
 
-    @Test
-    fun `test service to database json string`() {
-        // given
-        val v2ServiceDescriptor = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-
-        // when
-        val v3 = v2ServiceDescriptor.toV3("test_tenant")
-        val actual = prettyWriter.writeValueAsString(v3)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - tenant: test_tenant
+          descriptor: {"name": "gift", "desc": "Gift", "active": true}
+          expected: |-
             {
               "tenant": "test_tenant",
               "database": "gift",
@@ -82,36 +79,50 @@ class V2ServiceSerializationTest {
               "updatedAt": -1,
               "updatedBy": ""
             }
-            """.trimIndent()
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes V3 database object to JSON`(
+        tenant: String,
+        descriptor: V2ServiceDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor.toV3(tenant)))
     }
 
-    @Test
-    fun `test service to database create request`() {
-        // given
-        val v2ServiceDescriptor = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-
-        // when
-        val actual = v2ServiceDescriptor.toV3("test_tenant").toCreateRequest()
-
-        // then
-        val expected = DatabaseCreateRequest(database = "gift", comment = "Gift")
-
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - tenant: test_tenant
+          descriptor: {"name": "gift", "desc": "Gift", "active": true}
+          expected: {"database": "gift", "comment": "Gift"}
+        """,
+    )
+    fun `produces V3 create request`(
+        tenant: String,
+        descriptor: V2ServiceDescriptor,
+        expected: DatabaseCreateRequest,
+    ) {
+        // version is generated from currentTimeMillis(); normalize before comparing
+        val actual = descriptor.toV3(tenant).toCreateRequest()
         val sameVersion = 0L
         assertEquals(expected.copy(version = sameVersion), actual.copy(version = sameVersion))
     }
 
-    @Test
-    fun `test service to database update request`() {
-        // given
-        val v2ServiceDescriptor = V2ServiceDescriptor(name = "gift", desc = "Gift", active = true)
-
-        // when
-        val actual = v2ServiceDescriptor.toV3("test_tenant").toUpdateRequest()
-
-        // then
-        val expected = DatabaseUpdateRequest(active = true, comment = "Gift")
-
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - tenant: test_tenant
+          descriptor: {"name": "gift", "desc": "Gift", "active": true}
+          expected: {"active": true, "comment": "Gift"}
+        """,
+    )
+    fun `produces V3 update request`(
+        tenant: String,
+        descriptor: V2ServiceDescriptor,
+        expected: DatabaseUpdateRequest,
+    ) {
+        // version is generated from currentTimeMillis(); normalize before comparing
+        val actual = descriptor.toV3(tenant).toUpdateRequest()
         val sameVersion = 0L
         assertEquals(expected.copy(version = sameVersion), actual.copy(version = sameVersion))
     }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2StorageSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/v2/metadata/V2StorageSerializationTest.kt
@@ -1,39 +1,32 @@
 package com.kakao.actionbase.core.v2.metadata
 
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
-import kotlin.test.Test
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
 class V2StorageSerializationTest {
-    val prettyWriter = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
 
-    @Test
-    fun `test storage serialization`() {
-        // given
-        val v2StorageDescriptor =
-            V2StorageDescriptor(
-                type = "HBASE",
-                name = "st3_talkstore_view_product_v1_20240730_231948",
-                desc = "Shopping recently viewed products",
-                active = true,
-                conf =
-                    mapOf(
-                        "namespace" to "kc_graph",
-                        "tableName" to "st3_talkstore_view_product_v1_20240730_231948",
-                    ),
-            )
-
-        // when
-        val actual = prettyWriter.writeValueAsString(v2StorageDescriptor)
-
-        // then
-        val expected =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - descriptor: {
+              "type": "HBASE",
+              "name": "st3_talkstore_view_product_v1_20240730_231948",
+              "desc": "Shopping recently viewed products",
+              "active": true,
+              "conf": {
+                "namespace": "kc_graph",
+                "tableName": "st3_talkstore_view_product_v1_20240730_231948"
+              }
+            }
+          expected: |-
             {
               "type": "HBASE",
               "name": "st3_talkstore_view_product_v1_20240730_231948",
@@ -44,16 +37,19 @@ class V2StorageSerializationTest {
                 "tableName": "st3_talkstore_view_product_v1_20240730_231948"
               }
             }
-            """.trimIndent()
-
-        assertEquals(expected, actual)
+        """,
+    )
+    fun `serializes to JSON`(
+        descriptor: V2StorageDescriptor,
+        expected: String,
+    ) {
+        assertEquals(expected, prettyWriter.writeValueAsString(descriptor))
     }
 
-    @Test
-    fun `test storage deserialization`() {
-        // given
-        val json =
-            """
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - input: |-
             {
               "active": true,
               "name": "st3_talkstore_view_product_v1_20240730_231948",
@@ -64,24 +60,22 @@ class V2StorageSerializationTest {
                 "tableName": "st3_talkstore_view_product_v1_20240730_231948"
               }
             }
-            """.trimIndent()
-
-        // when
-        val actual = objectMapper.readValue<V2StorageDescriptor>(json)
-
-        // then
-        val expected =
-            V2StorageDescriptor(
-                type = "HBASE",
-                name = "st3_talkstore_view_product_v1_20240730_231948",
-                desc = "Shopping recently viewed products",
-                active = true,
-                conf =
-                    mapOf(
-                        "namespace" to "kc_graph",
-                        "tableName" to "st3_talkstore_view_product_v1_20240730_231948",
-                    ),
-            )
-        assertEquals(expected, actual)
+          expected: {
+              "type": "HBASE",
+              "name": "st3_talkstore_view_product_v1_20240730_231948",
+              "desc": "Shopping recently viewed products",
+              "active": true,
+              "conf": {
+                "namespace": "kc_graph",
+                "tableName": "st3_talkstore_view_product_v1_20240730_231948"
+              }
+            }
+        """,
+    )
+    fun `deserializes from JSON`(
+        input: String,
+        expected: V2StorageDescriptor,
+    ) {
+        assertEquals(expected, objectMapper.readValue<V2StorageDescriptor>(input))
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/test/json/PrettyObjectWriterTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/test/json/PrettyObjectWriterTest.kt
@@ -1,12 +1,15 @@
 package com.kakao.actionbase.test.json
 
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.test.documentations.params.TableSource
+
 import kotlin.test.assertEquals
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class PrettyObjectWriterTest {
-    private val writer = PrettyObjectWriter(indentSize = 2, lineLengthLimit = 80)
+    private val writer = PrettyObjectWriter.DEFAULT
 
     @Test
     fun `test empty object and array`() {
@@ -104,66 +107,41 @@ class PrettyObjectWriterTest {
         assertEquals(expected, actual)
     }
 
-    @Test
-    fun `test format sort=false`() {
-        // given
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        #   sort | expected
+        - 'false | {"z": 1, "a": 2, "m": 3}'
+        - 'true  | {"a": 2, "m": 3, "z": 1}'
+        """,
+    )
+    fun `format honors sort flag`(
+        sort: Boolean,
+        expected: String,
+    ) {
         val json = """{"z": 1, "a": 2, "m": 3}"""
-
-        // when
-        val actual = writer.format(json, sort = false)
-
-        // then
-        val expected = """{"z": 1, "a": 2, "m": 3}"""
-        assertEquals(expected, actual)
+        assertEquals(expected, writer.format(json, sort = sort))
     }
 
-    @Test
-    fun `test format sort=true`() {
-        // given
-        val json = """{"z": 1, "a": 2, "m": 3}"""
-
-        // when
-        val actual = writer.format(json, sort = true)
-
-        // then
-        val expected = """{"a": 2, "m": 3, "z": 1}"""
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `test writeValueAsString sort=false`() {
-        // given
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        #   sort | expected
+        - 'false | {"z": 1, "a": 2, "m": 3}'
+        - 'true  | {"a": 2, "m": 3, "z": 1}'
+        """,
+    )
+    fun `writeValueAsString honors sort flag`(
+        sort: Boolean,
+        expected: String,
+    ) {
         val orderedMap =
             mapOf(
                 "z" to 1,
                 "a" to 2,
                 "m" to 3,
             )
-
-        // when
-        val actual = writer.writeValueAsString(orderedMap, sort = false)
-
-        // then
-        val expected = """{"z": 1, "a": 2, "m": 3}"""
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `test writeValueAsString sort=true`() {
-        // given
-        val orderedMap =
-            mapOf(
-                "z" to 1,
-                "a" to 2,
-                "m" to 3,
-            )
-
-        // when
-        val actual = writer.writeValueAsString(orderedMap, sort = true)
-
-        // then
-        val expected = """{"a": 2, "m": 3, "z": 1}"""
-        assertEquals(expected, actual)
+        assertEquals(expected, writer.writeValueAsString(orderedMap, sort = sort))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Phase 2 of #271. Migrate the genuinely data-driven `core` tests; document why six files stay as `@Test`.

Refs #271

## Changes

- **Migrated**: 8 SerializationTests (Database, Datastore, Table, EdgeSchema, V2Alias, V2Label, V2Service, V2Storage) + AliasSerializationTest pilot reformatted; `EdgeMutationStrategyTest` (15 → 15, 4 `@Nested` matrices → 4 `@TableSource`); `PrettyObjectWriterTest` `sort=true/false` pairs only.
- **Conventions**: JSON-flow YAML for descriptor / expected objects (they travel as JSON); `PrettyObjectWriter.DEFAULT` replaces the repeated constructor (#291 finding); pipe rows containing `:` are single-quoted to keep YAML from reading them as flow mappings.
- **Kept as `@Test`** (added to #271 with reasons): `KotlinCoreJvmRuntimeTest`, `ApiTestExtensionsTest`, `EdgeBulkMutationRequestTest` (single-scenario, not data-driven); `EdgeMutationBuilderTest`, `EdgeCacheRecordMapperTest`, `V2MultiEdgeBulkLoadTest` (heterogeneous assertion shapes per case).

## How to Test

```bash
./gradlew :core:test
./gradlew spotlessKotlinCheck
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code with Claude Opus 4.7 (1M context)
