### PR TITLE
Add TypedKeyFieldValue and fix Cache.Field in `codec-java`

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/AbstractEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/AbstractEdgeEncoder.java
@@ -190,8 +190,8 @@ public abstract class AbstractEdgeEncoder<T> implements EdgeEncoder<T> {
       Object directedTgt,
       Map<String, Object> properties,
       EdgeBuffer buffer) {
-    for (Index.Field field : cache.getFields()) {
-      Object value = resolveFieldValue(field.getName(), ts, directedSrc, directedTgt, properties);
+    for (Cache.Field field : cache.getFields()) {
+      Object value = resolveFieldValue(field.getField(), ts, directedSrc, directedTgt, properties);
       buffer.encodeAny(value, field.getOrder());
     }
     buffer.encodeAny(directedTgt);

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -35,7 +35,7 @@ public class BulkEdgeEncoder {
   static final String SOURCE_FIELD_ON_STATE = "_source";
   static final String TARGET_FIELD_ON_STATE = "_target";
 
-  public static <T> List<KeyFieldValueV2<T>> bulkEncodeAll(
+  public static <T> List<TypedKeyFieldValue<T>> bulkEncodeAll(
       EdgeEncoder<T> encoder, BulkLoadEdge bulkLoadEdge, LabelDTO label) {
     LabelType labelType = label.getType();
 
@@ -45,7 +45,7 @@ public class BulkEdgeEncoder {
     Active active = bulkLoadEdge.isActive() ? Active.ACTIVE : Active.INACTIVE;
     Edge castedEdge = bulkLoadEdge.ensureType(label.getSchema());
 
-    List<KeyFieldValueV2<T>> edges = new ArrayList<>();
+    List<TypedKeyFieldValue<T>> edges = new ArrayList<>();
 
     // Special handling for MultiEdge
     // - Keep existing HASH, INDEXED as is, and for MultiEdge, create separate edges based on ID and
@@ -87,7 +87,7 @@ public class BulkEdgeEncoder {
                   edgeForEdgeState.getProps(),
                   insertTs,
                   deleteTs));
-      edges.add(new KeyFieldValueV2<>(EncodedEdgeType.HASH_EDGE_TYPE, key.key, key.field, value));
+      edges.add(new TypedKeyFieldValue<>(EncodedEdgeType.HASH_EDGE_TYPE, key.key, key.field, value));
     }
 
     List<Cache> caches = label.getCaches();
@@ -100,7 +100,7 @@ public class BulkEdgeEncoder {
             encoder
                 .encodeAllIndexedEdges(castedEdge, label.getDirType(), labelId, label.getIndices())
                 .stream()
-                .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                 .collect(Collectors.toList()));
 
         // Cache records are only supported on INDEXED labels (V3 EDGE type). V3 multi-hop queries
@@ -108,7 +108,7 @@ public class BulkEdgeEncoder {
         if (caches != null && !caches.isEmpty()) {
           edges.addAll(
               encoder.encodeAllCacheEdges(castedEdge, label.getDirType(), labelId, caches).stream()
-                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                  .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                   .collect(Collectors.toList()));
         }
       } else if (labelType == LabelType.MULTI_EDGE) {
@@ -122,24 +122,24 @@ public class BulkEdgeEncoder {
               encoder
                   .encodeAllIndexedEdges(outEdge, DirectionType.OUT, labelId, label.getIndices())
                   .stream()
-                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           edges.addAll(
               encoder
                   .encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
                   .stream()
-                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
                 encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches).stream()
-                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
             edges.addAll(
                 encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches).stream()
-                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
         } else if (label.getDirType() == DirectionType.OUT) {
@@ -149,13 +149,13 @@ public class BulkEdgeEncoder {
               encoder
                   .encodeAllIndexedEdges(outEdge, DirectionType.OUT, labelId, label.getIndices())
                   .stream()
-                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
                 encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches).stream()
-                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
         } else if (label.getDirType() == DirectionType.IN) {
@@ -165,13 +165,13 @@ public class BulkEdgeEncoder {
               encoder
                   .encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
                   .stream()
-                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
                 encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches).stream()
-                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .map(v -> TypedKeyFieldValue.from(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
         }
@@ -182,20 +182,20 @@ public class BulkEdgeEncoder {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
         edges.add(
-            new KeyFieldValueV2<>(
+            new TypedKeyFieldValue<>(
                 EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
         edges.add(
-            new KeyFieldValueV2<>(
+            new TypedKeyFieldValue<>(
                 EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       } else if (label.getDirType() == DirectionType.OUT) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
         edges.add(
-            new KeyFieldValueV2<>(
+            new TypedKeyFieldValue<>(
                 EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
       } else if (label.getDirType() == DirectionType.IN) {
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
         edges.add(
-            new KeyFieldValueV2<>(
+            new TypedKeyFieldValue<>(
                 EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       }
     }

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -2,7 +2,12 @@ package com.kakao.actionbase.v2.core.code;
 
 import com.kakao.actionbase.v2.core.edge.BulkLoadEdge;
 import com.kakao.actionbase.v2.core.edge.Edge;
-import com.kakao.actionbase.v2.core.metadata.*;
+import com.kakao.actionbase.v2.core.metadata.Active;
+import com.kakao.actionbase.v2.core.metadata.Direction;
+import com.kakao.actionbase.v2.core.metadata.DirectionType;
+import com.kakao.actionbase.v2.core.metadata.EncodedEdgeType;
+import com.kakao.actionbase.v2.core.metadata.LabelDTO;
+import com.kakao.actionbase.v2.core.metadata.LabelType;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -87,7 +87,8 @@ public class BulkEdgeEncoder {
                   edgeForEdgeState.getProps(),
                   insertTs,
                   deleteTs));
-      edges.add(new TypedKeyFieldValue<>(EncodedEdgeType.HASH_EDGE_TYPE, key.key, key.field, value));
+      edges.add(
+          new TypedKeyFieldValue<>(EncodedEdgeType.HASH_EDGE_TYPE, key.key, key.field, value));
     }
 
     List<Cache> caches = label.getCaches();

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -97,8 +97,8 @@ public class BulkEdgeEncoder {
       if (labelType == LabelType.INDEXED || labelType == LabelType.IMMUTABLE_INDEXED) {
         // Keep existing code
         edges.addAll(
-            encoder.encodeAllIndexedEdges(
-                    castedEdge, label.getDirType(), labelId, label.getIndices())
+            encoder
+                .encodeAllIndexedEdges(castedEdge, label.getDirType(), labelId, label.getIndices())
                 .stream()
                 .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                 .collect(Collectors.toList()));
@@ -107,8 +107,7 @@ public class BulkEdgeEncoder {
         // rely on the wide-row EdgeCacheRecord written here to stay in sync with EdgeIndexRecord.
         if (caches != null && !caches.isEmpty()) {
           edges.addAll(
-              encoder.encodeAllCacheEdges(castedEdge, label.getDirType(), labelId, caches)
-                  .stream()
+              encoder.encodeAllCacheEdges(castedEdge, label.getDirType(), labelId, caches).stream()
                   .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                   .collect(Collectors.toList()));
         }
@@ -120,27 +119,26 @@ public class BulkEdgeEncoder {
           Edge outEdge = new Edge(castedEdge.getTs(), castedEdge.getSrc(), edgeId, multiEdgeProps);
           Edge inEdge = new Edge(castedEdge.getTs(), edgeId, castedEdge.getTgt(), multiEdgeProps);
           edges.addAll(
-              encoder.encodeAllIndexedEdges(
-                      outEdge, DirectionType.OUT, labelId, label.getIndices())
+              encoder
+                  .encodeAllIndexedEdges(outEdge, DirectionType.OUT, labelId, label.getIndices())
                   .stream()
                   .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           edges.addAll(
-              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
+              encoder
+                  .encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
                   .stream()
                   .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
-                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches)
-                    .stream()
+                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches).stream()
                     .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
             edges.addAll(
-                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches)
-                    .stream()
+                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches).stream()
                     .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
@@ -148,16 +146,15 @@ public class BulkEdgeEncoder {
           // OUT: Create src->edgeId edge
           Edge outEdge = new Edge(castedEdge.getTs(), castedEdge.getSrc(), edgeId, multiEdgeProps);
           edges.addAll(
-              encoder.encodeAllIndexedEdges(
-                      outEdge, DirectionType.OUT, labelId, label.getIndices())
+              encoder
+                  .encodeAllIndexedEdges(outEdge, DirectionType.OUT, labelId, label.getIndices())
                   .stream()
                   .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
-                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches)
-                    .stream()
+                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches).stream()
                     .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
@@ -165,15 +162,15 @@ public class BulkEdgeEncoder {
           // IN: Create edgeId->tgt edge
           Edge inEdge = new Edge(castedEdge.getTs(), edgeId, castedEdge.getTgt(), multiEdgeProps);
           edges.addAll(
-              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
+              encoder
+                  .encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
                   .stream()
                   .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
                   .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
             edges.addAll(
-                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches)
-                    .stream()
+                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches).stream()
                     .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
                     .collect(Collectors.toList()));
           }
@@ -184,14 +181,22 @@ public class BulkEdgeEncoder {
       if (label.getDirType() == DirectionType.BOTH) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
-        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
-        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
+        edges.add(
+            new KeyFieldValueV2<>(
+                EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
+        edges.add(
+            new KeyFieldValueV2<>(
+                EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       } else if (label.getDirType() == DirectionType.OUT) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
-        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
+        edges.add(
+            new KeyFieldValueV2<>(
+                EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
       } else if (label.getDirType() == DirectionType.IN) {
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
-        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
+        edges.add(
+            new KeyFieldValueV2<>(
+                EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       }
     }
 

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -2,16 +2,13 @@ package com.kakao.actionbase.v2.core.code;
 
 import com.kakao.actionbase.v2.core.edge.BulkLoadEdge;
 import com.kakao.actionbase.v2.core.edge.Edge;
-import com.kakao.actionbase.v2.core.metadata.Active;
-import com.kakao.actionbase.v2.core.metadata.Direction;
-import com.kakao.actionbase.v2.core.metadata.DirectionType;
-import com.kakao.actionbase.v2.core.metadata.LabelDTO;
-import com.kakao.actionbase.v2.core.metadata.LabelType;
+import com.kakao.actionbase.v2.core.metadata.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Supported edge types:
@@ -33,7 +30,7 @@ public class BulkEdgeEncoder {
   static final String SOURCE_FIELD_ON_STATE = "_source";
   static final String TARGET_FIELD_ON_STATE = "_target";
 
-  public static <T> List<KeyFieldValue<T>> bulkEncodeAll(
+  public static <T> List<KeyFieldValueV2<T>> bulkEncodeAll(
       EdgeEncoder<T> encoder, BulkLoadEdge bulkLoadEdge, LabelDTO label) {
     LabelType labelType = label.getType();
 
@@ -43,7 +40,7 @@ public class BulkEdgeEncoder {
     Active active = bulkLoadEdge.isActive() ? Active.ACTIVE : Active.INACTIVE;
     Edge castedEdge = bulkLoadEdge.ensureType(label.getSchema());
 
-    List<KeyFieldValue<T>> edges = new ArrayList<>();
+    List<KeyFieldValueV2<T>> edges = new ArrayList<>();
 
     // Special handling for MultiEdge
     // - Keep existing HASH, INDEXED as is, and for MultiEdge, create separate edges based on ID and
@@ -85,7 +82,7 @@ public class BulkEdgeEncoder {
                   edgeForEdgeState.getProps(),
                   insertTs,
                   deleteTs));
-      edges.add(new KeyFieldValue<>(key.key, key.field, value));
+      edges.add(new KeyFieldValueV2<>(EncodedEdgeType.HASH_EDGE_TYPE, key.key, key.field, value));
     }
 
     List<Cache> caches = label.getCaches();
@@ -96,13 +93,19 @@ public class BulkEdgeEncoder {
         // Keep existing code
         edges.addAll(
             encoder.encodeAllIndexedEdges(
-                castedEdge, label.getDirType(), labelId, label.getIndices()));
+                    castedEdge, label.getDirType(), labelId, label.getIndices())
+                .stream()
+                .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                .collect(Collectors.toList()));
 
         // Cache records are only supported on INDEXED labels (V3 EDGE type). V3 multi-hop queries
         // rely on the wide-row EdgeCacheRecord written here to stay in sync with EdgeIndexRecord.
         if (caches != null && !caches.isEmpty()) {
           edges.addAll(
-              encoder.encodeAllCacheEdges(castedEdge, label.getDirType(), labelId, caches));
+              encoder.encodeAllCacheEdges(castedEdge, label.getDirType(), labelId, caches)
+                  .stream()
+                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                  .collect(Collectors.toList()));
         }
       } else if (labelType == LabelType.MULTI_EDGE) {
         multiEdgeProps.put(SOURCE_FIELD_ON_STATE, castedEdge.getSrc());
@@ -113,33 +116,61 @@ public class BulkEdgeEncoder {
           Edge inEdge = new Edge(castedEdge.getTs(), edgeId, castedEdge.getTgt(), multiEdgeProps);
           edges.addAll(
               encoder.encodeAllIndexedEdges(
-                  outEdge, DirectionType.OUT, labelId, label.getIndices()));
+                      outEdge, DirectionType.OUT, labelId, label.getIndices())
+                  .stream()
+                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .collect(Collectors.toList()));
 
           edges.addAll(
-              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices()));
+              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
+                  .stream()
+                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
-            edges.addAll(encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches));
-            edges.addAll(encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches));
+            edges.addAll(
+                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches)
+                    .stream()
+                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .collect(Collectors.toList()));
+            edges.addAll(
+                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches)
+                    .stream()
+                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .collect(Collectors.toList()));
           }
         } else if (label.getDirType() == DirectionType.OUT) {
           // OUT: Create src->edgeId edge
           Edge outEdge = new Edge(castedEdge.getTs(), castedEdge.getSrc(), edgeId, multiEdgeProps);
           edges.addAll(
               encoder.encodeAllIndexedEdges(
-                  outEdge, DirectionType.OUT, labelId, label.getIndices()));
+                      outEdge, DirectionType.OUT, labelId, label.getIndices())
+                  .stream()
+                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
-            edges.addAll(encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches));
+            edges.addAll(
+                encoder.encodeAllCacheEdges(outEdge, DirectionType.OUT, labelId, caches)
+                    .stream()
+                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .collect(Collectors.toList()));
           }
         } else if (label.getDirType() == DirectionType.IN) {
           // IN: Create edgeId->tgt edge
           Edge inEdge = new Edge(castedEdge.getTs(), edgeId, castedEdge.getTgt(), multiEdgeProps);
           edges.addAll(
-              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices()));
+              encoder.encodeAllIndexedEdges(inEdge, DirectionType.IN, labelId, label.getIndices())
+                  .stream()
+                  .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.INDEXED_EDGE_TYPE))
+                  .collect(Collectors.toList()));
 
           if (caches != null && !caches.isEmpty()) {
-            edges.addAll(encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches));
+            edges.addAll(
+                encoder.encodeAllCacheEdges(inEdge, DirectionType.IN, labelId, caches)
+                    .stream()
+                    .map(v -> KeyFieldValueV2.fromV1(v, EncodedEdgeType.EDGE_CACHE_TYPE))
+                    .collect(Collectors.toList()));
           }
         }
       }
@@ -148,14 +179,14 @@ public class BulkEdgeEncoder {
       if (label.getDirType() == DirectionType.BOTH) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
-        edges.add(new KeyFieldValue<>(encoder.getEmpty(), outboundKey));
-        edges.add(new KeyFieldValue<>(encoder.getEmpty(), inboundKey));
+        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
+        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       } else if (label.getDirType() == DirectionType.OUT) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
-        edges.add(new KeyFieldValue<>(encoder.getEmpty(), outboundKey));
+        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), outboundKey));
       } else if (label.getDirType() == DirectionType.IN) {
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);
-        edges.add(new KeyFieldValue<>(encoder.getEmpty(), inboundKey));
+        edges.add(new KeyFieldValueV2<>(EncodedEdgeType.COUNTER_EDGE_TYPE, encoder.getEmpty(), inboundKey));
       }
     }
 

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/Cache.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/Cache.java
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.core.code;
 
