### PR TITLE
Route HBase HASH labels through the V3 tableBinding path

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
@@ -17,7 +17,7 @@ import com.kakao.actionbase.v2.engine.entity.deprecated.DeprecatedEdgeSchema
 import com.kakao.actionbase.v2.engine.label.DatastoreHashLabel
 import com.kakao.actionbase.v2.engine.label.DatastoreIndexedLabel
 import com.kakao.actionbase.v2.engine.label.Label
-import com.kakao.actionbase.v2.engine.label.hbase.HBaseHashLabel
+import com.kakao.actionbase.v2.engine.label.hbase.HBaseHashOnlyIndexedLabel
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.label.metastore.JdbcHashLabel
 import com.kakao.actionbase.v2.engine.label.metastore.LocalBackedJdbcHashLabel
@@ -79,7 +79,7 @@ data class LabelEntity(
                     when (storage) {
                         is LocalStorage -> LocalBackedJdbcHashLabel.create(this, graph, storage, block)
                         is JdbcStorage -> JdbcHashLabel.create(this, graph, storage, block)
-                        is HBaseStorage -> HBaseHashLabel.create(this, graph, storage)
+                        is HBaseStorage -> HBaseHashOnlyIndexedLabel.create(this, graph, storage)
                         is DatastoreStorage -> DatastoreHashLabel.create(this, graph, block)
                         else -> {
                             logger.error(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashOnlyIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashOnlyIndexedLabel.kt
@@ -1,0 +1,68 @@
+package com.kakao.actionbase.v2.engine.label.hbase
+
+import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
+import com.kakao.actionbase.v2.core.code.EdgeEncoder
+import com.kakao.actionbase.v2.core.code.IdEdgeEncoder
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.engine.GraphDefaults
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
+import com.kakao.actionbase.v2.engine.label.LabelFactory
+import com.kakao.actionbase.v2.engine.sql.DataFrame
+import com.kakao.actionbase.v2.engine.sql.ScanFilter
+import com.kakao.actionbase.v2.engine.sql.StatKey
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseStorage
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTables
+
+import reactor.core.publisher.Mono
+
+/** Hash label exposed as an IndexedLabel to keep the V3 transition simple. */
+class HBaseHashOnlyIndexedLabel(
+    entity: LabelEntity,
+    coder: EdgeEncoder<ByteArray>,
+    tables: Mono<HBaseTables>,
+    edgeRecordMapper: EdgeRecordMapper,
+    lockTimeout: Long,
+) : HBaseIndexedLabel(
+        entity = entity,
+        coder = coder,
+        indices = emptyList(),
+        indexNameToIndex = emptyMap(),
+        tables = tables,
+        edgeRecordMapper = edgeRecordMapper,
+        lockTimeout = lockTimeout,
+    ) {
+    override fun scan(
+        scanFilter: ScanFilter,
+        stats: Set<StatKey>,
+        idEdgeEncoder: IdEdgeEncoder,
+    ): Mono<DataFrame> = unsupported("scan")
+
+    override fun cache(
+        sources: List<Any>,
+        cacheName: String,
+        direction: Direction,
+        limit: Int,
+        offset: String?,
+    ): Mono<DataFrame> = unsupported("seek")
+
+    private fun unsupported(op: String): Mono<DataFrame> =
+        Mono.error(
+            UnsupportedOperationException("$op is not supported on HASH-type label '${entity.fullName}'"),
+        )
+
+    companion object : LabelFactory<HBaseHashOnlyIndexedLabel, HBaseStorage> {
+        override fun create(
+            entity: LabelEntity,
+            graph: GraphDefaults,
+            storage: HBaseStorage,
+            block: HBaseHashOnlyIndexedLabel.() -> Unit,
+        ): HBaseHashOnlyIndexedLabel =
+            HBaseHashOnlyIndexedLabel(
+                entity = entity,
+                coder = graph.edgeEncoderFactory.bytesKeyValueEncoder,
+                tables = storage.options.getTables(),
+                edgeRecordMapper = graph.edgeRecordMapper,
+                lockTimeout = graph.lockTimeout,
+            )
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/alias/AliasSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/alias/AliasSpec.kt
@@ -56,7 +56,7 @@ class AliasSpec :
         "query on alias" {
             val src = GraphFixtures.sampleEdges.first().src
             val aliasName = EntityName(GraphFixtures.serviceName, "alias_${Random.nextInt().absoluteValue}")
-            val targetLabelName = EntityName(GraphFixtures.serviceName, GraphFixtures.hbaseHash)
+            val targetLabelName = EntityName(GraphFixtures.serviceName, GraphFixtures.jdbcHash)
             graph.aliasDdl
                 .create(
                     aliasName,
@@ -76,7 +76,7 @@ class AliasSpec :
 
         "mutate on alias" {
             val aliasName = EntityName(GraphFixtures.serviceName, "alias_${Random.nextInt().absoluteValue}")
-            val targetLabelName = EntityName(GraphFixtures.serviceName, GraphFixtures.hbaseHash)
+            val targetLabelName = EntityName(GraphFixtures.serviceName, GraphFixtures.jdbcHash)
             graph.aliasDdl
                 .create(
                     aliasName,
@@ -119,7 +119,7 @@ class AliasSpec :
         "alias cannot be made if a label has a same name" {
             graph.aliasDdl
                 .create(
-                    EntityName(GraphFixtures.serviceName, GraphFixtures.hbaseHash),
+                    EntityName(GraphFixtures.serviceName, GraphFixtures.jdbcHash),
                     AliasCreateRequest("", "test.like_hbase_hash"),
                 ).test()
                 .verifyError(IllegalArgumentException::class.java)

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelSpec.kt
@@ -16,7 +16,6 @@ import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.cdc.CdcContext
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.entity.LabelEntity
-import com.kakao.actionbase.v2.engine.label.hbase.HBaseHashLabel
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.label.metastore.JdbcHashLabel
 import com.kakao.actionbase.v2.engine.metadata.StorageType
@@ -183,10 +182,6 @@ class LabelSpec :
                 .verifyComplete()
         }
 
-        "empty src scan test - hbase" {
-            testEmptySrcScan(hbase)
-        }
-
         "empty src scan test - jdbc" {
             testEmptySrcScan(jdbc)
         }
@@ -211,13 +206,6 @@ class LabelSpec :
                 .test()
                 .assertNext { it.rows.size shouldBe 6 }
                 .verifyComplete()
-        }
-
-        "scan ignore dirty data - hbase" {
-            scanIgnoreDirtyData(hbase) { label, edge ->
-                val kfv = (label as HBaseHashLabel).coder.encodeHashEdgeKey(edge, label.entity.id)
-                label.create(EncodedKey(kfv.key, kfv.field), "dirtyData".toByteArray()).block()
-            }
         }
 
         "scan ignore dirty data - hbase indexed" {


### PR DESCRIPTION
## Summary

To keep the V3 surface uniform during the V2→V3 transition, HASH-type HBase labels are now exposed as an `HBaseIndexedLabel` shape so they reach the V3 `tableBinding` path without per-label-type branching in `V2BackedEngine`. A small adapter, `HBaseHashOnlyIndexedLabel`, plays this role: empty indices/caches, with `scan` and `cache` explicitly blocked.

Closes #

## Changes

- Add `HBaseHashOnlyIndexedLabel` (HASH-only adapter on top of `HBaseIndexedLabel`). `scan` and `cache` throw an explicit "not supported on HASH-type label" error so callers get a clear signal instead of an "Index/Cache not found" fall-through.
- `LabelEntity.materialize`: HASH + HBaseStorage now materializes via `HBaseHashOnlyIndexedLabel.create`.
- Drop two V2 HBase hash-prefix scan tests in `LabelSpec` that exercised a path no longer used in production (`- hbase` variants only); JDBC and `- hbase indexed` variants are kept.
- `AliasSpec`: switch fixture from `hbaseHash` to `jdbcHash` so the alias-mechanism coverage stays intact (JDBC HASH still supports hash-prefix scan).

## How to Test

- `./gradlew :engine:test`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)