### PR TITLE
Add ranges to the cache seek API

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/codec/ByteArrayBuffer.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/codec/ByteArrayBuffer.kt
@@ -20,4 +20,22 @@ fun <T> ByteArrayBuffer.getValueOrNull(): T? = ValueUtils.deserialize(buffer = t
 
 fun ByteArrayBuffer.hasRemaining(): Boolean = remaining > 0
 
+fun ByteArrayBuffer.plusOne(): ByteArrayBuffer {
+    val position = this.position
+    val bytes = this.bytes
+    var carry = true
+    var i = position - 1
+    while (i >= 0 && carry) {
+        if ((bytes[i].toInt() and 0xFF) == 0xFF) {
+            bytes[i] = 0
+        } else {
+            bytes[i]++
+            carry = false
+        }
+        i--
+    }
+    require(!carry) { "Overflow while incrementing byte buffer" }
+    return this
+}
+
 fun ByteArray.buffer(): ByteArrayBuffer = ByteArrayBuffer(this)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mapper/EdgeCacheRecordMapper.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mapper/EdgeCacheRecordMapper.kt
@@ -10,8 +10,10 @@ import com.kakao.actionbase.core.codec.buffer
 import com.kakao.actionbase.core.codec.getValue
 import com.kakao.actionbase.core.codec.getValueOrNull
 import com.kakao.actionbase.core.codec.hasRemaining
+import com.kakao.actionbase.core.codec.plusOne
 import com.kakao.actionbase.core.codec.putValue
 import com.kakao.actionbase.core.edge.record.EdgeCacheRecord
+import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.core.metadata.common.Direction
 import com.kakao.actionbase.core.storage.HBaseRecord
 
@@ -84,6 +86,45 @@ class EdgeCacheRecordMapper private constructor(
                             it.putValue(propertyValue)
                         }
                     }.toByteArray()
+            }
+
+        /**
+         * Encode the `start` side of a qualifier prefix range for an HBase
+         * `ColumnRangeFilter`.
+         *
+         * For each entry whose [QualifierStartStop.start] is non-null, append the value
+         * with its field's [Order]; non-inclusive components are advanced by one byte
+         * so an exclusive `min` bound skips the boundary value.
+         */
+        fun encodeQualifierPrefixStart(startStops: List<QualifierStartStop>): ByteArray =
+            bufferPool.use { buffer ->
+                startStops.forEach { (start, _) ->
+                    if (start != null) {
+                        buffer.putValue(start.value, start.order)
+                        if (!start.inclusive) buffer.plusOne()
+                    }
+                }
+                buffer.toByteArray()
+            }
+
+        /**
+         * Encode the `stop` side of a qualifier prefix range for an HBase
+         * `ColumnRangeFilter`.
+         *
+         * For each entry whose [QualifierStartStop.stop] is non-null, append the value
+         * with its field's [Order]; the trailing inclusive component is advanced by one
+         * byte so an exclusive `max` bound still admits the boundary value.
+         */
+        fun encodeQualifierPrefixStop(startStops: List<QualifierStartStop>): ByteArray =
+            bufferPool.use { buffer ->
+                val lastIndex = startStops.indexOfLast { it.stop != null }
+                startStops.forEachIndexed { index, (_, stop) ->
+                    if (stop != null) {
+                        buffer.putValue(stop.value, stop.order)
+                        if (stop.inclusive && index == lastIndex) buffer.plusOne()
+                    }
+                }
+                buffer.toByteArray()
             }
     }
 
@@ -160,3 +201,14 @@ class EdgeCacheRecordMapper private constructor(
         }
     }
 }
+
+data class QualifierStartStopItem(
+    val value: Any,
+    val order: Order,
+    val inclusive: Boolean,
+)
+
+data class QualifierStartStop(
+    val start: QualifierStartStopItem?,
+    val stop: QualifierStartStopItem?,
+)

--- a/core/src/test/kotlin/com/kakao/actionbase/core/edge/mapper/EdgeCacheRecordMapperTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/edge/mapper/EdgeCacheRecordMapperTest.kt
@@ -8,6 +8,18 @@ import kotlin.test.assertEquals
 
 import org.junit.jupiter.api.Test
 