+import com.kakao.actionbase.v2.core.code.hbase.Order;
 import com.kakao.actionbase.v2.core.code.hbase.ValueUtils;
 
 import java.io.Serializable;
@@ -22,11 +23,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <pre>
  * {
  *   "cache": "top_created_at",
- *   "fields": [{"name": "created_at", "order": "DESC"}],
+ *   "fields": [{"field": "created_at", "order": "DESC"}],
  *   "limit": 100,
  *   "comment": "..."
  * }
  * </pre>
+ *
+ * <p>The cache field uses the {@code "field"} JSON key (not {@code "name"}) to align with V3
+ * {@code IndexField.kt}. {@link Index.Field} keeps the legacy {@code "name"} key, so cache fields
+ * must not reuse it.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Cache implements Serializable {
@@ -38,7 +43,7 @@ public class Cache implements Serializable {
   private final String cache;
 
   @JsonProperty("fields")
-  private final List<Index.Field> fields;
+  private final List<Field> fields;
 
   @JsonProperty("limit")
   private final int limit;
@@ -51,7 +56,7 @@ public class Cache implements Serializable {
   @JsonCreator
   public Cache(
       @JsonProperty("cache") String cache,
-      @JsonProperty("fields") List<Index.Field> fields,
+      @JsonProperty("fields") List<Field> fields,
       @JsonProperty("limit") Integer limit,
       @JsonProperty("comment") String comment) {
     if (cache == null || cache.isEmpty()) {
@@ -68,7 +73,7 @@ public class Cache implements Serializable {
     this.code = ValueUtils.stringHash(cache);
   }
 
-  public Cache(String cache, List<Index.Field> fields) {
+  public Cache(String cache, List<Field> fields) {
     this(cache, fields, null, null);
   }
 
@@ -76,8 +81,50 @@ public class Cache implements Serializable {
     return cache;
   }
 
-  public List<Index.Field> getFields() {
+  public List<Field> getFields() {
     return fields;
+  }
+
+  public static class Field implements Serializable {
+
+    @JsonProperty("field")
+    private final String field;
+
+    @JsonProperty("order")
+    private final Order order;
+
+    @JsonCreator
+    public Field(@JsonProperty("field") String field, @JsonProperty("order") Order order) {
+      this.field = field;
+      this.order = order;
+    }
+
+    public String getField() {
+      return field;
+    }
+
+    public Order getOrder() {
+      return order;
+    }
+
+    @Override
+    public String toString() {
+      return "Field{" + "field='" + field + '\'' + ", order=" + order + '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Field) {
+        Field other = (Field) obj;
+        return Objects.equals(field, other.field) && Objects.equals(order, other.order);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field, order);
+    }
   }
 
   public int getLimit() {

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/Cache.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/Cache.java
@@ -29,9 +29,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * }
  * </pre>
  *
- * <p>The cache field uses the {@code "field"} JSON key (not {@code "name"}) to align with V3
- * {@code IndexField.kt}. {@link Index.Field} keeps the legacy {@code "name"} key, so cache fields
- * must not reuse it.
+ * <p>The cache field uses the {@code "field"} JSON key (not {@code "name"}) to align with V3 {@code
+ * IndexField.kt}. {@link Index.Field} keeps the legacy {@code "name"} key, so cache fields must not
+ * reuse it.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Cache implements Serializable {

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
@@ -30,7 +30,7 @@ public class KeyFieldValue<T> {
     return value;
   }
 
-  public static <T> KeyFieldValue<T> fromV2(KeyFieldValueV2<T> keyFieldValue) {
+  public static <T> KeyFieldValue<T> from(TypedKeyFieldValue<T> keyFieldValue) {
     return new KeyFieldValue<>(
         keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
   }

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
@@ -29,4 +29,8 @@ public class KeyFieldValue<T> {
   public T getValue() {
     return value;
   }
+
+  public static <T> KeyFieldValue<T> fromV2(KeyFieldValueV2<T> keyFieldValue) {
+    return new KeyFieldValue<>(keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
+  }
 }

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValue.java
@@ -31,6 +31,7 @@ public class KeyFieldValue<T> {
   }
 
   public static <T> KeyFieldValue<T> fromV2(KeyFieldValueV2<T> keyFieldValue) {
-    return new KeyFieldValue<>(keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
+    return new KeyFieldValue<>(
+        keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
   }
 }

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValueV2.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValueV2.java
@@ -38,7 +38,12 @@ public class KeyFieldValueV2<T> {
     return value;
   }
 
-  public static <T> KeyFieldValueV2<T> fromV1(KeyFieldValue<T> keyFieldValue, EncodedEdgeType encodedEdgeType) {
-    return new KeyFieldValueV2<>(encodedEdgeType, keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
+  public static <T> KeyFieldValueV2<T> fromV1(
+      KeyFieldValue<T> keyFieldValue, EncodedEdgeType encodedEdgeType) {
+    return new KeyFieldValueV2<>(
+        encodedEdgeType,
+        keyFieldValue.getKey(),
+        keyFieldValue.getField(),
+        keyFieldValue.getValue());
   }
 }

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValueV2.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/KeyFieldValueV2.java
@@ -1,0 +1,44 @@
+package com.kakao.actionbase.v2.core.code;
+
+import com.kakao.actionbase.v2.core.metadata.EncodedEdgeType;
+
+public class KeyFieldValueV2<T> {
+  EncodedEdgeType encodedEdgeType;
+  T key;
+  T field;
+  T value;
+
+  public KeyFieldValueV2(EncodedEdgeType encodedEdgeType, T key, T field, T value) {
+    this.encodedEdgeType = encodedEdgeType;
+    this.key = key;
+    this.field = field;
+    this.value = value;
+  }
+
+  public KeyFieldValueV2(EncodedEdgeType encodedEdgeType, T key, T value) {
+    this.encodedEdgeType = encodedEdgeType;
+    this.key = key;
+    this.field = null;
+    this.value = value;
+  }
+
+  public EncodedEdgeType getEncodedEdgeType() {
+    return encodedEdgeType;
+  }
+
+  public T getKey() {
+    return key;
+  }
+
+  public T getField() {
+    return field;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  public static <T> KeyFieldValueV2<T> fromV1(KeyFieldValue<T> keyFieldValue, EncodedEdgeType encodedEdgeType) {
+    return new KeyFieldValueV2<>(encodedEdgeType, keyFieldValue.getKey(), keyFieldValue.getField(), keyFieldValue.getValue());
+  }
+}

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/TypedKeyFieldValue.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/TypedKeyFieldValue.java
@@ -2,20 +2,20 @@ package com.kakao.actionbase.v2.core.code;
 
 import com.kakao.actionbase.v2.core.metadata.EncodedEdgeType;
 
-public class KeyFieldValueV2<T> {
+public class TypedKeyFieldValue<T> {
   EncodedEdgeType encodedEdgeType;
   T key;
   T field;
   T value;
 
-  public KeyFieldValueV2(EncodedEdgeType encodedEdgeType, T key, T field, T value) {
+  public TypedKeyFieldValue(EncodedEdgeType encodedEdgeType, T key, T field, T value) {
     this.encodedEdgeType = encodedEdgeType;
     this.key = key;
     this.field = field;
     this.value = value;
   }
 
-  public KeyFieldValueV2(EncodedEdgeType encodedEdgeType, T key, T value) {
+  public TypedKeyFieldValue(EncodedEdgeType encodedEdgeType, T key, T value) {
     this.encodedEdgeType = encodedEdgeType;
     this.key = key;
     this.field = null;
@@ -38,9 +38,9 @@ public class KeyFieldValueV2<T> {
     return value;
   }
 
-  public static <T> KeyFieldValueV2<T> fromV1(
+  public static <T> TypedKeyFieldValue<T> from(
       KeyFieldValue<T> keyFieldValue, EncodedEdgeType encodedEdgeType) {
-    return new KeyFieldValueV2<>(
+    return new TypedKeyFieldValue<>(
         encodedEdgeType,
         keyFieldValue.getKey(),
         keyFieldValue.getField(),

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -64,8 +64,7 @@ public class BulkEdgeEncoderTests {
       assertNull(kv.field);
 
       if (kv.key.length != 0) {
-        DecodedEdge decodedEdge =
-            DecodedEdge.from(KeyFieldValue.from(kv), Collections.emptyMap());
+        DecodedEdge decodedEdge = DecodedEdge.from(KeyFieldValue.from(kv), Collections.emptyMap());
         assertEquals(newLabel.getId(), decodedEdge.getLabelId());
         assertEquals(expectedEdge.getTs(), decodedEdge.getTs());
         if (decodedEdge.getType() == EncodedEdgeType.HASH_EDGE_TYPE) {

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -41,7 +41,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash edge + 2 indexed (OUT/IN) + 2 cache (OUT/IN) + 2 counter (OUT/IN)
@@ -54,7 +54,7 @@ public class BulkEdgeEncoderTests {
 
     int cacheRowCount = 0;
 
-    for (KeyFieldValue<byte[]> kv : encodedEdges) {
+    for (KeyFieldValueV2<byte[]> kv : encodedEdges) {
       // Cache rows are the only ones carrying a non-null qualifier in the bytes encoder;
       // round-trip via V3 decoder is covered by V2MultiEdgeBulkLoadTest.testEdgeCache*.
       if (kv.field != null) {
@@ -64,7 +64,7 @@ public class BulkEdgeEncoderTests {
       assertNull(kv.field);
 
       if (kv.key.length != 0) {
-        DecodedEdge decodedEdge = DecodedEdge.from(kv, Collections.emptyMap());
+        DecodedEdge decodedEdge = DecodedEdge.from(KeyFieldValue.fromV2(kv), Collections.emptyMap());
         assertEquals(newLabel.getId(), decodedEdge.getLabelId());
         assertEquals(expectedEdge.getTs(), decodedEdge.getTs());
         if (decodedEdge.getType() == EncodedEdgeType.HASH_EDGE_TYPE) {
@@ -113,7 +113,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 1 indexed(OUT) + 1 cache(OUT) + 1 counter(OUT)
@@ -132,7 +132,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 1 indexed(IN) + 1 cache(IN) + 1 counter(IN)
@@ -152,7 +152,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 2 counter (no indexed, no cache)
@@ -171,7 +171,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // Inactive edge on an INDEXED label with caches: only the hash tombstone is emitted.
@@ -191,7 +191,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges =
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 item for the hash edge.
@@ -218,7 +218,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 hash + 2 indexed(OUT/IN) + 2 counter(OUT/IN) — no cache rows.
     assertEquals(5, encodedEdges.size());

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -64,7 +64,8 @@ public class BulkEdgeEncoderTests {
       assertNull(kv.field);
 
       if (kv.key.length != 0) {
-        DecodedEdge decodedEdge = DecodedEdge.from(KeyFieldValue.fromV2(kv), Collections.emptyMap());
+        DecodedEdge decodedEdge =
+            DecodedEdge.from(KeyFieldValue.fromV2(kv), Collections.emptyMap());
         assertEquals(newLabel.getId(), decodedEdge.getLabelId());
         assertEquals(expectedEdge.getTs(), decodedEdge.getTs());
         if (decodedEdge.getType() == EncodedEdgeType.HASH_EDGE_TYPE) {
@@ -218,7 +219,8 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 hash + 2 indexed(OUT/IN) + 2 counter(OUT/IN) — no cache rows.
     assertEquals(5, encodedEdges.size());

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -22,7 +22,7 @@ public class BulkEdgeEncoderTests {
   ObjectMapper objectMapper = new ObjectMapper();
 
   static final String labelJsonString =
-      "{\"name\":\"gift.like_product_v1\",\"desc\":\"Gift Wish\",\"type\":\"INDEXED\",\"schema\":{\"src\":{\"type\":\"LONG\"},\"tgt\":{\"type\":\"STRING\"},\"fields\":[{\"name\":\"created_at\",\"type\":\"LONG\",\"nullable\":false},{\"name\":\"permission\",\"type\":\"STRING\",\"nullable\":true},{\"name\":\"memo\",\"type\":\"STRING\",\"nullable\":true}]},\"dirType\":\"BOTH\",\"storage\":\"hbase_sandbox\",\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}],\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}],\"event\":false,\"readOnly\":false}";
+      "{\"name\":\"gift.like_product_v1\",\"desc\":\"Gift Wish\",\"type\":\"INDEXED\",\"schema\":{\"src\":{\"type\":\"LONG\"},\"tgt\":{\"type\":\"STRING\"},\"fields\":[{\"name\":\"created_at\",\"type\":\"LONG\",\"nullable\":false},{\"name\":\"permission\",\"type\":\"STRING\",\"nullable\":true},{\"name\":\"memo\",\"type\":\"STRING\",\"nullable\":true}]},\"dirType\":\"BOTH\",\"storage\":\"hbase_sandbox\",\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}],\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}],\"event\":false,\"readOnly\":false}";
   static final String edgeJsonString =
       "{\"active\":true,\"ts\":1,\"src\":123,\"tgt\":\"Coffee10\",\"props\":{\"created_at\":1, \"permission\":\"public\", \"memo\":\"for good morning\"}}";
 
@@ -206,7 +206,7 @@ public class BulkEdgeEncoderTests {
   void testIndexedLabelWithoutCachesProducesNoCacheRows() throws JsonProcessingException {
     String labelJsonWithoutCaches =
         labelJsonString.replaceAll(
-            ",\"caches\":\\[\\{\"cache\":\"top_created_at\",\"fields\":\\[\\{\"name\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+            ",\"caches\":\\[\\{\"cache\":\"top_created_at\",\"fields\":\\[\\{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
             "");
     assertFalse(labelJsonWithoutCaches.contains("caches"));
 

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -41,7 +41,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash edge + 2 indexed (OUT/IN) + 2 cache (OUT/IN) + 2 counter (OUT/IN)
@@ -54,7 +54,7 @@ public class BulkEdgeEncoderTests {
 
     int cacheRowCount = 0;
 
-    for (KeyFieldValueV2<byte[]> kv : encodedEdges) {
+    for (TypedKeyFieldValue<byte[]> kv : encodedEdges) {
       // Cache rows are the only ones carrying a non-null qualifier in the bytes encoder;
       // round-trip via V3 decoder is covered by V2MultiEdgeBulkLoadTest.testEdgeCache*.
       if (kv.field != null) {
@@ -65,7 +65,7 @@ public class BulkEdgeEncoderTests {
 
       if (kv.key.length != 0) {
         DecodedEdge decodedEdge =
-            DecodedEdge.from(KeyFieldValue.fromV2(kv), Collections.emptyMap());
+            DecodedEdge.from(KeyFieldValue.from(kv), Collections.emptyMap());
         assertEquals(newLabel.getId(), decodedEdge.getLabelId());
         assertEquals(expectedEdge.getTs(), decodedEdge.getTs());
         if (decodedEdge.getType() == EncodedEdgeType.HASH_EDGE_TYPE) {
@@ -114,7 +114,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 1 indexed(OUT) + 1 cache(OUT) + 1 counter(OUT)
@@ -133,7 +133,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 1 indexed(IN) + 1 cache(IN) + 1 counter(IN)
@@ -153,7 +153,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 hash + 2 counter (no indexed, no cache)
@@ -172,7 +172,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // Inactive edge on an INDEXED label with caches: only the hash tombstone is emitted.
@@ -192,7 +192,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
 
     // 1 item for the hash edge.
@@ -219,7 +219,7 @@ public class BulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 hash + 2 indexed(OUT/IN) + 2 counter(OUT/IN) — no cache rows.

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
@@ -102,7 +102,7 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCache (OUT/IN) + 2 EdgeCount (OUT/IN)
     assertEquals(7, encodedEdges.size());
@@ -129,7 +129,7 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValue<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCount (OUT/IN) — no cache rows.
     assertEquals(5, encodedEdges.size());

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
@@ -102,7 +102,7 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCache (OUT/IN) + 2 EdgeCount (OUT/IN)
@@ -130,7 +130,7 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges =
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
         BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCount (OUT/IN) — no cache rows.

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
@@ -70,7 +70,7 @@ public class MultiEdgeBulkEdgeEncoderTests {
           + "  \"caches\": [\n"
           + "    {\n"
           + "      \"cache\": \"top_created_at\",\n"
-          + "      \"fields\": [{\"name\": \"created_at\", \"order\": \"DESC\"}],\n"
+          + "      \"fields\": [{\"field\": \"created_at\", \"order\": \"DESC\"}],\n"
           + "      \"limit\": 100\n"
           + "    }\n"
           + "  ],\n"

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/MultiEdgeBulkEdgeEncoderTests.java
@@ -102,7 +102,8 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCache (OUT/IN) + 2 EdgeCount (OUT/IN)
     assertEquals(7, encodedEdges.size());
@@ -129,7 +130,8 @@ public class MultiEdgeBulkEdgeEncoderTests {
     EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
     EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
 
-    List<KeyFieldValueV2<byte[]>> encodedEdges = BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
+    List<KeyFieldValueV2<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, label);
 
     // 1 EdgeState + 2 EdgeIndex (OUT/IN) + 2 EdgeCount (OUT/IN) — no cache rows.
     assertEquals(5, encodedEdges.size());

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
@@ -2,6 +2,7 @@ package com.kakao.actionbase.v2.core.metadata;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.kakao.actionbase.v2.core.code.Cache;
 import com.kakao.actionbase.v2.core.code.Index;
 import com.kakao.actionbase.v2.core.code.hbase.Order;
 import com.kakao.actionbase.v2.core.types.*;
@@ -75,5 +76,30 @@ public class LabelDTOTests {
     assertEquals("created_at", label.getIndices().get(0).getFields().get(0).getName());
     assertEquals(Order.DESC, label.getIndices().get(0).getFields().get(0).getOrder());
     assertEquals("ASYNC", label.getMode().name());
+  }
+
+  @Test
+  void testGraphResponseDeserializationWithCaches() throws JsonProcessingException {
+    // Server (LabelEntity) imports the V3 Cache from core.metadata.common, whose IndexField
+    // serializes as {"field": ..., "order": ...}. The V2 client must accept that wire shape.
+    String jsonString =
+        "{\"name\":\"gift.like_product_v1\",\"desc\":\"\",\"type\":\"INDEXED\","
+            + "\"schema\":{\"src\":{\"type\":\"LONG\"},\"tgt\":{\"type\":\"STRING\"},\"fields\":[]},"
+            + "\"dirType\":\"BOTH\",\"storage\":\"hbase_sandbox\",\"indices\":[],\"groups\":[],"
+            + "\"caches\":[{\"cache\":\"top_created_at\","
+            + "\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],"
+            + "\"limit\":50,\"comment\":\"top by created_at\"}],"
+            + "\"event\":false,\"readOnly\":false,\"mode\":\"ASYNC\"}";
+
+    LabelDTO label = objectMapper.readValue(jsonString, LabelDTO.class);
+
+    assertEquals(1, label.getCaches().size());
+    Cache cache = label.getCaches().get(0);
+    assertEquals("top_created_at", cache.getCache());
+    assertEquals(50, cache.getLimit());
+    assertEquals("top by created_at", cache.getComment());
+    assertEquals(1, cache.getFields().size());
+    assertEquals("created_at", cache.getFields().get(0).getField());
+    assertEquals(Order.DESC, cache.getFields().get(0).getOrder());
   }
 }


### PR DESCRIPTION
## Summary

Two fixes to V2 codec edge encoding.

**`Cache.fields` wire shape.** Server `LabelEntity` mixes V2 `Index` with V3 `Cache`, so `caches[].fields[].*` uses the V3 key `field`, not V2's `name`. V2's `Cache` reused `Index.Field`, so real responses deserialized to null names and broke encoding. New `Cache.Field` annotated `@JsonProperty("field")`; `Index.Field` keeps `name`.

**Row type tag on bulk output.** `bulkEncodeAll` consumers couldn't tell hash from indexed/cache/counter rows without re-decoding keys. `TypedKeyFieldValue<T>` carries `EncodedEdgeType` with `key`/`field`/`value`, and `bulkEncodeAll` now returns `List<TypedKeyFieldValue<T>>`. Kept separate from `KeyFieldValue` so engine scan paths (`HBaseHashLabel`, `JdbcHashLabel`) stay untouched; overloaded `from` adapters bridge them.

Closes #

## Changes

- Add `Cache.Field` with `@JsonProperty("field")` to match the V3 server wire shape (`core.metadata.common.IndexField`); `Index.Field` keeps the legacy `name` key.
- Introduce `TypedKeyFieldValue<T>` carrying `EncodedEdgeType` alongside `key`/`field`/`value`.
- Switch `BulkEdgeEncoder.bulkEncodeAll` to return `List<TypedKeyFieldValue<T>>`; update `AbstractEdgeEncoder` signatures accordingly.
- Add overloaded `from` adapters between `KeyFieldValue` and `TypedKeyFieldValue`; existing engine scan/query paths are unchanged.
- Expand the wildcard metadata import in `BulkEdgeEncoder` and apply spotless formatting to the codec-java module.
- Tests: add `LabelDTOTests`; update `BulkEdgeEncoderTests` and `MultiEdgeBulkEdgeEncoderTests` for the new return type.

## How to Test

- `./gradlew :codec-java:test` — covers both fixes via `BulkEdgeEncoderTests`, `MultiEdgeBulkEdgeEncoderTests`, and the new `LabelDTOTests`.
- `./gradlew test` — full suite green; engine integration tests confirm the existing `KeyFieldValue` scan path is untouched.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7, 1M context)
