### PR TITLE
docs: update codec-java compatibility for 0.2.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -124,13 +124,10 @@ Each module releases independently.
 | **server**     | Docker image | `ghcr.io/kakao/actionbase` |
 | **cli**        | Binary       | GitHub Releases            |
 
-`codec-java` is slated for deprecation and will be absorbed into the Kotlin `core` module.
-
 ### Compatibility
 
-| codec-java                              | Actionbase (server) |
-| --------------------------------------- | ------------------- |
-| `v2-core:1.0.14-SNAPSHOT` (source only) | 0.1.x, 0.2.x        |
-| `codec-java:0.1.0`                      | 0.3.x               |
+| codec-java | Actionbase (server) |
+| ---------- | ------------------- |
+| 0.2.0      | 0.3.x               |
 
 Release announcements are posted in [GitHub Releases](https://github.com/kakao/actionbase/releases).


### PR DESCRIPTION
## Summary

Update the codec-java compatibility table to reflect the 0.2.0 release.

## Changes

- Map `codec-java 0.2.0` to server `0.3.x` in the compatibility table
- Drop the legacy `v2-core:1.0.14-SNAPSHOT` source-only entry
- Remove the pending deprecation note for codec-java

## How to Test

Render `RELEASES.md` on GitHub and confirm the Compatibility table shows a single `0.2.0 → 0.3.x` row.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)