+private fun compareUnsigned(
+    a: ByteArray,
+    b: ByteArray,
+): Int {
+    val len = minOf(a.size, b.size)
+    for (i in 0 until len) {
+        val diff = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+        if (diff != 0) return diff
+    }
+    return a.size - b.size
+}
+
 /**
  * EdgeCache (Wide Row) layout:
  *
@@ -233,6 +245,113 @@ class EdgeCacheRecordMapperTest {
         assertEquals(Direction.IN, record.key.direction)
         assertEquals("product1", record.key.directedSource)
         assertEquals("user1", record.qualifier.directedTarget)
+    }
+
+    /**
+     * Compound (permission ASC, createdAt DESC). Per-field [Order] is baked into
+     * the qualifier bytes via OrderedBytes (DESC fields are bit-inverted), so an
+     * unsigned-byte lex sort — the way HBase scans columns — yields the intended
+     * compound order without any explicit scan-direction handling.
+     *
+     * | target | permission (ASC) | createdAt (DESC) |
+     * |--------|------------------|------------------|
+     * | t5     | "others"         | 1716388213000    |
+     * | t2     | "me"             | 1744597404230    |
+     * | t7     | "others"         | 1629251546000    |
+     * | t3     | "others"         | 1766556337836    |
+     * | t4     | "others"         | 1744692001289    |
+     * | t6     | "others"         | 1682054196000    |
+     *
+     * | byte-sort | permission | createdAt     | reason                     |
+     * |-----------|------------|---------------|----------------------------|
+     * | t2        | "me"       | 1744597404230 | "me" < "others" (ASCII)    |
+     * | t3        | "others"   | 1766556337836 | largest createdAt, DESC 1st|
+     * | t4        | "others"   | 1744692001289 | ↓                          |
+     * | t5        | "others"   | 1716388213000 | ↓                          |
+     * | t6        | "others"   | 1682054196000 | ↓                          |
+     * | t7        | "others"   | 1629251546000 | smallest, DESC last        |
+     */
+    @Test
+    fun `compound mixed-direction qualifiers sort lex by (leading ASC, trailing DESC)`() {
+        // schema: (permission ASC, createdAt DESC)
+        val records =
+            listOf(
+                Triple("others", 1716388213000L, "t5"),
+                Triple("me", 1744597404230L, "t2"),
+                Triple("others", 1629251546000L, "t7"),
+                Triple("others", 1766556337836L, "t3"),
+                Triple("others", 1744692001289L, "t4"),
+                Triple("others", 1682054196000L, "t6"),
+            )
+        val encoded =
+            records.map { (perm, ts, target) ->
+                val q =
+                    EdgeCacheRecord.Qualifier(
+                        cacheValues =
+                            listOf(
+                                EdgeCacheRecord.Qualifier.CacheValue(perm, Order.ASC),
+                                EdgeCacheRecord.Qualifier.CacheValue(ts, Order.DESC),
+                            ),
+                        directedTarget = target,
+                    )
+                target to mapper.encoder.encodeQualifier(q)
+            }
+
+        val sorted = encoded.sortedWith { a, b -> compareUnsigned(a.second, b.second) }
+
+        assertEquals(listOf("t2", "t3", "t4", "t5", "t6", "t7"), sorted.map { it.first })
+    }
+
+    /**
+     * Predicate `WHERE permission='others'` on schema (permission ASC, createdAt DESC).
+     *
+     * |   bound   |           encoded bytes           |
+     * |-----------|-----------------------------------|
+     * | start (≤) | encode("others", ASC)             |
+     * | stop  (<) | encode("others", ASC) + plusOne() |
+     *
+     * | qualifier (permission | createdAt(DESC) | target) | vs [start, stop) |
+     * |---------------------------------------------------|------------------|
+     * | "me"                  | 1000L          | "tx"     | < start          |
+     * | "others"              | 1000L          | "tx"     | inside           |
+     * | "public"              | 1000L          | "tx"     | ≥ stop           |
+     *
+     * `WHERE permission='others'` becomes a contiguous qualifier range
+     * `[encode("others"), encode("others")+1)` — the byte-range translated
+     * into a single ColumnRangeFilter by the seek API.
+     */
+    @Test
+    fun `predicate prefix start-stop bracket matching qualifiers and exclude others`() {
+        val comparator = Comparator<ByteArray> { a, b -> compareUnsigned(a, b) }
+        // Eq("permission", "others") on an ASC field → same item on both start and stop sides.
+        val eqItem = QualifierStartStopItem("others", Order.ASC, true)
+        val startStops = listOf(QualifierStartStop(eqItem, eqItem))
+        val start = mapper.encoder.encodeQualifierPrefixStart(startStops)
+        val stop = mapper.encoder.encodeQualifierPrefixStop(startStops)
+
+        fun encodeFor(perm: String): ByteArray {
+            val q =
+                EdgeCacheRecord.Qualifier(
+                    cacheValues =
+                        listOf(
+                            EdgeCacheRecord.Qualifier.CacheValue(perm, Order.ASC),
+                            EdgeCacheRecord.Qualifier.CacheValue(1_000L, Order.DESC),
+                        ),
+                    directedTarget = "tx",
+                )
+            return mapper.encoder.encodeQualifier(q)
+        }
+
+        val matching = encodeFor("others")
+        val before = encodeFor("me")
+        val after = encodeFor("public") // 'p' > 'o'
+
+        // matching qualifier sits in [start, stop)
+        assert(comparator.compare(start, matching) < 0) { "start should be < matching" }
+        assert(comparator.compare(matching, stop) < 0) { "matching should be < stop" }
+        // non-matching qualifiers fall outside
+        assert(comparator.compare(before, start) < 0) { "permission='me' must precede start" }
+        assert(comparator.compare(after, stop) >= 0) { "permission='public' must not precede stop" }
     }
 
     /**

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -63,6 +63,7 @@ interface TableBinding {
         direction: Direction,
         limit: Int,
         offset: String?,
+        ranges: String?,
     ): Mono<DataFrame>
 
     fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
@@ -90,6 +90,7 @@ data class ActionbaseQuery(
             val direction: Direction,
             val cache: String,
             val limit: Int,
+            val ranges: String? = null,
             override val include: Boolean = false,
             override val memoize: Boolean = false,
             override val post: List<PostProcessor> = emptyList(),

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
@@ -190,7 +190,7 @@ class ActionbaseQueryExecutor(
                 .flatMap { start ->
                     engine
                         .getTableBinding(database = queryItem.database, alias = queryItem.table)
-                        .seek(queryItem.cache, start, queryItem.direction, queryItem.limit, offset = null)
+                        .seek(queryItem.cache, start, queryItem.direction, queryItem.limit, offset = null, ranges = queryItem.ranges)
                 }.reduce { a, b ->
                     DataFrame(rows = a.rows + b.rows, schema = a.schema, total = a.total + b.total)
                 }.switchIfEmpty(Mono.just(DataFrame.empty))

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -142,10 +142,11 @@ class QueryService(
         direction: Direction,
         limit: Int = ScanFilter.defaultLimit,
         offset: String? = null,
+        ranges: String? = null,
     ): Mono<DataFrameEdgePayload> =
         engine
             .getTableBinding(database, table)
-            .seek(cache, start, direction, limit, offset)
+            .seek(cache, start, direction, limit, offset, ranges)
             .map { it.toEdgePayload() }
 
     fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/Label.kt
@@ -12,6 +12,7 @@ import com.kakao.actionbase.v2.engine.entity.LabelEntity
 import com.kakao.actionbase.v2.engine.sql.DataFrame
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
 import com.kakao.actionbase.v2.engine.sql.StatKey
+import com.kakao.actionbase.v2.engine.sql.WherePredicate
 
 import java.lang.AutoCloseable
 
@@ -95,6 +96,7 @@ interface Label : AutoCloseable {
         direction: Direction,
         limit: Int,
         offset: String? = null,
+        predicates: List<WherePredicate> = emptyList(),
     ): Mono<DataFrame> = Mono.error(UnsupportedOperationException("cache is not supported for ${this::class.simpleName}"))
 
     fun count(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashLabel.kt
@@ -448,14 +448,8 @@ open class HBaseHashLabel(
         rows: List<ByteArray>,
         from: ByteArray?,
         to: ByteArray?,
-        order: Order,
         limit: Int,
     ): Mono<List<HBaseRecord>> {
-        // ColumnRangeFilter requires minColumn <= maxColumn in byte order.
-        // DESC encoding flips bytes, so from > to; swap to restore byte order.
-        val (min, max) =
-            if (order == Order.DESC) to to from else from to to
-
         val gets =
             rows.map {
                 val get =
@@ -464,12 +458,12 @@ open class HBaseHashLabel(
 
                 val filters = FilterList(FilterList.Operator.MUST_PASS_ALL)
 
-                if (min != null || max != null) {
+                if (from != null || to != null) {
                     filters.addFilter(
                         ColumnRangeFilter(
-                            min,
+                            from,
                             false,
-                            max,
+                            to,
                             false,
                         ),
                     )

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashOnlyIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseHashOnlyIndexedLabel.kt
@@ -10,6 +10,7 @@ import com.kakao.actionbase.v2.engine.label.LabelFactory
 import com.kakao.actionbase.v2.engine.sql.DataFrame
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
 import com.kakao.actionbase.v2.engine.sql.StatKey
+import com.kakao.actionbase.v2.engine.sql.WherePredicate
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseStorage
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTables
 
@@ -43,6 +44,7 @@ class HBaseHashOnlyIndexedLabel(
         direction: Direction,
         limit: Int,
         offset: String?,
+        predicates: List<WherePredicate>,
     ): Mono<DataFrame> = unsupported("seek")
 
     private fun unsupported(op: String): Mono<DataFrame> =

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseIndexedLabel.kt
@@ -2,8 +2,11 @@ package com.kakao.actionbase.v2.engine.label.hbase
 
 import com.kakao.actionbase.core.edge.Edge
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
+import com.kakao.actionbase.core.edge.mapper.QualifierStartStop
+import com.kakao.actionbase.core.edge.mapper.QualifierStartStopItem
 import com.kakao.actionbase.core.edge.record.EdgeCacheRecord
 import com.kakao.actionbase.core.java.codec.common.hbase.Order
+import com.kakao.actionbase.core.metadata.common.IndexField
 import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.v2.core.code.CryptoUtils
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
@@ -24,6 +27,7 @@ import com.kakao.actionbase.v2.engine.sql.DataFrame
 import com.kakao.actionbase.v2.engine.sql.Row
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
 import com.kakao.actionbase.v2.engine.sql.StatKey
+import com.kakao.actionbase.v2.engine.sql.WherePredicate
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseStorage
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTables
 import com.kakao.actionbase.v2.engine.v3.V2BackedTableBinding
@@ -78,12 +82,12 @@ open class HBaseIndexedLabel(
         direction: Direction,
         limit: Int,
         offset: String?,
+        predicates: List<WherePredicate>,
     ): Mono<DataFrame> {
         val cache =
             entity.caches.find { it.cache == cacheName }
                 ?: return Mono.error(IllegalArgumentException("Cache not found: $cacheName"))
 
-        val order = cache.fields.first().order
         val source =
             when (direction) {
                 Direction.OUT -> entity.schema.src.type.type
@@ -106,17 +110,9 @@ open class HBaseIndexedLabel(
         val descriptor = V3TableDescriptor.create(entity)
         val schema = buildSchema()
 
-        val decodedOffset = offset?.let { CryptoUtils.decodeAndDecryptUrlSafe(it) }
-        val (from, to) =
-            if (decodedOffset == null) {
-                null to null
-            } else if (order == Order.DESC) {
-                null to decodedOffset
-            } else {
-                decodedOffset to null
-            }
+        val (from, to) = encodeCacheRange(fields = cache.fields.take(predicates.size), predicates, offset)
 
-        return hbaseGetWideRow(keys, from, to, order, limit + 1)
+        return hbaseGetWideRow(keys, from, to, limit + 1)
             .map { records ->
                 val hasNext = records.size > limit
                 val results = if (hasNext) records.dropLast(1) else records
@@ -137,6 +133,120 @@ open class HBaseIndexedLabel(
                 DataFrame(rows, schema, offsets = listOfNotNull(nextOffset), hasNext = listOf(hasNext))
             }
     }
+
+    /**
+     * Build the `(from, to)` qualifier byte range.
+     *
+     * Qualifier bytes already carry each field's [Order] (DESC fields are bit-inverted
+     * by `OrderedBytes` at write time), so the resulting range is consumed by a single
+     * forward `ColumnRangeFilter` that honours the declared compound order.
+     *
+     * When [offset] is supplied it replaces the predicate-derived `from`: a paginated
+     * cursor always lies inside the predicate range produced by the previous page.
+     *
+     * @param fields  the leading-prefix subset of the cache schema covered by [predicates].
+     * @param offset  encrypted qualifier from the previous page, or `null` for the first page.
+     * @return `(from, to)` where either side may be `null` when no bound applies.
+     */
+    private fun encodeCacheRange(
+        fields: List<IndexField>,
+        predicates: List<WherePredicate>,
+        offset: String?,
+    ): Pair<ByteArray?, ByteArray?> {
+        val (predicateStart, predicateStop) =
+            if (fields.isEmpty()) {
+                null to null
+            } else {
+                val startStops =
+                    fields.mapIndexed { idx, field ->
+                        toQualifierStartStop(field, predicates[idx])
+                    }
+                val encoder = edgeRecordMapper.cache.encoder
+                val start =
+                    if (startStops.any { it.start != null }) {
+                        encoder.encodeQualifierPrefixStart(startStops)
+                    } else {
+                        null
+                    }
+                val stop =
+                    if (startStops.any { it.stop != null }) {
+                        encoder.encodeQualifierPrefixStop(startStops)
+                    } else {
+                        null
+                    }
+                start to stop
+            }
+
+        val decodedOffset = offset?.let(CryptoUtils::decodeAndDecryptUrlSafe)
+        return (decodedOffset ?: predicateStart) to predicateStop
+    }
+
+    /**
+     * Lift one [WherePredicate] against one cache [field] into its qualifier-prefix
+     * `start`/`stop` contribution for an HBase `ColumnRangeFilter`.
+     *
+     * Because qualifier bytes for DESC fields are bit-inverted by `OrderedBytes` at
+     * write time, an operator's start/stop side flips relative to ASC: e.g. `<` on a
+     * DESC field contributes to `start`, not `stop`.
+     */
+    private fun toQualifierStartStop(
+        field: IndexField,
+        predicate: WherePredicate,
+    ): QualifierStartStop =
+        when (predicate) {
+            is WherePredicate.Eq -> {
+                val item = QualifierStartStopItem(predicate.value, field.order, true)
+                QualifierStartStop(item, item)
+            }
+
+            is WherePredicate.Lt -> {
+                val item = QualifierStartStopItem(predicate.value, field.order, false)
+                if (field.order == Order.ASC) {
+                    QualifierStartStop(null, item)
+                } else {
+                    QualifierStartStop(item, null)
+                }
+            }
+
+            is WherePredicate.Lte -> {
+                val item = QualifierStartStopItem(predicate.value, field.order, true)
+                if (field.order == Order.ASC) {
+                    QualifierStartStop(null, item)
+                } else {
+                    QualifierStartStop(item, null)
+                }
+            }
+
+            is WherePredicate.Gt -> {
+                val item = QualifierStartStopItem(predicate.value, field.order, false)
+                if (field.order == Order.ASC) {
+                    QualifierStartStop(item, null)
+                } else {
+                    QualifierStartStop(null, item)
+                }
+            }
+
+            is WherePredicate.Gte -> {
+                val item = QualifierStartStopItem(predicate.value, field.order, true)
+                if (field.order == Order.ASC) {
+                    QualifierStartStop(item, null)
+                } else {
+                    QualifierStartStop(null, item)
+                }
+            }
+
+            is WherePredicate.Between -> {
+                val (low, high) =
+                    if (field.order == Order.ASC) predicate.from to predicate.to else predicate.to to predicate.from
+                QualifierStartStop(
+                    QualifierStartStopItem(low, field.order, true),
+                    QualifierStartStopItem(high, field.order, true),
+                )
+            }
+
+            is WherePredicate.In ->
+                error("Cache `${entity.fullName}` does not support `IN` predicate on field `${field.field}`")
+        }
 
     private fun toRow(
         edge: Edge,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -63,6 +63,7 @@ class NilTableBinding(
         direction: Direction,
         limit: Int,
         offset: String?,
+        ranges: String?,
     ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -228,11 +228,40 @@ class V2BackedTableBinding(
         direction: Direction,
         limit: Int,
         offset: String?,
-    ): Mono<DataFrame> =
-        label
-            .cache(listOf(start), cache, direction, limit, offset)
+        ranges: String?,
+    ): Mono<DataFrame> {
+        val cacheEntity =
+            label.entity.caches.find { it.cache == cache }
+                ?: return Mono.error(IllegalArgumentException("cache `$cache` is not found in label `${label.entity.name}`."))
+
+        val cacheFieldNames = cacheEntity.fields.map { it.field }
+        val predicates = ranges?.let { WherePredicate.parse(it, label.entity.schema) } ?: emptyList()
+        val predicateKeys = predicates.map { it.key }
+
+        val lazyCacheMismatchErrorMessage: () -> String = {
+            "valid `ranges` order for the cache `$cache` is $cacheFieldNames. input was: $predicateKeys."
+        }
+        require(predicateKeys.size <= cacheFieldNames.size, lazyCacheMismatchErrorMessage)
+        predicateKeys.zip(cacheFieldNames).forEach { (predicateFieldName, cacheFieldName) ->
+            require(predicateFieldName == cacheFieldName, lazyCacheMismatchErrorMessage)
+        }
+
+        predicates.dropLast(1).forEach { predicate ->
+            require(predicate is WherePredicate.Eq) {
+                "cache `$cache` predicate on `${predicate.key}` must be `=` (only the trailing predicate may be a range)."
+            }
+        }
+        predicates.lastOrNull()?.let { trailing ->
+            require(trailing !is WherePredicate.In) {
+                "cache `$cache` does not support `IN` predicate on `${trailing.key}`."
+            }
+        }
+
+        return label
+            .cache(listOf(start), cache, direction, limit, offset, predicates)
             .map { it.toV3() }
             .switchIfEmpty(EMPTY_DATAFRAME)
+    }
 
     override fun agg(
         group: String,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeQueryController.kt
@@ -103,9 +103,10 @@ class EdgeQueryController(
         @RequestParam direction: Direction,
         @RequestParam limit: Int = ScanFilter.defaultLimit,
         @RequestParam offset: String? = null,
+        @RequestParam ranges: String? = null,
     ): Mono<ResponseEntity<DataFrameEdgePayload>> =
         queryService
-            .seek(database, table, cache, start, direction, limit, offset)
+            .seek(database, table, cache, start, direction, limit, offset, ranges)
             .mapToResponseEntity()
 
     @GetMapping("/graph/v3/databases/{database}/tables/{table}/edges/agg/{group}")

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeCacheQueryE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeCacheQueryE2ETest.kt
@@ -41,7 +41,8 @@ class EdgeCacheQueryE2ETest : E2ETestBase() {
                     "source": {"type": "long", "comment": "src"},
                     "target": {"type": "long", "comment": "tgt"},
                     "properties": [
-                      {"name": "createdAt", "type": "long", "comment": "ts", "nullable": true}
+                      {"name": "createdAt", "type": "long", "comment": "ts", "nullable": true},
+                      {"name": "permission", "type": "string", "comment": "perm", "nullable": true}
                     ],
                     "direction": "BOTH",
                     "indexes": [],
@@ -50,6 +51,14 @@ class EdgeCacheQueryE2ETest : E2ETestBase() {
                       {
                         "cache": "recent_wishlist",
                         "fields": [{"field": "createdAt", "order": "DESC"}],
+                        "limit": 100
+                      },
+                      {
+                        "cache": "permission_created_at_desc",
+                        "fields": [
+                          {"field": "permission", "order": "ASC"},
+                          {"field": "createdAt", "order": "DESC"}
+                        ],
                         "limit": 100
                       }
                     ]
@@ -63,6 +72,9 @@ class EdgeCacheQueryE2ETest : E2ETestBase() {
             .expectStatus()
             .isOk
 
+        // Single-source fixtures used by recent_wishlist (single-field cache) tests.
+        // permission is omitted, so the compound cache stores `(null, createdAt, target)`
+        // for these rows — they don't intersect with the compound-test source below.
         client
             .post()
             .uri("/graph/v3/databases/$db/tables/$edgeTable/edges")
@@ -73,6 +85,29 @@ class EdgeCacheQueryE2ETest : E2ETestBase() {
                   "mutations": [
                     {"type": "INSERT", "edge": {"version": 1, "source": 1000, "target": 2000, "properties": {"createdAt": 100}}},
                     {"type": "INSERT", "edge": {"version": 1, "source": 1000, "target": 2001, "properties": {"createdAt": 101}}}
+                  ]
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        // Compound-cache fixtures on a separate source. permission groups: "me" (1 row),
+        // "others" (4 rows). Within "others", createdAt descends 500 → 400 → 300 → 100.
+        // Lex byte order = (permission ASC, createdAt DESC).
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$edgeTable/edges")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 1, "source": 1, "target": 2, "properties": {"permission": "me",     "createdAt": 200}}},
+                    {"type": "INSERT", "edge": {"version": 1, "source": 1, "target": 3, "properties": {"permission": "others", "createdAt": 500}}},
+                    {"type": "INSERT", "edge": {"version": 1, "source": 1, "target": 4, "properties": {"permission": "others", "createdAt": 400}}},
+                    {"type": "INSERT", "edge": {"version": 1, "source": 1, "target": 5, "properties": {"permission": "others", "createdAt": 300}}},
+                    {"type": "INSERT", "edge": {"version": 1, "source": 1, "target": 6, "properties": {"permission": "others", "createdAt": 100}}}
                   ]
                 }
                 """.trimIndent(),
@@ -240,6 +275,102 @@ class EdgeCacheQueryE2ETest : E2ETestBase() {
             .isEqualTo(1000)
             .jsonPath("$.edges[0].target")
             .isEqualTo(2000)
+            .jsonPath("$.edges[0].properties.createdAt")
+            .isEqualTo(100)
+    }
+
+    /**
+     * Single-field DESC cache filtered by `ranges=createdAt:gte:101`.
+     *
+     * EdgeCache (source=1000, OUT, recent_wishlist) wide row:
+     * |       row key        | qualifier (DESC) | target | createdAt | vs gte:101 |
+     * |----------------------|------------------|--------|-----------|------------|
+     * | hash|1000|T|-6|OUT|C | ~101             | 2001   | 101       | included   |
+     * |                      | ~100             | 2000   | 100       | excluded   |
+     *
+     * Expected: only 2001 (createdAt=101) survives the `ColumnRangeFilter`.
+     */
+    @Test
+    fun `seek with single-field range filter excludes rows below the bound`() {
+        client
+            .get()
+            .uri(
+                "/graph/v3/databases/$db/tables/$edgeTable/edges/seek/recent_wishlist" +
+                    "?start=1000&direction=OUT&ranges=createdAt:gte:101",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.count")
+            .isEqualTo(1)
+            .jsonPath("$.edges[0].target")
+            .isEqualTo(2001)
+            .jsonPath("$.edges[0].properties.createdAt")
+            .isEqualTo(101)
+            .jsonPath("$.hasNext")
+            .isEqualTo(false)
+    }
+
+    /**
+     * Compound cache (permission ASC, createdAt DESC) filtered by leading-prefix `Eq`.
+     *
+     * EdgeCache (source=1, OUT, permission_created_at_desc) wide row:
+     * |      row key      | permission (ASC) | createdAt (DESC) | target | vs eq:others |
+     * |-------------------|------------------|------------------|--------|--------------|
+     * | hash|1|T|-6|OUT|C | "me"             | 200              | 2      | excluded     |
+     * |                   | "others"         | 500              | 3      | included     |
+     * |                   | "others"         | 400              | 4      | included     |
+     * |                   | "others"         | 300              | 5      | included     |
+     * |                   | "others"         | 100              | 6      | included     |
+     *
+     * `ranges=permission:eq:others` brackets the four "others" rows into a single
+     * `ColumnRangeFilter`. Expected: targets [3, 4, 5, 6] in createdAt DESC order.
+     */
+    @Test
+    fun `seek with compound Eq filter returns only the matching permission group`() {
+        client
+            .get()
+            .uri(
+                "/graph/v3/databases/$db/tables/$edgeTable/edges/seek/permission_created_at_desc" +
+                    "?start=1&direction=OUT&ranges=permission:eq:others",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.count")
+            .isEqualTo(4)
+            .jsonPath("$.edges[0].target")
+            .isEqualTo(3)
+            .jsonPath("$.edges[0].properties.createdAt")
+            .isEqualTo(500)
+            .jsonPath("$.edges[3].target")
+            .isEqualTo(6)
+            .jsonPath("$.edges[3].properties.createdAt")
+            .isEqualTo(100)
+    }
+
+    /**
+     * Same compound cache, but `Eq` on permission combined with a trailing range
+     * on createdAt — the canonical `WHERE permission = X AND createdAt < T` shape.
+     *
+     * `ranges=permission:eq:others;createdAt:lt:300` keeps only "others" rows
+     * with createdAt < 300, i.e. the single row with createdAt=100.
+     */
+    @Test
+    fun `seek with compound Eq plus trailing range filters within the group`() {
+        client
+            .get()
+            .uri(
+                "/graph/v3/databases/$db/tables/$edgeTable/edges/seek/permission_created_at_desc" +
+                    "?start=1&direction=OUT&ranges=permission:eq:others;createdAt:lt:300",
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.count")
+            .isEqualTo(1)
+            .jsonPath("$.edges[0].target")
+            .isEqualTo(6)
             .jsonPath("$.edges[0].properties.createdAt")
             .isEqualTo(100)
     }


### PR DESCRIPTION
## Summary

Adds a `ranges` query parameter to the cache `seek` API. Predicates form a leading prefix of the cache's fields and translate to a single HBase `ColumnRangeFilter` over the qualifier bytes. Per-field `Order` is honored by `OrderedBytes` (DESC fields are bit-inverted at write time), so the forward column scan yields the declared compound order with no scan-direction handling required.

Closes #303

## Changes

- Plumb `ranges: String?` from `EdgeQueryController` and `ActionbaseQuery.Item.Seek` through `QueryService.seek` → `TableBinding.seek` → `Label.cache` → `HBaseIndexedLabel.cache`.
- Validate predicates at `V2BackedTableBinding.seek` (matching `scan`): leading-prefix order, trailing-only range, and `IN` rejection.
- Add `HBaseIndexedLabel.encodeCacheRange` to resolve predicates plus offset into one `(from, to)` byte range; offset, when present, supersedes the predicate-derived `from`.
- Add `QualifierStartStop`/`QualifierStartStopItem` as the cache-side analogue of `IndexedLabelMixin.StartStop`/`StartStopItem` (collapsible in a follow-up).
- Drop the `order` parameter and the `from`/`to` swap from `hbaseGetWideRow`; bytes are byte-ordered upstream, so the swap was a no-op.
- Add `ByteArrayBuffer.plusOne` (Kotlin port of `EdgeBuffer.plusOne`) for exclusive boundary bytes on the cache encoder path.

## How to Test

- `./gradlew :core:test --tests "com.kakao.actionbase.core.edge.mapper.EdgeCacheRecordMapperTest"`
- `./gradlew :server:test --tests "com.kakao.actionbase.server.api.graph.v3.EdgeCacheQueryE2ETest"`
- `./gradlew spotlessCheck`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7, 1M context)

