### PR TITLE
Align `scan` and `seek` signatures, expose multi-start in seek

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -59,11 +59,13 @@ interface TableBinding {
 
     fun seek(
         cache: String,
-        start: Any,
+        start: List<Any>,
         direction: Direction,
         limit: Int,
         offset: String?,
         ranges: String?,
+        filters: String?,
+        features: List<String>,
     ): Mono<DataFrame>
 
     fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
@@ -185,15 +185,10 @@ class ActionbaseQueryExecutor(
         actionBaseQuery: ActionbaseQuery,
     ): Mono<DataFrame> =
         resolveVertex(queryItem.source, context, actionBaseQuery).flatMap { source ->
-            Flux
-                .fromIterable(source)
-                .flatMap { start ->
-                    engine
-                        .getTableBinding(database = queryItem.database, alias = queryItem.table)
-                        .seek(queryItem.cache, start, queryItem.direction, queryItem.limit, offset = null, ranges = queryItem.ranges)
-                }.reduce { a, b ->
-                    DataFrame(rows = a.rows + b.rows, schema = a.schema, total = a.total + b.total)
-                }.switchIfEmpty(Mono.just(DataFrame.empty))
+            engine
+                .getTableBinding(database = queryItem.database, alias = queryItem.table)
+                .seek(queryItem.cache, source.toList(), queryItem.direction, queryItem.limit, offset = null, ranges = queryItem.ranges, filters = null, features = emptyList())
+                .switchIfEmpty(Mono.just(DataFrame.empty))
         }
 
     // region Aggregators

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -138,15 +138,17 @@ class QueryService(
         database: String,
         table: String,
         cache: String,
-        start: Any,
+        start: List<Any>,
         direction: Direction,
         limit: Int = ScanFilter.defaultLimit,
         offset: String? = null,
         ranges: String? = null,
+        filters: String? = null,
+        features: List<String> = emptyList(),
     ): Mono<DataFrameEdgePayload> =
         engine
             .getTableBinding(database, table)
-            .seek(cache, start, direction, limit, offset, ranges)
+            .seek(cache, start, direction, limit, offset, ranges, filters, features)
             .map { it.toEdgePayload() }
 
     fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -59,11 +59,13 @@ class NilTableBinding(
 
     override fun seek(
         cache: String,
-        start: Any,
+        start: List<Any>,
         direction: Direction,
         limit: Int,
         offset: String?,
         ranges: String?,
+        filters: String?,
+        features: List<String>,
     ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
     override fun agg(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -224,12 +224,17 @@ class V2BackedTableBinding(
 
     override fun seek(
         cache: String,
-        start: Any,
+        start: List<Any>,
         direction: Direction,
         limit: Int,
         offset: String?,
         ranges: String?,
+        filters: String?,
+        features: List<String>,
     ): Mono<DataFrame> {
+        require(filters == null) { "`filters` is not yet supported in seek query." }
+        require(features.isEmpty()) { "`features` ${features.joinToString(", ")} are not supported in seek query." }
+
         val cacheEntity =
             label.entity.caches.find { it.cache == cache }
                 ?: return Mono.error(IllegalArgumentException("cache `$cache` is not found in label `${label.entity.name}`."))
@@ -258,7 +263,7 @@ class V2BackedTableBinding(
         }
 
         return label
-            .cache(listOf(start), cache, direction, limit, offset, predicates)
+            .cache(start, cache, direction, limit, offset, predicates)
             .map { it.toV3() }
             .switchIfEmpty(EMPTY_DATAFRAME)
     }

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
@@ -128,6 +128,170 @@ class EdgeCacheQuerySpec :
         }
 
         /**
+         * Mutation:
+         * | source | target | createdAt |
+         * |--------|--------|-----------|
+         * | 1000   | 2000   | 100       |
+         * | 1000   | 2002   | 300       |
+         * | 1001   | 3000   | 200       |
+         * | 1001   | 3001   | 400       |
+         *
+         * EdgeCache (direction=OUT) — two distinct row keys
+         * |       row key        | qualifier (DESC) |                   value                 |
+         * |----------------------|------------------|-----------------------------------------|
+         * | hash|1000|T|-6|OUT|C | ~300 | 2002      | version=1, permission=na, createdAt=300 |
+         * |                      | ~100 | 2000      | version=1, permission=na, createdAt=100 |
+         * | hash|1001|T|-6|OUT|C | ~400 | 3001      | version=1, permission=na, createdAt=400 |
+         * |                      | ~200 | 3000      | version=1, permission=na, createdAt=200 |
+         *
+         * Query OUT (start=[1000, 1001], limit=10, DESC)
+         *
+         * Expected: 4 edges — (1000,2002), (1000,2000), (1001,3001), (1001,3000)
+         * (within each row qualifiers are DESC; ordering across rows is not guaranteed)
+         */
+        "INSERT → seek OUT with multi-start returns edges from all sources" {
+            val database = GraphFixtures.serviceName
+            val table = "cache_multi_start_test"
+            val cacheName = "created_at_desc"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "cache multi-start test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    caches =
+                        listOf(
+                            Cache(
+                                cache = cacheName,
+                                fields = listOf(IndexField("createdAt", Order.DESC)),
+                                limit = 100,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "na", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "na", "createdAt": 300}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1001", "target": "3000", "properties": {"permission": "na", "createdAt": 200}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1001", "target": "3001", "properties": {"permission": "na", "createdAt": 400}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { }
+                .verifyComplete()
+
+            queryService
+                .seek(database, table, cacheName, listOf("1000", "1001"), Direction.OUT, 10)
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 4
+                    payload.edges
+                        .map { it.source to it.target }
+                        .toSet() shouldBe
+                        setOf(
+                            1000L to 2002L,
+                            1000L to 2000L,
+                            1001L to 3001L,
+                            1001L to 3000L,
+                        )
+                }.verifyComplete()
+        }
+
+        /**
+         * Multi-start with one source that has no edges — only the populated source contributes.
+         *
+         * EdgeCache (direction=OUT)
+         * |       row key        | qualifier (DESC) |                   value                 |
+         * |----------------------|------------------|-----------------------------------------|
+         * | hash|1000|T|-6|OUT|C | ~200 | 2001      | version=1, permission=na, createdAt=200 |
+         * |                      | ~100 | 2000      | version=1, permission=na, createdAt=100 |
+         * | hash|9999|T|-6|OUT|C | (empty)          |                                         |
+         *
+         * Query OUT (start=[1000, 9999], limit=10, DESC)
+         *
+         * Expected: 2 edges — (1000,2001), (1000,2000)
+         */
+        "INSERT → seek OUT with multi-start tolerates empty source" {
+            val database = GraphFixtures.serviceName
+            val table = "cache_multi_start_empty_test"
+            val cacheName = "created_at_desc"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "cache multi-start empty source test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    caches =
+                        listOf(
+                            Cache(
+                                cache = cacheName,
+                                fields = listOf(IndexField("createdAt", Order.DESC)),
+                                limit = 100,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "na", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "na", "createdAt": 200}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { }
+                .verifyComplete()
+
+            queryService
+                .seek(database, table, cacheName, listOf("1000", "9999"), Direction.OUT, 10)
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 2
+                    payload.edges
+                        .map { it.source to it.target }
+                        .toSet() shouldBe
+                        setOf(
+                            1000L to 2001L,
+                            1000L to 2000L,
+                        )
+                }.verifyComplete()
+        }
+
+        /**
          * Same data as above, but query with limit=2 + cursor pagination.
          *
          * EdgeCache (source=1000, direction=OUT)

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeCacheQuerySpec.kt
@@ -118,7 +118,7 @@ class EdgeCacheQuerySpec :
                 }.verifyComplete()
 
             queryService
-                .seek(database, table, cacheName, "1000", Direction.OUT, 10)
+                .seek(database, table, cacheName, listOf("1000"), Direction.OUT, 10)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 3
@@ -192,7 +192,7 @@ class EdgeCacheQuerySpec :
             // Page 1: limit=2 → [2002, 2001], hasNext=true
             var nextOffset: String? = null
             queryService
-                .seek(database, table, cacheName, "1000", Direction.OUT, 2)
+                .seek(database, table, cacheName, listOf("1000"), Direction.OUT, 2)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 2
@@ -204,7 +204,7 @@ class EdgeCacheQuerySpec :
 
             // Page 2: offset=cursor → [2000], hasNext=false
             queryService
-                .seek(database, table, cacheName, "1000", Direction.OUT, 2, nextOffset)
+                .seek(database, table, cacheName, listOf("1000"), Direction.OUT, 2, nextOffset)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 1
@@ -276,7 +276,7 @@ class EdgeCacheQuerySpec :
 
             // Query IN with start=2000 — should find 1 edge (source=1000 → target=2000)
             queryService
-                .seek(database, table, cacheName, "2000", Direction.IN, 10)
+                .seek(database, table, cacheName, listOf("2000"), Direction.IN, 10)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 1
@@ -286,7 +286,7 @@ class EdgeCacheQuerySpec :
 
             // Query IN with start=1000 — no edges (1000 is source, not target)
             queryService
-                .seek(database, table, cacheName, "1000", Direction.IN, 10)
+                .seek(database, table, cacheName, listOf("1000"), Direction.IN, 10)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 0
@@ -384,7 +384,7 @@ class EdgeCacheQuerySpec :
 
             // Query cache — should return only 1 edge
             queryService
-                .seek(database, table, cacheName, "1000", Direction.OUT, 10)
+                .seek(database, table, cacheName, listOf("1000"), Direction.OUT, 10)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 1
@@ -474,7 +474,7 @@ class EdgeCacheQuerySpec :
 
             // Query OUT — directedTarget is id, not target
             queryService
-                .seek(database, table, cacheName, "1000", Direction.OUT, 10)
+                .seek(database, table, cacheName, listOf("1000"), Direction.OUT, 10)
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 3

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeQueryController.kt
@@ -99,14 +99,16 @@ class EdgeQueryController(
         @PathVariable database: String,
         @PathVariable table: String,
         @PathVariable cache: String,
-        @RequestParam start: String,
+        @RequestParam start: List<String>,
         @RequestParam direction: Direction,
         @RequestParam limit: Int = ScanFilter.defaultLimit,
         @RequestParam offset: String? = null,
         @RequestParam ranges: String? = null,
+        @RequestParam filters: String? = null,
+        @RequestParam features: List<String> = emptyList(),
     ): Mono<ResponseEntity<DataFrameEdgePayload>> =
         queryService
-            .seek(database, table, cache, start, direction, limit, offset, ranges)
+            .seek(database, table, cache, start, direction, limit, offset, ranges, filters, features)
             .mapToResponseEntity()
 
     @GetMapping("/graph/v3/databases/{database}/tables/{table}/edges/agg/{group}")


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/kakao/actionbase/pull/304#issuecomment-4394343062. `seek` is backed by `Label.cache` / `hbaseGetWideRow`, which already take a list of keys, but `TableBinding.seek` / `QueryService.seek` / the HTTP controller exposed only a single `Any`. Widen the external surface to `List<Any>` so it matches the underlying capability and aligns with `agg`'s `start: List<Any>`.

`seek` also gains `filters` and `features` to mirror `scan`. Neither is implemented on the cache path; `V2BackedTableBinding.seek` rejects them via `require(...)` in the same style as `QueryService.counts` / `gets`, so the surface can be filled in later without another signature break.

## Changes

- `TableBinding.seek` / `QueryService.seek` / `V2BackedTableBinding.seek` / `NilTableBinding.seek`: `start: Any` → `List<Any>`, plus `filters: String?` and `features: List<String>`.
- `V2BackedTableBinding.seek`: pass `start` straight through to `label.cache(start, …)`; `require(filters == null)` and `require(features.isEmpty())`.
- `EdgeQueryController.seek`: `@RequestParam start: List<String>` (mirrors `agg`), plus `filters` and `features`.
- `ActionbaseQueryExecutor.processSeek`: drop the per-source `Flux.fromIterable.flatMap`; pass the resolved sources into `seek` in a single call.

## How to Test

- \`./gradlew :engine:test --tests \"com.kakao.actionbase.v2.engine.v3.EdgeCacheQuerySpec\"\`
- \`./gradlew :engine:test --tests \"com.kakao.actionbase.v2.engine.v3.MultiHopQuerySpec\"\`
- \`./gradlew :server:test --tests \"com.kakao.actionbase.server.api.graph.v3.EdgeCacheQueryE2ETest\"\`
- \`./gradlew spotlessCheck\`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7, 1M context)