### PR TITLE
Add workflow DSL skeleton for pipeline jobs

### DIFF
--- a/pipeline/build.gradle.kts
+++ b/pipeline/build.gradle.kts
@@ -13,6 +13,28 @@ tasks.withType<JavaExec> {
     jvmArgs = listOf("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED")
 }
 
+// Run a Workflow YAML through EmbeddedRunner without a separate spark-submit.
+//   ./gradlew :pipeline:runWorkflow --args="pipeline/workflows/spark-pi.yaml"
+//
+// `env:` values can be overridden by passing extra `KEY=VALUE` args after the YAML path:
+//   ./gradlew :pipeline:runWorkflow --args="pipeline/workflows/spark-pi.yaml SAMPLES=100000"
+//
+// Working directory is the repo root so paths in `--args=...` are interpreted
+// the same as if the user typed them from where they invoke gradle.
+//
+// Spark is `compileOnly` for the module (a real `spark-submit` runtime provides it),
+// so the embedded runner pulls Spark from the test classpath where it is `testImplementation`.
+tasks.register<JavaExec>("runWorkflow") {
+    group = "application"
+    description = "Run a Workflow YAML through the EmbeddedRunner."
+    mainClass.set("com.kakao.actionbase.pipeline.runner.EmbeddedRunner")
+    classpath = sourceSets["test"].runtimeClasspath
+    workingDir = project.rootDir
+    systemProperty("spark.master", "local[*]")
+    systemProperty("spark.driver.bindAddress", "127.0.0.1")
+    systemProperty("spark.ui.enabled", "false")
+}
+
 dependencies {
     implementation(project(":codec-java"))
 

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Job.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Job.scala
@@ -1,0 +1,78 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import com.kakao.actionbase.pipeline.runtime.JobOutputs
+import org.apache.spark.sql.SparkSession
+
+import scala.reflect.ClassTag
+
+/** One spark-submit unit. Subclass and implement `plan(cfg)`.
+  *
+  * Two entry points share the same Cfg-binding mapper:
+  *   - `main(argv)` — for spark-submit / CLI: parses `--key=value` argv into Cfg.
+  *   - `planFromMap(args)` — for in-process runners: binds an arbitrary YAML-shaped Map onto Cfg, supporting nested
+  *     fields like `Seq[StepSpec]` that argv cannot represent.
+  *
+  * Use `emit(name, value)` from inside `plan` to expose a named output to downstream jobs in the same Workflow (e.g.,
+  * a file path the Job decided at run time). When invoked outside a runner, emit() is a no-op.
+  *
+  * case class MyConfig(in: String, out: String)
+  *
+  * object MyJob extends Job[MyConfig] { override def plan(cfg: MyConfig): Plan.Closed = { emit("out", cfg.out)
+  * FileSource(cfg.in, "parquet") ~> MyTransform() ~> FileSink(cfg.out, "parquet") } }
+  */
+abstract class Job[C <: Product: ClassTag] {
+
+  def plan(cfg: C): Plan.Closed
+
+  protected def emit(name: String, value: String): Unit = JobOutputs.emit(name, value)
+
+  /** Hook for subclasses to tweak the SparkSession builder (master, configs). */
+  protected def configure(builder: SparkSession.Builder): SparkSession.Builder = builder
+
+  /** Bind `args` onto Cfg via Jackson and return the resulting Plan. Used by runners that already manage Spark. */
+  def planFromMap(args: Map[String, Any]): Plan.Closed = {
+    val cls = implicitly[ClassTag[C]].runtimeClass.asInstanceOf[Class[C]]
+    val cfg = Job.mapper.convertValue(args, cls)
+    plan(cfg)
+  }
+
+  def main(argv: Array[String]): Unit = {
+    val args = Job.parseArgv(argv)
+    println(s"Running ${getClass.getSimpleName}: $args")
+
+    val spark = configure(
+      SparkSession.builder().appName(getClass.getCanonicalName.stripSuffix("$"))
+    ).getOrCreate()
+
+    try planFromMap(args).run()(spark)
+    finally {
+      println("Stopping Spark session...")
+      spark.stop()
+    }
+  }
+}
+
+object Job {
+
+  // Strict mapper: missing required primitives must throw rather than silently
+  // become 0/false. Unknown keys are tolerated so `--extra=...` doesn't fail.
+  @transient private[pipeline] lazy val mapper: ObjectMapper with ClassTagExtensions = {
+    val m = new ObjectMapper() with ClassTagExtensions
+    m.registerModule(DefaultScalaModule)
+    m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    m.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+    m
+  }
+
+  private def parseArgv(argv: Array[String]): Map[String, Any] =
+    argv.iterator.flatMap { s =>
+      if (!s.startsWith("--")) None
+      else
+        s.drop(2).split("=", 2) match {
+          case Array(k, v) => Some(k -> v)
+          case _           => None
+        }
+    }.toMap
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Plan.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Plan.scala
@@ -1,0 +1,132 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import scala.collection.mutable
+
+// Type-state wrapper around the internal Ast.
+//   Open   = chain ends in a Source or Transform; not yet runnable.
+//   Closed = chain ends in a Sink (or Fork of Sinks); runnable.
+sealed trait Plan {
+  private[dsl] def ast: Ast
+}
+
+object Plan {
+
+  final class Open private[dsl] (
+      private[dsl] val ast: Ast,
+      private[dsl] val edgeLabel: String = "_0"
+  ) extends Plan {
+
+    /** Name this step's output for the consumer's view of it (e.g., the temp view name a `SqlTransform` will see).
+      * Defaults to `"_0"` if not called.
+      */
+    def as(label: String): Open = new Open(ast, label)
+
+    def ~>(t: Transform): Open = new Open(Ast.Tx(Seq(edgeLabel -> ast), t))
+
+    def ~>(s: Sink): Closed = new Closed(Ast.Snk(ast, s))
+
+    /** Combine with another labeled output to feed a multi-input Transform:
+      *
+      * `(users.as("u") + events.as("e")) ~> SqlTransform("... FROM u JOIN e ...")`.
+      */
+    def +(other: Open): MultiOpen =
+      new MultiOpen(Seq(edgeLabel -> ast, other.edgeLabel -> other.ast))
+
+    def fanOut(branches: (Open => Closed)*): Closed = {
+      require(branches.nonEmpty, "fanOut requires at least one branch")
+      val branchAsts = branches.map { b =>
+        val branchOpen = new Open(Ast.Ref)
+        b(branchOpen).ast
+      }
+      new Closed(Ast.Fork(ast, branchAsts))
+    }
+  }
+
+  /** Two or more labeled outputs combined for a multi-input Transform. Build via `Open.+`; finish with `~>`. */
+  final class MultiOpen private[dsl] (private[dsl] val parts: Seq[(String, Ast)]) {
+    def +(other: Open): MultiOpen = new MultiOpen(parts :+ (other.edgeLabel -> other.ast))
+    def ~>(t: Transform): Open    = new Open(Ast.Tx(parts, t))
+  }
+
+  final class Closed private[dsl] (private[dsl] val ast: Ast) extends Plan {
+    def run()(implicit spark: SparkSession): Unit = Executor.run(ast)
+  }
+
+  /** Escape hatch for runners that build the AST directly (e.g., `StepsBuilder` assembling a DAG from YAML). */
+  private[pipeline] def closed(ast: Ast): Closed = new Closed(ast)
+  private[pipeline] def open(ast: Ast): Open     = new Open(ast)
+}
+
+// Internal AST. Hidden from users so the DSL surface stays small.
+private[pipeline] sealed trait Ast
+private[pipeline] object Ast {
+  case class Src(s: Source)                                  extends Ast
+  case class Tx(upstreams: Seq[(String, Ast)], t: Transform) extends Ast
+  case class Snk(upstream: Ast, s: Sink)                     extends Ast
+  case class Fork(upstream: Ast, branches: Seq[Ast])         extends Ast
+  // Multiple terminal roots executed under a shared materialization memo, so a common upstream is built once even
+  // when several sinks consume it.
+  case class Group(roots: Seq[Ast])                          extends Ast
+  case object Ref                                            extends Ast
+}
+
+private[dsl] object Executor {
+
+  def run(ast: Ast)(implicit spark: SparkSession): Unit = {
+    val memo = mutable.Map.empty[Ast, DataFrame]
+    runRoot(ast, memo)
+  }
+
+  private def runRoot(ast: Ast, memo: mutable.Map[Ast, DataFrame])(implicit
+      spark: SparkSession
+  ): Unit = ast match {
+    case Ast.Snk(up, sink) =>
+      sink.write(materialize(up, memo))
+
+    case Ast.Fork(up, branches) =>
+      val df = materialize(up, memo).cache()
+      try branches.foreach(b => runBranch(b, df))
+      finally df.unpersist(blocking = false)
+
+    case Ast.Group(roots) =>
+      roots.foreach(r => runRoot(r, memo))
+
+    case other =>
+      throw new IllegalStateException(
+        s"Top-level Plan must end in a Sink, Fork, or Group, got: $other"
+      )
+  }
+
+  private def materialize(ast: Ast, memo: mutable.Map[Ast, DataFrame])(implicit
+      spark: SparkSession
+  ): DataFrame = memo.getOrElseUpdate(
+    ast,
+    ast match {
+      case Ast.Src(s) => s.read()
+      case Ast.Tx(ups, t) =>
+        t.apply(ups.map { case (label, up) => label -> materialize(up, memo) })
+      case Ast.Ref =>
+        throw new IllegalStateException("Ast.Ref outside fanOut branch — invalid Plan")
+      case other =>
+        throw new IllegalStateException(s"materialize cannot handle: $other")
+    }
+  )
+
+  private def runBranch(ast: Ast, root: DataFrame)(implicit spark: SparkSession): Unit = {
+    def go(p: Ast): DataFrame = p match {
+      case Ast.Ref         => root
+      case Ast.Tx(ups, t)  => t.apply(ups.map { case (label, up) => label -> go(up) })
+      case other =>
+        throw new IllegalStateException(
+          s"fanOut branch must be Transform*-then-Sink rooted at the fork, got: $other"
+        )
+    }
+    ast match {
+      case Ast.Snk(up, sink) => sink.write(go(up))
+      case other =>
+        throw new IllegalStateException(s"fanOut branch must end in Sink, got: $other")
+    }
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Step.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Step.scala
@@ -1,0 +1,27 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+sealed trait Step
+
+trait Source extends Step {
+  def read()(implicit spark: SparkSession): DataFrame
+}
+
+/** A Transform consumes one or more labeled input DataFrames and produces one. Each input arrives as a
+  * `(label, df)` pair so consumers (e.g., `SqlTransform`) can use the label as a temp view name without re-stating
+  * it. The label is the producer's `as:` (or `"_0"` for a single-input chain default).
+  */
+trait Transform extends Step {
+  def apply(inputs: Seq[(String, DataFrame)])(implicit spark: SparkSession): DataFrame
+
+  /** Single-input convenience for DSL `~>` and unit tests. The implicit label is `"_0"`. */
+  def apply(in: DataFrame)(implicit spark: SparkSession): DataFrame = apply(Seq("_0" -> in))
+}
+
+/** A Sink consumes a single DataFrame. Multi-input fan-in isn't a Sink concern — wire multiple sinks as siblings via
+  * `fanOut(...)` (Scala DSL) or repeat the sink step under different `inputs:` (YAML).
+  */
+trait Sink extends Step {
+  def write(in: DataFrame)(implicit spark: SparkSession): Unit
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/package.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/package.scala
@@ -1,0 +1,10 @@
+package com.kakao.actionbase.pipeline
+
+import scala.language.implicitConversions
+
+package object dsl {
+  // Lets a Source start a chain: `MySource(...) ~> MyTransform() ~> MySink(...)`.
+  // `~>` lives on Plan.Open, so this conversion bridges the gap.
+  implicit def sourceToOpen(s: Source): Plan.Open =
+    new Plan.Open(Ast.Src(s))
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/SparkPiJob.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/SparkPiJob.scala
@@ -1,0 +1,23 @@
+package com.kakao.actionbase.pipeline.jobs
+
+import com.kakao.actionbase.pipeline.dsl._
+import com.kakao.actionbase.pipeline.steps.sink.ShowSink
+import com.kakao.actionbase.pipeline.steps.source.SampleSource
+import com.kakao.actionbase.pipeline.steps.transform.SqlTransform
+
+/** Worked example of the Source ~> Transform ~> Sink DSL: Monte-Carlo estimation of π.
+  *
+  * Throws `samples` random points into the unit square, computes π ≈ 4 · inside / total via SQL, and prints the
+  * single-row result to stdout. Pure composition of reusable Steps — no Job-specific Step definitions.
+  */
+case class SparkPiCfg(samples: Long = 1000000L)
+
+object SparkPiJob extends Job[SparkPiCfg] {
+
+  override def plan(cfg: SparkPiCfg): Plan.Closed =
+    SampleSource(cfg.samples, Seq("x", "y")).as("samples") ~>
+      SqlTransform(
+        "SELECT 4.0 * SUM(CASE WHEN x*x + y*y <= 1 THEN 1 ELSE 0 END) / COUNT(*) AS pi FROM samples"
+      ) ~>
+      ShowSink()
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJob.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJob.scala
@@ -1,0 +1,19 @@
+package com.kakao.actionbase.pipeline.jobs
+
+import com.kakao.actionbase.pipeline.dsl.{Job, Plan}
+import com.kakao.actionbase.pipeline.runner.StepsBuilder
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+
+/** Generic Job whose Plan is built at runtime from an inline `steps:` list in its Cfg. Lets a workflow YAML express
+  * a Source ~> Transform* ~> Sink chain without requiring a hand-written Job class:
+  *
+  * jobs: pi: uses: com.kakao.actionbase.pipeline.jobs.StepsRunnerJob with: steps:
+  *   - uses: com.kakao.actionbase.pipeline.steps.source.SampleSource with: { n: 1000000, columns: [x, y] }
+  *   - uses: com.kakao.actionbase.pipeline.steps.transform.SqlTransform with: { query: "SELECT ... FROM _0" }
+  *   - uses: com.kakao.actionbase.pipeline.steps.sink.ShowSink
+  */
+case class StepsRunnerCfg(steps: Seq[StepSpec])
+
+object StepsRunnerJob extends Job[StepsRunnerCfg] {
+  override def plan(cfg: StepsRunnerCfg): Plan.Closed = StepsBuilder.build(cfg.steps)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/ClassResolver.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/ClassResolver.scala
@@ -1,0 +1,32 @@
+package com.kakao.actionbase.pipeline.runner
+
+/** Resolves a Job or Step class name from a workflow YAML. The name may be:
+  *   - a full FQN (`com.kakao.actionbase.pipeline.jobs.SparkPiJob`),
+  *   - a short name (`SparkPiJob`), resolved relative to one of `roots`,
+  *   - or a sub-package name (`subdir.MySource`), also resolved relative to a root.
+  *
+  * Roots are tried in order; first match wins.
+  */
+object ClassResolver {
+
+  val JobRoots: Seq[String] = Seq("com.kakao.actionbase.pipeline.jobs")
+
+  val StepRoots: Seq[String] = Seq(
+    "com.kakao.actionbase.pipeline.steps.source",
+    "com.kakao.actionbase.pipeline.steps.transform",
+    "com.kakao.actionbase.pipeline.steps.sink"
+  )
+
+  def resolve(name: String, roots: Seq[String]): Class[_] = {
+    val candidates = name +: roots.map(r => s"$r.$name")
+    candidates.view.flatMap(tryLoad).headOption.getOrElse {
+      throw new ClassNotFoundException(
+        s"Cannot resolve '$name' as a full FQN or under any of: ${roots.mkString(", ")}"
+      )
+    }
+  }
+
+  private def tryLoad(fqn: String): Option[Class[_]] =
+    try Some(Class.forName(fqn))
+    catch { case _: ClassNotFoundException => None }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/EmbeddedRunner.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/EmbeddedRunner.scala
@@ -1,0 +1,155 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.dsl.Job
+import com.kakao.actionbase.pipeline.runtime.JobOutputs
+import com.kakao.actionbase.pipeline.workflow.{JobSpec, Workflow, WorkflowLoader}
+import org.apache.spark.sql.SparkSession
+
+import java.nio.file.Files
+
+import scala.collection.mutable
+
+/** In-process runner for a Workflow YAML. Resolves dependencies via topological sort and invokes each Job in the
+  * same JVM. Each Job creates and tears down its own SparkSession (`local[*]` by default).
+  *
+  * Intended for tests and local dev: no `spark-submit` binary is required and `submit:` is advisory. For
+  * production-parity execution (subprocess `spark-submit`, `submit:` mapped to CLI flags), use a `spark-submit`-based
+  * runner — TBD.
+  *
+  * Expression resolution: `${{ env.X }}` and `${{ needs.A.outputs.X }}` are substituted in every string leaf of each
+  * Job's `with:` map (recursively into nested maps and lists) before binding to the Job's Cfg.
+  */
+object EmbeddedRunner {
+
+  def main(argv: Array[String]): Unit = {
+    require(argv.nonEmpty, "Usage: EmbeddedRunner <workflow.yaml> [KEY=VALUE ...]")
+    val workflowPath = argv.head
+    val cliArgs = argv.tail.flatMap { kv =>
+      kv.split("=", 2) match {
+        case Array(k, v) if k.nonEmpty => Some(k -> v)
+        case _ =>
+          System.err.println(s"[EmbeddedRunner] ignoring malformed env override: '$kv' (expected KEY=VALUE)")
+          None
+      }
+    }.toMap
+
+    val wf        = WorkflowLoader.load(workflowPath)
+    val perSource = EnvCascade.perSource(wf.env, cliArgs)
+    EnvCascade.printReport(perSource)
+
+    run(wf, cliArgs)
+  }
+
+  def run(
+      wf: Workflow,
+      extraEnv: Map[String, String] = Map.empty
+  ): Map[String, Map[String, String]] = {
+    val order = topoSort(wf.jobs)
+    val sched = wf.schedule.map(s => s" (schedule advisory: '$s')").getOrElse("")
+    println(s"Workflow '${wf.name}'$sched — running ${order.size} job(s): ${order.mkString(" -> ")}")
+
+    val tmpDir  = Files.createTempDirectory(s"actionbase-runner-${wf.name}-")
+    val canonEnv = EnvCascade.merged(EnvCascade.perSource(wf.env, extraEnv))
+    var ctx      = Context(env = canonEnv)
+    val skipped  = mutable.Set[String]()
+
+    order.foreach { id =>
+      val spec        = wf.jobs(id)
+      val skippedDeps = spec.needs.filter(skipped.contains)
+
+      if (skippedDeps.nonEmpty) {
+        println(s"--- [$id] SKIPPED (dep skipped: ${skippedDeps.mkString(", ")})")
+        skipped += id
+      } else if (!spec.`if`.forall(cond => Expression.evaluateBoolean(cond, ctx))) {
+        println(s"--- [$id] SKIPPED (if='${spec.`if`.get}')")
+        skipped += id
+      } else {
+        val ref             = UsesRef.parse(spec.uses)
+        val effectiveSubmit = SubmitPreset.resolve(spec.submit, wf.presets)
+
+        if (ref.kind == "spark" && effectiveSubmit.isEmpty) {
+          throw new IllegalArgumentException(
+            s"[$id] `submit:` is required for kind=spark — even though EmbeddedRunner runs in-process, " +
+              "production runners need it to assemble `spark-submit`. Use `preset:` or inline keys."
+          )
+        }
+
+        val outputFile = tmpDir.resolve(s"$id.outputs").toString
+        System.setProperty(JobOutputs.SystemPropertyKey, outputFile)
+
+        if (effectiveSubmit.nonEmpty) {
+          println(s"    [$id] submit (advisory, in-process runner ignores): $effectiveSubmit")
+        }
+
+        try runJob(id, spec, ctx, ref)
+        finally System.clearProperty(JobOutputs.SystemPropertyKey)
+
+        val outputs = JobOutputs.read(outputFile)
+        if (outputs.nonEmpty) println(s"    [$id] outputs: $outputs")
+        ctx = ctx.copy(outputs = ctx.outputs + (id -> outputs))
+      }
+    }
+    ctx.outputs
+  }
+
+  private def runJob(id: String, spec: JobSpec, ctx: Context, ref: UsesRef): Unit = {
+    val resolvedWith = Expression.resolveDeep(spec.`with`, ctx).asInstanceOf[Map[String, Any]]
+
+    println(s"    [$id] uses ${ref.coord} (kind=${ref.kind})")
+
+    ref.kind match {
+      case "spark" => runSparkJob(id, ref, resolvedWith)
+      case other =>
+        throw new IllegalArgumentException(
+          s"[$id] kind '$other' is reserved for future use; v1 supports `spark` only"
+        )
+    }
+  }
+
+  private def runSparkJob(id: String, ref: UsesRef, resolvedWith: Map[String, Any]): Unit = {
+    val className = ref.mainClass.getOrElse {
+      throw new IllegalArgumentException(
+        s"[$id] `uses:` must include the entry-point class — " +
+          s"e.g., `${ref.coord}:MyJob` (mirrors `spark-submit --class`)"
+      )
+    }
+
+    println(s"--- [$id] $className $resolvedWith")
+    val plan  = loadJob(className).planFromMap(resolvedWith)
+    val spark = SparkSession.builder().appName(s"actionbase-$id").getOrCreate()
+    try plan.run()(spark)
+    finally spark.stop()
+  }
+
+  // Kahn-style DFS topo sort. Detects cycles, fails on unknown `needs`.
+  private def topoSort(jobs: Map[String, JobSpec]): Seq[String] = {
+    val visited  = mutable.LinkedHashSet[String]()
+    val visiting = mutable.Set[String]()
+
+    def visit(id: String): Unit = {
+      if (visiting(id)) throw new IllegalStateException(s"Cycle detected involving job '$id'")
+      if (!visited(id)) {
+        visiting += id
+        val spec = jobs.getOrElse(
+          id,
+          throw new IllegalStateException(s"Unknown job in 'needs': '$id'")
+        )
+        spec.needs.foreach(visit)
+        visiting -= id
+        visited += id
+      }
+    }
+
+    jobs.keys.toSeq.sorted.foreach(visit)
+    visited.toSeq
+  }
+
+  // Scala objects compile to a class with a static `MODULE$` field — load it
+  // and cast back to the Job contract. `name` may be a full FQN, a short name,
+  // or a sub-package name relative to `ClassResolver.JobRoots`.
+  private def loadJob(name: String): Job[_ <: Product] = {
+    val cls    = ClassResolver.resolve(s"$name$$", ClassResolver.JobRoots)
+    val module = cls.getField("MODULE$").get(null)
+    module.asInstanceOf[Job[_ <: Product]]
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/EnvCascade.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/EnvCascade.scala
@@ -1,0 +1,66 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.util.ConfigSource
+
+/** Cascading resolution of a workflow's `env:` overrides, mirroring the `ConfigLoader` / `ConfigPrinter` model used
+  * by Job Cfg loading. Sources are merged left-to-right, so later wins. v1 ships two sources:
+  *
+  *   yaml (workflow `env:` defaults) < args (CLI `KEY=VALUE` overrides)
+  *
+  * Keys are matched Spring-relaxed-binding style: every key is canonicalized to lowercase with `--` / `-` / `_`
+  * stripped, so `SAMPLES`, `samples`, `--samples`, `--Sample-S`, and `sample_s` all resolve to the same entry.
+  */
+object EnvCascade {
+
+  /** Canonical key form: `lower_snake_case`. The same canonical key matches across these surface forms:
+    *
+    *   `SOME_SAMPLES` ≡ `some_samples` ≡ `someSamples` ≡ `some-samples` ≡ `--some-samples`
+    *
+    * The rule: drop a leading `--`, swap `-` for `_`, insert `_` at every camel-case boundary, lowercase. Word
+    * boundaries inside the key are preserved — `sample_s` stays distinct from `samples`, so distinct logical names
+    * don't accidentally collide.
+    */
+  def canonical(k: String): String = {
+    val stripped = if (k.startsWith("--")) k.drop(2) else k
+    stripped
+      .replace('-', '_')
+      .replaceAll("([a-z])([A-Z])", "$1_$2")
+      .toLowerCase
+  }
+
+  case class YamlSource(env: Map[String, String]) extends ConfigSource {
+    val name                          = "yaml"
+    def load(): Map[String, String]   = env.map { case (k, v) => canonical(k) -> v }
+  }
+
+  case class ArgsSource(args: Map[String, String]) extends ConfigSource {
+    val name                          = "args"
+    def load(): Map[String, String]   = args.map { case (k, v) => canonical(k) -> v }
+  }
+
+  def perSource(yamlEnv: Map[String, String], cliArgs: Map[String, String]): Seq[(String, Map[String, String])] = {
+    val sources: Seq[ConfigSource] = Seq(YamlSource(yamlEnv), ArgsSource(cliArgs))
+    sources.map(s => s.name -> s.load())
+  }
+
+  def merged(perSource: Seq[(String, Map[String, String])]): Map[String, String] =
+    if (perSource.isEmpty) Map.empty else perSource.map(_._2).reduce(_ ++ _)
+
+  /** Per-key report of the resolved env: winning value, its source, and a trace of every source that contributed.
+    * Matches `ConfigPrinter.printConfigReport` shape so a reader sees the same format across Cfg and env loading.
+    */
+  def printReport(perSource: Seq[(String, Map[String, String])]): Unit = {
+    val m = merged(perSource)
+    if (m.isEmpty) return
+    println("=== Workflow env ===")
+    m.keys.toSeq.sorted.foreach { k =>
+      val v = m(k)
+      val origin = perSource.reverse
+        .collectFirst { case (n, src) if src.contains(k) => n }
+        .getOrElse("?")
+      val trace     = perSource.flatMap { case (n, src) => src.get(k).map(vv => s"$n=$vv") }
+      val tracePart = if (trace.isEmpty) "" else s"  (${trace.mkString(", ")})"
+      println(s"  $k = $v  [$origin]$tracePart")
+    }
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/Expression.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/Expression.scala
@@ -1,0 +1,95 @@
+package com.kakao.actionbase.pipeline.runner
+
+import scala.collection.JavaConverters._
+import scala.util.matching.Regex
+
+/** Resolves `${{ ... }}` expressions in workflow YAML against a context tree. Supported paths:
+  *   - `env.<name>` → Workflow `env:` block
+  *   - `needs.<jobId>.outputs.<name>` → outputs emitted by an upstream job
+  *
+  * Resolution is one-pass. Nested expressions inside another expression's resolved value are not re-evaluated,
+  * mirroring GitHub Actions semantics.
+  *
+  * `evaluateBoolean` handles `if:` conditions: truthy check by default, with optional `==` / `!=` string comparison.
+  * Outer `${{ ... }}` braces are optional in `if:` since the value is always an expression.
+  */
+object Expression {
+
+  private val pattern: Regex = """\$\{\{\s*([^}]+?)\s*\}\}""".r
+  private val eqRe: Regex    = """\A(.+?)\s*==\s*(.+)\z""".r
+  private val neqRe: Regex   = """\A(.+?)\s*!=\s*(.+)\z""".r
+
+  def resolve(input: String, ctx: Context): String =
+    pattern.replaceAllIn(input, m => Regex.quoteReplacement(lookup(m.group(1), ctx)))
+
+  /** Recursively resolve `${{ ... }}` in every string leaf of a YAML-shaped value (Map / Seq / scalar). Non-string
+    * leaves pass through unchanged. Returns Scala collections so Jackson can convert the result to a Cfg.
+    */
+  def resolveDeep(value: Any, ctx: Context): Any = value match {
+    case s: String => resolve(s, ctx)
+    case m: scala.collection.Map[_, _] =>
+      m.iterator.map { case (k, v) => k.toString -> resolveDeep(v, ctx) }.toMap
+    case jm: java.util.Map[_, _] =>
+      jm.asScala.iterator.map { case (k, v) => k.toString -> resolveDeep(v, ctx) }.toMap
+    case s: scala.collection.Iterable[_] => s.map(resolveDeep(_, ctx)).toSeq
+    case jl: java.util.List[_]           => jl.asScala.map(resolveDeep(_, ctx)).toSeq
+    case other                           => other
+  }
+
+  def evaluateBoolean(input: String, ctx: Context): Boolean = {
+    val expr = stripBraces(input).trim
+    expr match {
+      case neqRe(l, r) => evalOperand(l, ctx) != evalOperand(r, ctx)
+      case eqRe(l, r)  => evalOperand(l, ctx) == evalOperand(r, ctx)
+      case _           => isTruthy(evalOperand(expr, ctx))
+    }
+  }
+
+  private def stripBraces(s: String): String = {
+    val t = s.trim
+    if (t.startsWith("${{") && t.endsWith("}}")) t.substring(3, t.length - 2).trim else t
+  }
+
+  private def evalOperand(token: String, ctx: Context): String = {
+    val t = token.trim
+    if (
+      t.length >= 2 && (
+        (t.startsWith("'") && t.endsWith("'")) ||
+          (t.startsWith("\"") && t.endsWith("\""))
+      )
+    ) {
+      t.substring(1, t.length - 1)
+    } else {
+      lookup(t, ctx)
+    }
+  }
+
+  private def isTruthy(s: String): Boolean = s.trim match {
+    case "" | "false" | "0" => false
+    case _                  => true
+  }
+
+  private def lookup(path: String, ctx: Context): String = path.split('.').toList match {
+    case "env" :: key :: Nil =>
+      ctx.env.getOrElse(EnvCascade.canonical(key), throw missing(s"env.$key"))
+
+    case "needs" :: jobId :: "outputs" :: name :: Nil =>
+      ctx.outputs
+        .getOrElse(jobId, throw missing(s"needs.$jobId (job has no recorded outputs)"))
+        .getOrElse(name, throw missing(s"needs.$jobId.outputs.$name"))
+
+    case _ =>
+      throw new IllegalArgumentException(s"Unsupported expression: '$path'")
+  }
+
+  private def missing(path: String): IllegalStateException =
+    new IllegalStateException(s"Expression resolution failed: '$path' not found in context")
+}
+
+/** Runtime context maintained by the runner across job executions. `outputs` is keyed by jobId, then by emitted output
+  * name.
+  */
+case class Context(
+    env: Map[String, String] = Map.empty,
+    outputs: Map[String, Map[String, String]] = Map.empty
+)

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/StepsBuilder.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/StepsBuilder.scala
@@ -1,0 +1,126 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.dsl._
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+
+import scala.collection.mutable
+
+/** Reflectively assembles a runnable `Plan.Closed` from a list of `StepSpec`s. Each spec's `args:` map is bound onto
+  * the Step's case-class fields via Jackson; the resulting AST is wired together as a DAG.
+  *
+  * Wiring rules:
+  *   - Source steps stand alone (no upstream).
+  *   - A step's upstream inputs are resolved from `inputs:` labels first; if absent, the previous step's output is
+  *     used (linear-chain default).
+  *   - `as: <label>` registers the step's output for later `inputs:` references.
+  *   - The terminal step must be a Sink; the result is a `Plan.Closed`.
+  *
+  * Expression resolution (`${{ ... }}`) is the caller's responsibility — `args:` values are bound as-is.
+  */
+object StepsBuilder {
+
+  def build(steps: Seq[StepSpec]): Plan.Closed = {
+    require(steps.nonEmpty, "`steps` must be non-empty")
+
+    val byLabel       = mutable.LinkedHashMap.empty[String, Ast]
+    val sinks         = mutable.ListBuffer.empty[Ast.Snk]
+    var prev: Ast     = null  // most recent step's AST (linear-chain default upstream)
+
+    steps.foreach { spec =>
+      val instance = instantiate(spec)
+      val ast: Ast = instance match {
+        case s: Source =>
+          require(spec.inputs.isEmpty, s"Source `${spec.step}` cannot declare `inputs:`")
+          Ast.Src(s)
+
+        case t: Transform =>
+          Ast.Tx(resolveUpstreams(spec, byLabel, prev), t)
+
+        case k: Sink =>
+          require(
+            spec.inputs.size <= 1,
+            s"Sink `${spec.step}` is single-input; `inputs:` must have at most one entry, got ${spec.inputs.size}"
+          )
+          val (_, up) = resolveUpstreams(spec, byLabel, prev).head
+          val snk     = Ast.Snk(up, k)
+          sinks += snk
+          snk
+
+        case other =>
+          throw new IllegalArgumentException(
+            s"${spec.step} is not a Step (must extend Source, Transform, or Sink); got ${other.getClass.getName}"
+          )
+      }
+
+      spec.as.foreach { label =>
+        if (byLabel.contains(label)) {
+          throw new IllegalArgumentException(s"duplicate step label `as: $label`")
+        }
+        byLabel(label) = ast
+      }
+      prev = ast
+    }
+
+    sinks.size match {
+      case 0 => throw new IllegalArgumentException("workflow must have at least one Sink")
+      case 1 => Plan.closed(sinks.head)
+      case _ => Plan.closed(Ast.Group(sinks.toSeq))
+    }
+  }
+
+  private def resolveUpstreams(
+      spec: StepSpec,
+      byLabel: collection.Map[String, Ast],
+      prev: Ast
+  ): Seq[(String, Ast)] = {
+    val ups: Seq[(String, Ast)] =
+      if (spec.inputs.nonEmpty) {
+        spec.inputs.map { label =>
+          val up = byLabel.getOrElse(
+            label,
+            throw new IllegalArgumentException(
+              s"step `${spec.step}` references unknown input `$label`; " +
+                s"known labels: ${if (byLabel.isEmpty) "<none>" else byLabel.keys.mkString(", ")}"
+            )
+          )
+          label -> up
+        }
+      } else {
+        if (prev == null) {
+          throw new IllegalArgumentException(
+            s"step `${spec.step}` has no upstream — the first step must be a Source, " +
+              "or specify `inputs:` referencing labeled upstream(s)"
+          )
+        }
+        Seq("_0" -> prev)
+      }
+
+    ups.foreach {
+      case (_, _: Ast.Src) | (_, _: Ast.Tx) => // ok — produces a DataFrame
+      case (_, other) =>
+        throw new IllegalArgumentException(
+          s"step `${spec.step}` upstream must be a Source or Transform, got ${describe(other)}"
+        )
+    }
+    ups
+  }
+
+  private def instantiate(spec: StepSpec): Step = {
+    val cls = ClassResolver.resolve(spec.step, ClassResolver.StepRoots)
+    val obj = Job.mapper.convertValue(spec.args, cls)
+    obj match {
+      case step: Step => step
+      case _ =>
+        throw new IllegalArgumentException(
+          s"${spec.step} is not a Step (must extend Source, Transform, or Sink)"
+        )
+    }
+  }
+
+  private def describe(ast: Ast): String = ast match {
+    case Ast.Src(s)    => s"Source(${s.getClass.getSimpleName})"
+    case Ast.Tx(_, t)  => s"Transform(${t.getClass.getSimpleName})"
+    case Ast.Snk(_, s) => s"Sink(${s.getClass.getSimpleName})"
+    case other         => other.toString
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/SubmitPreset.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/SubmitPreset.scala
@@ -1,0 +1,39 @@
+package com.kakao.actionbase.pipeline.runner
+
+/** Resolves a job's `submit:` block against the workflow's `presets:` table.
+  *
+  * If `submit` declares `preset: <name>`, the named preset is used as a base and the rest of `submit` is layered on
+  * top:
+  *
+  *   - top-level keys present in user `submit` replace preset values,
+  *   - nested maps (e.g., `conf:`) merge deeply per-key,
+  *   - lists and scalars are replaced wholesale.
+  */
+object SubmitPreset {
+
+  def resolve(
+      submit: Map[String, Any],
+      presets: Map[String, Map[String, Any]]
+  ): Map[String, Any] = submit.get("preset") match {
+    case None => submit
+    case Some(name: String) =>
+      val base = presets.getOrElse(
+        name,
+        throw new IllegalArgumentException(
+          s"Unknown submit preset `$name`. Known: ${if (presets.isEmpty) "<none>" else presets.keys.mkString(", ")}"
+        )
+      )
+      deepMerge(base, submit - "preset")
+    case Some(other) =>
+      throw new IllegalArgumentException(s"`submit.preset:` must be a string, got: $other")
+  }
+
+  private def deepMerge(base: Map[String, Any], overrides: Map[String, Any]): Map[String, Any] =
+    base ++ overrides.map { case (k, v) =>
+      (base.get(k), v) match {
+        case (Some(b: Map[_, _]), o: Map[_, _]) =>
+          k -> deepMerge(b.asInstanceOf[Map[String, Any]], o.asInstanceOf[Map[String, Any]])
+        case _ => k -> v
+      }
+    }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/UsesRef.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/UsesRef.scala
@@ -1,0 +1,58 @@
+package com.kakao.actionbase.pipeline.runner
+
+/** Parsed `uses:` reference. Two surface forms collapse into the same Maven coord; only the group portion differs:
+  *
+  *   - GHA-style sugar: `<owner>/<artifact>@<version>[:<class>]` — `<owner>` is a registered alias for a Maven
+  *     groupId. The optional trailing `:<class>` names the entry point (mirrors `spark-submit --class`).
+  *   - Maven coord: `<group>:<artifact>:<version>[:<class>]` — used directly.
+  *
+  * Owner aliases (v1): `actionbase` → `com.kakao.actionbase`. So the following are equivalent:
+  *
+  *   `actionbase/pipeline@0.x:SparkPiJob`     ≡ `com.kakao.actionbase:pipeline:0.x:SparkPiJob`
+  *   `actionbase/pipeline@0.3.0-SNAPSHOT:Foo` ≡ `com.kakao.actionbase:pipeline:0.3.0-SNAPSHOT:Foo`
+  *
+  * `<version>` is a free-form string passed to the runner. EmbeddedRunner is in-process and never fetches a jar, so
+  * it ignores the version entirely. Production runners (TBD) will resolve it via Maven repo metadata. Recommended
+  * forms (npm-/semver-style, in increasing strictness): `0.x` (any 0.* release), `0.3.x`, `0.3.0-SNAPSHOT`. `latest`
+  * is accepted but discouraged — it can pull a major-version-incompatible release.
+  *
+  * `kind` selects the runtime dispatch; v1 supports `spark` only and defaults to it.
+  */
+case class UsesRef(
+    group: String,
+    artifact: String,
+    version: String,
+    kind: String,
+    mainClass: Option[String]
+) {
+  def coord: String = s"$group:$artifact:$version"
+}
+
+object UsesRef {
+
+  /** Short-owner → Maven groupId aliases. Add an entry to expose a new short prefix. */
+  private val OwnerAliases: Map[String, String] = Map(
+    "actionbase" -> "com.kakao.actionbase"
+  )
+
+  private val GhaRe   = """^([\w.-]+)/([\w.-]+)@([^:]+?)(?::([\w.]+))?$""".r
+  private val MavenRe = """^([\w.]+):([\w.-]+):([^:]+?)(?::([\w.]+))?$""".r
+
+  def parse(s: String): UsesRef = s match {
+    case GhaRe(owner, artifact, version, klass) =>
+      val group = OwnerAliases.getOrElse(
+        owner,
+        throw new IllegalArgumentException(
+          s"Unknown owner alias `$owner`. Known: ${OwnerAliases.keys.mkString(", ")}"
+        )
+      )
+      UsesRef(group, artifact, version, "spark", Option(klass))
+    case MavenRe(group, artifact, version, klass) =>
+      UsesRef(group, artifact, version, "spark", Option(klass))
+    case other =>
+      throw new IllegalArgumentException(
+        s"`uses:` must be `<owner>/<artifact>@<version>[:<class>]` or " +
+          s"`<group>:<artifact>:<version>[:<class>]`, got: '$other'"
+      )
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runtime/JobOutputs.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runtime/JobOutputs.scala
@@ -1,0 +1,45 @@
+package com.kakao.actionbase.pipeline.runtime
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths, StandardOpenOption}
+
+import scala.collection.JavaConverters._
+
+/** Channel for a Job to emit named outputs the runner can pick up after the job completes. The runner sets
+  * `actionbase.pipeline.outputFile` to a path before invoking `Job.main`; emit() appends `name=value` lines there.
+  *
+  * Mirrors GitHub Actions' `$GITHUB_OUTPUT` mechanism. When the system property is unset (e.g., the Job is invoked
+  * directly by spark-submit outside a runner), emit() is a silent no-op.
+  */
+object JobOutputs {
+
+  val SystemPropertyKey = "actionbase.pipeline.outputFile"
+
+  def emit(name: String, value: String): Unit =
+    Option(System.getProperty(SystemPropertyKey)).foreach { path =>
+      val line = s"$name=$value\n"
+      Files.write(
+        Paths.get(path),
+        line.getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND
+      )
+    }
+
+  def read(path: String): Map[String, String] = {
+    val file = Paths.get(path)
+    if (!Files.exists(file)) Map.empty
+    else
+      Files
+        .readAllLines(file, StandardCharsets.UTF_8)
+        .asScala
+        .iterator
+        .flatMap { line =>
+          line.split("=", 2) match {
+            case Array(k, v) if k.nonEmpty => Some(k -> v)
+            case _                         => None
+          }
+        }
+        .toMap
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/FileSink.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/FileSink.scala
@@ -1,0 +1,17 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.dsl.Sink
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Writes a DataFrame to file storage using Spark's `DataFrameWriter`. `format` is any Spark-supported short name
+  * (`parquet`, `json`, `csv`, `orc`, ...); `options` are passed through to `DataFrameWriter.options`.
+  */
+case class FileSink(
+    path: String,
+    format: String,
+    mode: String = "overwrite",
+    options: Map[String, String] = Map.empty
+) extends Sink {
+  override def write(in: DataFrame)(implicit spark: SparkSession): Unit =
+    in.write.format(format).mode(mode).options(options).save(path)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSink.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSink.scala
@@ -1,0 +1,10 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.dsl.Sink
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Prints rows to stdout via Spark's `DataFrame.show`. Useful as a debug/demo Sink. */
+case class ShowSink(numRows: Int = 20, truncate: Boolean = true) extends Sink {
+  override def write(in: DataFrame)(implicit spark: SparkSession): Unit =
+    in.show(numRows, truncate)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/FileSource.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/FileSource.scala
@@ -1,0 +1,16 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.dsl.Source
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Reads a file-based dataset using Spark's `DataFrameReader`. `format` is any Spark-supported short name (`json`,
+  * `parquet`, `csv`, `orc`, ...); `options` are passed through to `DataFrameReader.options`.
+  */
+case class FileSource(
+    path: String,
+    format: String,
+    options: Map[String, String] = Map.empty
+) extends Source {
+  override def read()(implicit spark: SparkSession): DataFrame =
+    spark.read.format(format).options(options).load(path)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/SampleSource.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/SampleSource.scala
@@ -1,0 +1,13 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.dsl.Source
+import org.apache.spark.sql.functions.rand
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Produces `n` rows of random values uniformly drawn from `[0.0, 1.0)`, one column per name in `columns`. */
+case class SampleSource(n: Long, columns: Seq[String]) extends Source {
+  require(columns.nonEmpty, "SampleSource requires at least one column")
+
+  override def read()(implicit spark: SparkSession): DataFrame =
+    spark.range(n).select(columns.map(name => rand().as(name)): _*)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransform.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransform.scala
@@ -1,0 +1,18 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.dsl.Transform
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.storage.StorageLevel
+
+/** Materializes its input once and reuses it across downstream consumers. Useful when a single upstream feeds two or
+  * more transforms (e.g., a "split" expressed as two filter transforms over the same source) — without it, Spark
+  * re-executes the upstream lineage per consumer.
+  *
+  * `level` is any string accepted by `StorageLevel.fromString` (default `MEMORY_AND_DISK`).
+  */
+case class CacheTransform(level: String = "MEMORY_AND_DISK") extends Transform {
+  override def apply(inputs: Seq[(String, DataFrame)])(implicit spark: SparkSession): DataFrame = {
+    require(inputs.size == 1, s"CacheTransform expects 1 input, got ${inputs.size}")
+    inputs.head._2.persist(StorageLevel.fromString(level))
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransform.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransform.scala
@@ -1,0 +1,19 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.dsl.Transform
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Runs `query` against the labeled input DataFrames. Each input is registered as a temp view named after its label
+  * — the producer's `as:` (or `"_0"` for the chain default). No separate `views:` parameter — the SQL refers to
+  * inputs by the same names that wired them in.
+  *
+  * Single-input chain: `SqlTransform("SELECT ... FROM _0")`.
+  * Join: pair two labeled FileSources with `inputs: [users, events]`, then
+  * `SqlTransform("SELECT ... FROM users JOIN events USING (id)")`.
+  */
+case class SqlTransform(query: String) extends Transform {
+  override def apply(inputs: Seq[(String, DataFrame)])(implicit spark: SparkSession): DataFrame = {
+    inputs.foreach { case (name, df) => df.createOrReplaceTempView(name) }
+    spark.sql(query)
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/GhaWorkflow.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/GhaWorkflow.scala
@@ -1,0 +1,37 @@
+package com.kakao.actionbase.pipeline.workflow
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/** Minimal GHA workflow schema — just the bits we read.
+  *
+  * The user-facing YAML is a real GitHub Actions workflow. Our `WorkflowLoader` parses it into this shape and then
+  * adapts to the internal `Workflow` / `JobSpec` model used by the runner. Fields irrelevant to actionbase
+  * (`runs-on`, `permissions`, etc.) are kept as `Any` or ignored, but tolerated so the file remains valid for GHA's
+  * own parser.
+  */
+case class GhaWorkflow(
+    name: String,
+    // GHA accepts `on:` as a String (`on: push`), an array (`on: [push, pull_request]`), or a map
+    // (`on: { workflow_dispatch: {}, schedule: [...] }`). Keep it untyped and pull `schedule` out by hand.
+    on: Option[Any] = None,
+    env: Map[String, String] = Map.empty,
+    presets: Map[String, Map[String, Any]] = Map.empty,
+    jobs: Map[String, GhaJob]
+)
+
+case class GhaJob(
+    @JsonProperty("runs-on") runsOn: String = "ubuntu-latest",
+    needs: Seq[String] = Seq.empty,
+    @JsonProperty("if") `if`: Option[String] = None,
+    env: Map[String, String] = Map.empty,
+    steps: Seq[GhaStep]
+)
+
+case class GhaStep(
+    uses: Option[String] = None,
+    name: Option[String] = None,
+    @JsonProperty("if") `if`: Option[String] = None,
+    @JsonProperty("with") `with`: Map[String, Any] = Map.empty,
+    run: Option[String] = None,
+    env: Map[String, String] = Map.empty
+)

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/Workflow.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/Workflow.scala
@@ -1,0 +1,68 @@
+package com.kakao.actionbase.pipeline.workflow
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/** Parsed YAML workflow spec. The Workflow itself is purely declarative — it describes a DAG of Jobs and how each is
+  * parameterized. Runners (in-process EmbeddedRunner; production spark-submit-based — TBD) read this spec and
+  * dispatch.
+  *
+  * YAML shape (mirrors GitHub Actions where it makes sense):
+  *
+  *   name: spark-pi
+  *   schedule: '0 0 * * *'              # optional cron — workflow runs as a unit
+  *   env: { SAMPLES: 1000000 }
+  *   jobs:
+  *     pi:
+  *       uses: actionbase/pipeline@0.x:SparkPiJob
+  *       with: { samples: "${{ env.SAMPLES }}" }
+  *       submit: { preset: small }
+  *
+  * `schedule:` is a workflow-level cron expression (the workflow is itself a
+  * complete DAG; its scheduling unit is the whole spec, not individual jobs).
+  * EmbeddedRunner is a one-shot runner and only logs the value; production
+  * runners (Airflow / GHA scheduled trigger / Jenkins cron) consume it.
+  */
+case class Workflow(
+    name: String,
+    schedule: Option[String] = None,
+    env: Map[String, String] = Map.empty,
+    presets: Map[String, Map[String, Any]] = Map.empty,
+    jobs: Map[String, JobSpec]
+)
+
+/** `uses` — artifact + entry-point reference. GHA short form `actionbase/pipeline@0.x:SparkPiJob` or Maven coord
+  * `com.kakao.actionbase:pipeline:0.x:SparkPiJob`; both resolve to the same `(group, artifact, version, kind,
+  * mainClass)` via `UsesRef`. The trailing `:<class>` mirrors `spark-submit --class`. `needs` — ids of jobs that
+  * must complete before this one starts. `if` — boolean expression; the job runs only when it evaluates to true
+  * (defaults to true when absent). Cascades: if any `needs` was skipped, this job is skipped too. `with` — Cfg
+  * fields for the entry-point class. Strings, numbers, booleans, lists, and nested maps are all allowed; string
+  * leaves go through `${{ ... }}` resolution. `submit` — flat 1:1 map onto `spark-submit` CLI flags (kebab-case).
+  * Required for `kind=spark`. Scalars become `--key value`; lists become `--key v1,v2`; maps (e.g. `conf:`) become
+  * repeated `--key k=v`. Advisory in v1: EmbeddedRunner runs in-process and only logs them; production runners
+  * (TBD) will assemble the actual `spark-submit` invocation.
+  */
+case class JobSpec(
+    uses: String,
+    needs: Seq[String] = Seq.empty,
+    @JsonProperty("if") `if`: Option[String] = None,
+    @JsonProperty("with") `with`: Map[String, Any] = Map.empty,
+    submit: Map[String, Any] = Map.empty
+)
+
+/** A Step entry inside a Cfg whose Job interprets a `steps:` list (e.g., `StepsRunnerJob`).
+  *
+  * `step` — Step class name (Source / Transform / Sink); short / sub-package / FQN forms all resolve via
+  * `ClassResolver.StepRoots`. `args` — constructor args bound to the Step's case-class fields. Both keys are
+  * actionbase-internal — distinct from the GHA-style `uses:` / `with:` at the job level.
+  *
+  * Multi-input wiring:
+  *   - `as` — optional label that names this step's output for downstream reference.
+  *   - `inputs` — labels of upstream steps to feed in. Empty = the previous step's output (linear chain default).
+  *     Multi-element = join semantics (e.g., `inputs: [users, events]` for a `SqlTransform` with two views).
+  */
+case class StepSpec(
+    step: String,
+    args: Map[String, Any] = Map.empty,
+    as: Option[String] = None,
+    inputs: Seq[String] = Seq.empty
+)

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/WorkflowLoader.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/WorkflowLoader.scala
@@ -1,0 +1,135 @@
+package com.kakao.actionbase.pipeline.workflow
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+
+import java.io.File
+
+/** Loads a GHA-native workflow YAML and adapts it to the internal `Workflow` / `JobSpec` model.
+  *
+  * The user's YAML is a real GitHub Actions workflow. Each job has one step that uses the actionbase pipeline runner
+  * action — that step's `with:` carries the entry-point class, Cfg, and submit flags. The loader extracts those and
+  * synthesizes the internal `JobSpec`. Multi-step GHA jobs (e.g., `checkout` + `pipeline-runner`) are tolerated; only
+  * the pipeline-runner step is consumed.
+  *
+  * Also auto-loads every `.yaml` file under `<workflowDir>/preset/` into `Workflow.presets`.
+  */
+object WorkflowLoader {
+
+  /** Marker substring used to find the actionbase pipeline-runner step among a job's steps. Matches both
+    * `kakao/actionbase/actions/pipeline-runner@<ref>` (monorepo subpath) and a future standalone repo.
+    */
+  private val PipelineRunnerActionMarker = "actionbase/actions/pipeline-runner"
+
+  @transient private lazy val yaml: YAMLMapper with ClassTagExtensions = {
+    val m = new YAMLMapper() with ClassTagExtensions
+    m.registerModule(DefaultScalaModule)
+    m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    m
+  }
+
+  def load(path: String): Workflow = load(new File(path))
+
+  def load(file: File): Workflow = {
+    val gha         = yaml.readValue(file, classOf[GhaWorkflow])
+    val internal    = adapt(gha)
+    val filePresets = loadPresetDir(file.getParentFile)
+    internal.copy(presets = internal.presets ++ filePresets)
+  }
+
+  private def adapt(gha: GhaWorkflow): Workflow = {
+    val schedule = extractSchedule(gha.on)
+    val jobs = gha.jobs.map { case (id, ghaJob) =>
+      id -> adaptJob(id, ghaJob)
+    }
+    Workflow(
+      name = gha.name,
+      schedule = schedule,
+      env = gha.env,
+      presets = gha.presets,
+      jobs = jobs
+    )
+  }
+
+  /** Pull a cron string out of `on:` if present. GHA accepts string / array / map shapes; only the map form can hold
+    * `schedule:`. Walks both Scala and Java collection types since Jackson's `Any` binding can produce either.
+    */
+  private def extractSchedule(on: Option[Any]): Option[String] = on.flatMap {
+    case m: scala.collection.Map[_, _] =>
+      asScheduleEntries(m.asInstanceOf[scala.collection.Map[String, Any]].get("schedule"))
+    case jm: java.util.Map[_, _] =>
+      val k = jm.asInstanceOf[java.util.Map[String, Any]]
+      asScheduleEntries(Option(k.get("schedule")))
+    case _ => None
+  }
+
+  private def asScheduleEntries(v: Option[Any]): Option[String] = v.flatMap {
+    case s: scala.collection.Seq[_] =>
+      s.headOption.flatMap(cronOf)
+    case jl: java.util.List[_] =>
+      val it = jl.iterator()
+      if (it.hasNext) cronOf(it.next()) else None
+    case _ => None
+  }
+
+  private def cronOf(item: Any): Option[String] = item match {
+    case m: scala.collection.Map[_, _] =>
+      m.asInstanceOf[scala.collection.Map[String, Any]].get("cron").map(_.toString)
+    case jm: java.util.Map[_, _] =>
+      Option(jm.asInstanceOf[java.util.Map[String, Any]].get("cron")).map(_.toString)
+    case _ => None
+  }
+
+  private def adaptJob(id: String, gha: GhaJob): JobSpec = {
+    val runner = gha.steps
+      .find(_.uses.exists(_.contains(PipelineRunnerActionMarker)))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"job '$id' must include a step that `uses: kakao/actionbase/actions/pipeline-runner@...`"
+        )
+      )
+
+    val w         = runner.`with`
+    val className = w.get("class") match {
+      case Some(s: String) => s
+      case _               =>
+        throw new IllegalArgumentException(s"job '$id' pipeline-runner step requires `with.class:`")
+    }
+    val config = asMap(w.get("config")).getOrElse(Map.empty[String, Any])
+    val submit = asMap(w.get("submit")).getOrElse(Map.empty[String, Any])
+
+    JobSpec(
+      uses = s"actionbase/pipeline@0.x:$className",
+      needs = gha.needs,
+      `if` = gha.`if`,
+      `with` = config,
+      submit = submit
+    )
+  }
+
+  private def asMap(v: Option[Any]): Option[Map[String, Any]] = v match {
+    case Some(m: Map[_, _]) => Some(m.asInstanceOf[Map[String, Any]])
+    case Some(s: String) if s.trim.nonEmpty =>
+      // `with:` inputs are strings in real GHA; the action would parse them as YAML at runtime.
+      // We do the same so a YAML block-scalar form (`config: |\n  ...`) also works.
+      Some(yaml.readValue(s, classOf[Map[String, Any]]))
+    case _ => None
+  }
+
+  private def loadPresetDir(workflowDir: File): Map[String, Map[String, Any]] = {
+    if (workflowDir == null) return Map.empty
+    val dir = new File(workflowDir, "preset")
+    if (!dir.isDirectory) return Map.empty
+
+    val files = Option(dir.listFiles).getOrElse(Array.empty[File])
+    files.iterator
+      .filter(f => f.isFile && f.getName.endsWith(".yaml"))
+      .map { f =>
+        val name = f.getName.stripSuffix(".yaml")
+        val map  = yaml.readValue(f, classOf[Map[String, Any]])
+        name -> map
+      }
+      .toMap
+  }
+}

--- a/pipeline/src/test/resources/workflows/minimal-skip.yaml
+++ b/pipeline/src/test/resources/workflows/minimal-skip.yaml
@@ -1,0 +1,30 @@
+name: minimal-skip
+on: workflow_dispatch
+
+env:
+  enabled: "false"
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    if: ${{ env.enabled == 'true' }}
+    steps:
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: com.kakao.actionbase.pipeline.runner.StageJob
+          config:
+            in: ${{ env.INPUT }}
+            out: ${{ env.OUT }}
+          submit:
+            preset: test-small
+  count:
+    runs-on: ubuntu-latest
+    needs: [stage]
+    steps:
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: com.kakao.actionbase.pipeline.runner.CountJob
+          config:
+            in: ${{ needs.stage.outputs.out }}
+          submit:
+            preset: test-small

--- a/pipeline/src/test/resources/workflows/minimal.yaml
+++ b/pipeline/src/test/resources/workflows/minimal.yaml
@@ -1,0 +1,26 @@
+name: minimal
+on: workflow_dispatch
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: com.kakao.actionbase.pipeline.runner.StageJob
+          config:
+            in: ${{ env.INPUT }}
+            out: ${{ env.OUT }}
+          submit:
+            preset: test-small
+  count:
+    runs-on: ubuntu-latest
+    needs: [stage]
+    steps:
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: com.kakao.actionbase.pipeline.runner.CountJob
+          config:
+            in: ${{ needs.stage.outputs.out }}
+          submit:
+            preset: test-small

--- a/pipeline/src/test/resources/workflows/preset/test-small.yaml
+++ b/pipeline/src/test/resources/workflows/preset/test-small.yaml
@@ -1,0 +1,4 @@
+executor-memory: 1g
+driver-memory: 512m
+conf:
+  spark.sql.shuffle.partitions: 4

--- a/pipeline/src/test/resources/workflows/with-preset.yaml
+++ b/pipeline/src/test/resources/workflows/with-preset.yaml
@@ -1,0 +1,16 @@
+name: with-preset
+on: workflow_dispatch
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: com.kakao.actionbase.pipeline.runner.StageJob
+          config:
+            in: /tmp/x
+            out: /tmp/y
+          submit:
+            preset: test-small
+            driver-memory: 1g

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
@@ -1,0 +1,16 @@
+package com.kakao.actionbase.pipeline
+
+import org.apache.spark.sql.SparkSession
+
+/** Mix-in for unit tests that need an `implicit SparkSession`. The session is `local[2]` and shared across all
+  * `SparkTest` mixers in the JVM (Spark's own `getOrCreate` semantics).
+  */
+trait SparkTest {
+  protected implicit lazy val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[2]")
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .config("spark.ui.enabled", "false")
+    .appName(getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/WorkflowFixtures.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/WorkflowFixtures.scala
@@ -1,0 +1,20 @@
+package com.kakao.actionbase.pipeline
+
+import java.nio.file.{Files, Paths}
+
+/** Shared test helper for resolving Workflow YAML files in `pipeline/workflows/`. The Gradle test working directory is
+  * the module root (`pipeline/`), but tests started from the repo root also resolve correctly.
+  */
+object WorkflowFixtures {
+
+  def path(name: String): String = {
+    val candidates = Seq(
+      Paths.get("workflows", name),
+      Paths.get("pipeline", "workflows", name)
+    )
+    candidates
+      .find(Files.exists(_))
+      .map(_.toAbsolutePath.toString)
+      .getOrElse(throw new IllegalStateException(s"Workflow YAML not found: $name"))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanMultiInputTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanMultiInputTest.scala
@@ -1,0 +1,67 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.kakao.actionbase.pipeline.SparkTest
+import com.kakao.actionbase.pipeline.steps.sink.ShowSink
+import com.kakao.actionbase.pipeline.steps.source.SampleSource
+import com.kakao.actionbase.pipeline.steps.transform.SqlTransform
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class PlanMultiInputTest extends SparkTest {
+
+  /** Captures the joined DataFrame so we can assert. Test-local sink — multi-input not needed. */
+  private case class CaptureSink() extends Sink {
+    @volatile var captured: DataFrame = _
+    override def write(in: DataFrame)(implicit spark: SparkSession): Unit = captured = in
+  }
+
+  @Test
+  def combinesTwoLabeledSourcesViaPlus(): Unit = {
+    val sink = CaptureSink()
+
+    val plan: Plan.Closed =
+      (SampleSource(3, Seq("u")).as("users") + SampleSource(2, Seq("e")).as("events")) ~>
+        SqlTransform("SELECT u, e FROM users CROSS JOIN events") ~>
+        sink
+
+    plan.run()(spark)
+
+    val rows = sink.captured.collect()
+    assertEquals(6, rows.length, "3 users × 2 events = 6 rows")
+    assertEquals(Set("u", "e"), sink.captured.columns.toSet)
+  }
+
+  @Test
+  def transformOutputsAreOpenSoAsAndPlusApply(): Unit = {
+    // Each `~> Transform` returns Plan.Open, so `.as(...)` and `+` work on Transform outputs the same as on Sources.
+    val sink = CaptureSink()
+
+    val left  = SampleSource(2, Seq("u")) ~> SqlTransform("SELECT u AS x FROM _0")
+    val right = SampleSource(2, Seq("e")) ~> SqlTransform("SELECT e AS y FROM _0")
+
+    val plan: Plan.Closed =
+      (left.as("L") + right.as("R")) ~>
+        SqlTransform("SELECT L.x, R.y FROM L CROSS JOIN R") ~>
+        sink
+
+    plan.run()(spark)
+    assertEquals(4, sink.captured.collect().length, "2 × 2 = 4 rows")
+    assertEquals(Set("x", "y"), sink.captured.columns.toSet)
+  }
+
+  @Test
+  def chainsThreePlusInputs(): Unit = {
+    val sink = CaptureSink()
+
+    val plan: Plan.Closed =
+      (SampleSource(2, Seq("a")).as("a") +
+        SampleSource(2, Seq("b")).as("b") +
+        SampleSource(2, Seq("c")).as("c")) ~>
+        SqlTransform("SELECT a.a, b.b, c.c FROM a, b, c") ~>
+        sink
+
+    plan.run()(spark)
+    assertEquals(8, sink.captured.collect().length, "2 × 2 × 2 = 8 rows")
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/jobs/SparkPiJobTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/jobs/SparkPiJobTest.scala
@@ -1,0 +1,30 @@
+package com.kakao.actionbase.pipeline.jobs
+
+import com.kakao.actionbase.pipeline.WorkflowFixtures
+import com.kakao.actionbase.pipeline.runner.EmbeddedRunner
+import com.kakao.actionbase.pipeline.workflow.WorkflowLoader
+import org.junit.jupiter.api.{BeforeAll, Test}
+
+object SparkPiJobTest {
+  @BeforeAll
+  def setupSpark(): Unit = {
+    System.setProperty("spark.master", "local[2]")
+    System.setProperty("spark.driver.bindAddress", "127.0.0.1")
+    System.setProperty("spark.ui.enabled", "false")
+  }
+}
+
+class SparkPiJobTest {
+
+  @Test
+  def runsJobFormEndToEnd(): Unit = {
+    val wf = WorkflowLoader.load(WorkflowFixtures.path("spark-pi.yaml"))
+    EmbeddedRunner.run(wf, Map("SAMPLES" -> "100000"))
+  }
+
+  @Test
+  def runsStepsFormEndToEnd(): Unit = {
+    val wf = WorkflowLoader.load(WorkflowFixtures.path("spark-pi-steps.yaml"))
+    EmbeddedRunner.run(wf, Map("SAMPLES" -> "100000"))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/ClassResolverTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/ClassResolverTest.scala
@@ -1,0 +1,46 @@
+package com.kakao.actionbase.pipeline.runner
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class ClassResolverTest {
+
+  @Test
+  def resolvesFullyQualifiedName(): Unit = {
+    val cls = ClassResolver.resolve(
+      "com.kakao.actionbase.pipeline.steps.source.SampleSource",
+      ClassResolver.StepRoots
+    )
+    assertEquals("com.kakao.actionbase.pipeline.steps.source.SampleSource", cls.getName)
+  }
+
+  @Test
+  def resolvesShortNameUnderJobRoot(): Unit = {
+    val cls = ClassResolver.resolve("SparkPiJob$", ClassResolver.JobRoots)
+    assertEquals("com.kakao.actionbase.pipeline.jobs.SparkPiJob$", cls.getName)
+  }
+
+  @Test
+  def resolvesShortNameAcrossStepRoots(): Unit = {
+    // SampleSource lives under steps.source — the resolver must try each root in order
+    val source = ClassResolver.resolve("SampleSource", ClassResolver.StepRoots)
+    assertEquals("com.kakao.actionbase.pipeline.steps.source.SampleSource", source.getName)
+
+    // SqlTransform under steps.transform
+    val transform = ClassResolver.resolve("SqlTransform", ClassResolver.StepRoots)
+    assertEquals("com.kakao.actionbase.pipeline.steps.transform.SqlTransform", transform.getName)
+
+    // ShowSink under steps.sink
+    val sink = ClassResolver.resolve("ShowSink", ClassResolver.StepRoots)
+    assertEquals("com.kakao.actionbase.pipeline.steps.sink.ShowSink", sink.getName)
+  }
+
+  @Test
+  def throwsWhenUnresolvable(): Unit = {
+    val ex = assertThrows(
+      classOf[ClassNotFoundException],
+      () => ClassResolver.resolve("DoesNotExist", ClassResolver.StepRoots)
+    )
+    assertTrue(ex.getMessage.contains("DoesNotExist"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/EmbeddedRunnerTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/EmbeddedRunnerTest.scala
@@ -1,0 +1,83 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.dsl._
+import com.kakao.actionbase.pipeline.steps.sink.FileSink
+import com.kakao.actionbase.pipeline.steps.source.FileSource
+import com.kakao.actionbase.pipeline.runtime.JobOutputs
+import com.kakao.actionbase.pipeline.workflow.WorkflowLoader
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeAll, Test}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+
+// Minimal Jobs co-located with the test so the runner has something concrete
+// to load via reflection without pulling domain example code into `main`.
+
+case class StageCfg(in: String, out: String)
+object StageJob extends Job[StageCfg] {
+  override def plan(cfg: StageCfg): Plan.Closed = {
+    emit("out", cfg.out)
+    FileSource(cfg.in, "json") ~> FileSink(cfg.out, "parquet")
+  }
+}
+
+case class CountCfg(in: String)
+object CountJob extends Job[CountCfg] {
+  override def plan(cfg: CountCfg): Plan.Closed =
+    FileSource(cfg.in, "parquet") ~> RowCountSink("rows")
+}
+
+private case class RowCountSink(name: String) extends Sink {
+  override def write(in: DataFrame)(implicit spark: SparkSession): Unit =
+    JobOutputs.emit(name, in.count().toString)
+}
+
+object EmbeddedRunnerTest {
+  @BeforeAll
+  def setupSpark(): Unit = {
+    System.setProperty("spark.master", "local[2]")
+    System.setProperty("spark.driver.bindAddress", "127.0.0.1")
+    System.setProperty("spark.ui.enabled", "false")
+  }
+}
+
+class EmbeddedRunnerTest {
+
+  private def workflowResource(name: String): String =
+    Paths.get(getClass.getResource(s"/workflows/$name").toURI).toString
+
+  private def writeInputJson(dir: Path): String = {
+    val p = dir.resolve("in.json")
+    Files.write(p, "{\"a\":1}\n{\"a\":2}\n{\"a\":3}\n".getBytes(StandardCharsets.UTF_8))
+    p.toString
+  }
+
+  @Test
+  def runsTwoJobsWithDynamicOutputs(): Unit = {
+    val tmp = Files.createTempDirectory("pipeline-")
+    val in  = writeInputJson(tmp)
+    val out = tmp.resolve("staged").toString
+
+    val wf = WorkflowLoader.load(workflowResource("minimal.yaml"))
+    EmbeddedRunner.run(wf, Map("INPUT" -> in, "OUT" -> out))
+
+    assertTrue(Files.exists(Paths.get(out)), s"$out should exist")
+  }
+
+  @Test
+  def cascadeSkipsWhenIfFalse(): Unit = {
+    val tmp = Files.createTempDirectory("pipeline-skip-")
+    val in  = writeInputJson(tmp)
+    val out = tmp.resolve("staged").toString
+
+    val wf = WorkflowLoader.load(workflowResource("minimal-skip.yaml"))
+    EmbeddedRunner.run(wf, Map("INPUT" -> in, "OUT" -> out))
+
+    assertFalse(
+      Files.exists(Paths.get(out)),
+      s"$out must not exist when stage is skipped"
+    )
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/StepsBuilderTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/StepsBuilderTest.scala
@@ -1,0 +1,141 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.SparkTest
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class StepsBuilderTest extends SparkTest {
+
+  private val ShowSinkFqn      = "com.kakao.actionbase.pipeline.steps.sink.ShowSink"
+  private val SampleSourceFqn  = "com.kakao.actionbase.pipeline.steps.source.SampleSource"
+  private val SqlTransformFqn  = "com.kakao.actionbase.pipeline.steps.transform.SqlTransform"
+
+  @Test
+  def buildsAndRunsSourceSinkChain(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 50L, "columns" -> Seq("a", "b"))),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def buildsAndRunsSourceTransformSinkChain(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 20L, "columns" -> Seq("x"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT x * 2 AS y FROM _0")),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def buildsAndRunsJoinAcrossLabeledSources(): Unit = {
+    val steps = Seq(
+      StepSpec(
+        SampleSourceFqn,
+        args = Map("n" -> 5L, "columns" -> Seq("u")),
+        as = Some("users")
+      ),
+      StepSpec(
+        SampleSourceFqn,
+        args = Map("n" -> 5L, "columns" -> Seq("e")),
+        as = Some("events")
+      ),
+      StepSpec(
+        SqlTransformFqn,
+        args = Map("query" -> "SELECT u.u, e.e FROM users u CROSS JOIN events e"),
+        inputs = Seq("users", "events")
+      ),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def rejectsSinkWithoutUpstream(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(Seq(StepSpec(ShowSinkFqn)))
+    )
+    assertTrue(ex.getMessage.contains("no upstream"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsWorkflowWithNoSink(): Unit = {
+    val steps = Seq(StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a"))))
+    val ex    = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("at least one Sink"), ex.getMessage)
+  }
+
+  @Test
+  def runsMultipleSinksOverSharedUpstream(): Unit = {
+    val FileSinkFqn = "com.kakao.actionbase.pipeline.steps.sink.FileSink"
+    val tmpA = java.nio.file.Files.createTempDirectory("multi-sink-a-").resolve("out").toString
+    val tmpB = java.nio.file.Files.createTempDirectory("multi-sink-b-").resolve("out").toString
+
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("x")), as = Some("data")),
+      StepSpec(FileSinkFqn, Map("path" -> tmpA, "format" -> "parquet"), inputs = Seq("data")),
+      StepSpec(FileSinkFqn, Map("path" -> tmpB, "format" -> "parquet"), inputs = Seq("data"))
+    )
+
+    StepsBuilder.build(steps).run()
+
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpA)), s"sink A should write: $tmpA")
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpB)), s"sink B should write: $tmpB")
+  }
+
+  @Test
+  def runsIndependentSinkSubTrees(): Unit = {
+    val FileSinkFqn = "com.kakao.actionbase.pipeline.steps.sink.FileSink"
+    val tmpA = java.nio.file.Files.createTempDirectory("indep-a-").resolve("out").toString
+    val tmpB = java.nio.file.Files.createTempDirectory("indep-b-").resolve("out").toString
+
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 3L, "columns" -> Seq("a"))),
+      StepSpec(FileSinkFqn, Map("path" -> tmpA, "format" -> "parquet")),
+      StepSpec(SampleSourceFqn, Map("n" -> 3L, "columns" -> Seq("b"))),
+      StepSpec(FileSinkFqn, Map("path" -> tmpB, "format" -> "parquet"))
+    )
+
+    StepsBuilder.build(steps).run()
+
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpA)), s"first subtree should write: $tmpA")
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpB)), s"second subtree should write: $tmpB")
+  }
+
+  @Test
+  def rejectsUnknownInputLabel(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a"))),
+      StepSpec(ShowSinkFqn, inputs = Seq("ghost"))
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("ghost"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsDuplicateLabel(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a")), as = Some("dup")),
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("b")), as = Some("dup")),
+      StepSpec(ShowSinkFqn)
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("duplicate"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/SubmitPresetTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/SubmitPresetTest.scala
@@ -1,0 +1,63 @@
+package com.kakao.actionbase.pipeline.runner
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class SubmitPresetTest {
+
+  private val Presets = Map(
+    "small" -> Map[String, Any](
+      "executor-memory" -> "1g",
+      "executor-cores"  -> 1,
+      "driver-memory"   -> "512m",
+      "conf" -> Map[String, Any](
+        "spark.sql.shuffle.partitions"     -> 4,
+        "spark.dynamicAllocation.enabled"  -> "true"
+      )
+    )
+  )
+
+  @Test
+  def passesSubmitThroughWhenNoPresetReferenced(): Unit = {
+    val submit = Map[String, Any]("executor-memory" -> "2g")
+    assertEquals(submit, SubmitPreset.resolve(submit, Presets))
+  }
+
+  @Test
+  def expandsPresetWhenReferenced(): Unit = {
+    val submit = Map[String, Any]("preset" -> "small")
+    val result = SubmitPreset.resolve(submit, Presets)
+    assertEquals("1g", result("executor-memory"))
+    assertEquals(1, result("executor-cores"))
+    assertFalse(result.contains("preset"), "the `preset` key itself should be stripped")
+  }
+
+  @Test
+  def topLevelOverrideReplacesPresetValue(): Unit = {
+    val submit = Map[String, Any]("preset" -> "small", "driver-memory" -> "1g")
+    val result = SubmitPreset.resolve(submit, Presets)
+    assertEquals("1g", result("driver-memory"))                  // user override
+    assertEquals("1g", result("executor-memory"))                // preset preserved
+  }
+
+  @Test
+  def nestedMapDeepMerges(): Unit = {
+    val submit = Map[String, Any](
+      "preset" -> "small",
+      "conf"   -> Map("spark.sql.shuffle.partitions" -> 8)        // override one conf entry
+    )
+    val result = SubmitPreset.resolve(submit, Presets)
+    val conf   = result("conf").asInstanceOf[Map[String, Any]]
+    assertEquals(8, conf("spark.sql.shuffle.partitions"))           // user wins
+    assertEquals("true", conf("spark.dynamicAllocation.enabled"))   // preset preserved
+  }
+
+  @Test
+  def throwsOnUnknownPreset(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => SubmitPreset.resolve(Map("preset" -> "huge"), Presets)
+    )
+    assertTrue(ex.getMessage.contains("huge"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/UsesRefTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/UsesRefTest.scala
@@ -1,0 +1,89 @@
+package com.kakao.actionbase.pipeline.runner
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class UsesRefTest {
+
+  @Test
+  def parsesGhaShortFormToMavenCoord(): Unit = {
+    val ref = UsesRef.parse("actionbase/pipeline@v1")
+    assertEquals("com.kakao.actionbase", ref.group)
+    assertEquals("pipeline", ref.artifact)
+    assertEquals("v1", ref.version)
+    assertEquals("spark", ref.kind)
+    assertEquals(None, ref.mainClass)
+  }
+
+  @Test
+  def parsesClassSuffixInBothForms(): Unit = {
+    val gha = UsesRef.parse("actionbase/pipeline@0.x:SparkPiJob")
+    assertEquals(Some("SparkPiJob"), gha.mainClass)
+
+    val maven = UsesRef.parse("com.kakao.actionbase:pipeline:0.x:SparkPiJob")
+    assertEquals(Some("SparkPiJob"), maven.mainClass)
+
+    val fqn = UsesRef.parse("actionbase/pipeline@0.x:com.example.MyJob")
+    assertEquals(Some("com.example.MyJob"), fqn.mainClass)
+  }
+
+  @Test
+  def ghaRefAcceptsSemverVersion(): Unit = {
+    val ref = UsesRef.parse("actionbase/pipeline@0.3.0")
+    assertEquals("0.3.0", ref.version)
+  }
+
+  @Test
+  def acceptsLatestAsVersion(): Unit = {
+    val ref = UsesRef.parse("actionbase/pipeline@latest")
+    assertEquals("latest", ref.version)
+    assertEquals("com.kakao.actionbase:pipeline:latest", ref.coord)
+  }
+
+  @Test
+  def acceptsNpmStyleRangeVersions(): Unit = {
+    assertEquals("0.x", UsesRef.parse("actionbase/pipeline@0.x").version)
+    assertEquals("0.3.x", UsesRef.parse("actionbase/pipeline@0.3.x").version)
+    assertEquals("0.2.0-SNAPSHOT", UsesRef.parse("actionbase/pipeline@0.2.0-SNAPSHOT").version)
+  }
+
+  @Test
+  def parsesMavenCoordDirectly(): Unit = {
+    val ref = UsesRef.parse("com.kakao.actionbase:pipeline:0.3.0-SNAPSHOT")
+    assertEquals("com.kakao.actionbase", ref.group)
+    assertEquals("pipeline", ref.artifact)
+    assertEquals("0.3.0-SNAPSHOT", ref.version)
+    assertEquals("spark", ref.kind)
+  }
+
+  @Test
+  def ghaAndMavenFormsResolveIdentically(): Unit = {
+    val gha   = UsesRef.parse("actionbase/pipeline@v1")
+    val maven = UsesRef.parse("com.kakao.actionbase:pipeline:v1")
+    assertEquals(gha, maven)
+  }
+
+  @Test
+  def coordAssemblesGroupArtifactVersion(): Unit = {
+    val ref = UsesRef.parse("actionbase/pipeline@0.3.0")
+    assertEquals("com.kakao.actionbase:pipeline:0.3.0", ref.coord)
+  }
+
+  @Test
+  def rejectsUnknownOwnerAlias(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => UsesRef.parse("unknown-owner/pipeline@v1")
+    )
+    assertTrue(ex.getMessage.contains("unknown-owner"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsMalformedReference(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => UsesRef.parse("not-a-ref")
+    )
+    assertTrue(ex.getMessage.contains("must be"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/FileSinkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/FileSinkTest.scala
@@ -1,0 +1,49 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.file.{Files, Paths}
+
+class FileSinkTest extends SparkTest {
+
+  @Test
+  def writesParquet(): Unit = {
+    import spark.implicits._
+    val df   = Seq(("a", 1), ("b", 2)).toDF("k", "v")
+    val tmp  = Files.createTempDirectory("file-sink-parquet-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "parquet").write(df)
+
+    assertTrue(Files.exists(Paths.get(path)))
+    assertEquals(2L, spark.read.parquet(path).count())
+  }
+
+  @Test
+  def writesJson(): Unit = {
+    import spark.implicits._
+    val df   = Seq(1, 2, 3).toDF("v")
+    val tmp  = Files.createTempDirectory("file-sink-json-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "json").write(df)
+
+    assertEquals(3L, spark.read.json(path).count())
+  }
+
+  @Test
+  def overwriteReplacesExisting(): Unit = {
+    import spark.implicits._
+    val df1  = Seq(1, 2).toDF("v")
+    val df2  = Seq(10, 20, 30).toDF("v")
+    val tmp  = Files.createTempDirectory("file-sink-mode-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "parquet").write(df1)
+    FileSink(path, "parquet").write(df2)
+
+    assertEquals(3L, spark.read.parquet(path).count())
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSinkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSinkTest.scala
@@ -1,0 +1,16 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Test
+
+class ShowSinkTest extends SparkTest {
+
+  @Test
+  def writesDataframeWithoutError(): Unit = {
+    import spark.implicits._
+    val in = Seq((1, "a"), (2, "b")).toDF("n", "name")
+
+    ShowSink().write(in)
+    ShowSink(numRows = 1, truncate = false).write(in)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/FileSourceTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/FileSourceTest.scala
@@ -1,0 +1,58 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+class FileSourceTest extends SparkTest {
+
+  @Test
+  def readsJson(): Unit = {
+    val tmp  = Files.createTempDirectory("file-source-json-")
+    val path = tmp.resolve("data.json").toString
+    Files.write(
+      Paths.get(path),
+      "{\"a\":1}\n{\"a\":2}\n".getBytes(StandardCharsets.UTF_8)
+    )
+
+    val df = FileSource(path, "json").read()
+
+    assertEquals(2L, df.count())
+    assertTrue(df.columns.contains("a"))
+  }
+
+  @Test
+  def readsParquet(): Unit = {
+    val tmp = Files.createTempDirectory("file-source-parquet-")
+    val src = tmp.resolve("src.json").toString
+    Files.write(
+      Paths.get(src),
+      "{\"a\":1}\n{\"a\":2}\n{\"a\":3}\n".getBytes(StandardCharsets.UTF_8)
+    )
+    val parquet = tmp.resolve("out.parquet").toString
+    spark.read.json(src).write.parquet(parquet)
+
+    val df = FileSource(parquet, "parquet").read()
+
+    assertEquals(3L, df.count())
+  }
+
+  @Test
+  def passesOptionsToReader(): Unit = {
+    val tmp  = Files.createTempDirectory("file-source-csv-")
+    val path = tmp.resolve("data.csv").toString
+    Files.write(
+      Paths.get(path),
+      "name,age\nalice,30\nbob,25\n".getBytes(StandardCharsets.UTF_8)
+    )
+
+    val df = FileSource(path, "csv", Map("header" -> "true")).read()
+
+    assertEquals(2L, df.count())
+    assertTrue(df.columns.toSet.contains("name"))
+    assertTrue(df.columns.toSet.contains("age"))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/SampleSourceTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/SampleSourceTest.scala
@@ -1,0 +1,38 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class SampleSourceTest extends SparkTest {
+
+  @Test
+  def producesRowsForRequestedColumns(): Unit = {
+    val df = SampleSource(1000L, Seq("x", "y")).read()
+    assertEquals(1000L, df.count())
+    assertEquals(Set("x", "y"), df.columns.toSet)
+  }
+
+  @Test
+  def supportsArbitraryColumnSet(): Unit = {
+    val df = SampleSource(50L, Seq("a", "b", "c", "d")).read()
+    assertEquals(50L, df.count())
+    assertEquals(Set("a", "b", "c", "d"), df.columns.toSet)
+  }
+
+  @Test
+  def valuesAreInUnitInterval(): Unit = {
+    val df   = SampleSource(200L, Seq("x", "y")).read()
+    val rows = df.collect()
+    assertTrue(rows.forall { r =>
+      val x = r.getAs[Double]("x")
+      val y = r.getAs[Double]("y")
+      x >= 0.0 && x < 1.0 && y >= 0.0 && y < 1.0
+    })
+  }
+
+  @Test
+  def rejectsEmptyColumnList(): Unit = {
+    assertThrows(classOf[IllegalArgumentException], () => SampleSource(10L, Seq.empty))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransformTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransformTest.scala
@@ -1,0 +1,42 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.apache.spark.storage.StorageLevel
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class CacheTransformTest extends SparkTest {
+
+  @Test
+  def persistsAtDefaultLevel(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = CacheTransform().apply(in)
+
+    assertEquals(StorageLevel.MEMORY_AND_DISK, out.storageLevel)
+    out.unpersist()
+  }
+
+  @Test
+  def respectsExplicitStorageLevel(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = CacheTransform(level = "MEMORY_ONLY").apply(in)
+
+    assertEquals(StorageLevel.MEMORY_ONLY, out.storageLevel)
+    out.unpersist()
+  }
+
+  @Test
+  def passesRowsThroughUnchanged(): Unit = {
+    import spark.implicits._
+    val in = Seq(("a", 1), ("b", 2)).toDF("k", "v")
+
+    val out = CacheTransform().apply(in)
+
+    assertEquals(in.collect().toSet, out.collect().toSet)
+    out.unpersist()
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransformTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransformTest.scala
@@ -1,0 +1,54 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class SqlTransformTest extends SparkTest {
+
+  @Test
+  def projectsAndComputesColumns(): Unit = {
+    import spark.implicits._
+    val in = Seq((1, 2), (3, 4)).toDF("a", "b")
+
+    val out = SqlTransform("SELECT a, b, a + b AS sum FROM _0").apply(in)
+
+    assertEquals(Set("a", "b", "sum"), out.columns.toSet)
+    val sums = out.collect().map(_.getAs[Int]("sum")).toSet
+    assertEquals(Set(3, 7), sums)
+  }
+
+  @Test
+  def usesProvidedLabelAsViewName(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = SqlTransform("SELECT SUM(n) AS total FROM nums").apply(Seq("nums" -> in))
+
+    assertEquals(6L, out.first().getLong(0))
+  }
+
+  @Test
+  def filtersRowsViaWhere(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3, 4).toDF("n")
+
+    val out = SqlTransform("SELECT n FROM _0 WHERE n > 2").apply(in)
+
+    assertEquals(Set(3, 4), out.collect().map(_.getInt(0)).toSet)
+  }
+
+  @Test
+  def joinsTwoLabeledInputs(): Unit = {
+    import spark.implicits._
+    val users  = Seq((1, "alice"), (2, "bob")).toDF("id", "name")
+    val events = Seq((1, "login"), (2, "click"), (2, "logout")).toDF("user_id", "kind")
+
+    val out = SqlTransform(
+      "SELECT u.name, e.kind FROM users u JOIN events e ON u.id = e.user_id"
+    ).apply(Seq("users" -> users, "events" -> events))
+
+    val rows = out.collect().map(r => r.getString(0) -> r.getString(1)).toSet
+    assertEquals(Set("alice" -> "login", "bob" -> "click", "bob" -> "logout"), rows)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/workflow/WorkflowLoaderTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/workflow/WorkflowLoaderTest.scala
@@ -1,0 +1,31 @@
+package com.kakao.actionbase.pipeline.workflow
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.file.Paths
+
+class WorkflowLoaderTest {
+
+  private def resourcePath(name: String): String =
+    Paths.get(getClass.getResource(s"/workflows/$name").toURI).toString
+
+  @Test
+  def loadsPresetsFromAdjacentDirectory(): Unit = {
+    val wf = WorkflowLoader.load(resourcePath("with-preset.yaml"))
+    assertTrue(wf.presets.contains("test-small"), s"presets keys: ${wf.presets.keys}")
+
+    val preset = wf.presets("test-small")
+    assertEquals("1g", preset("executor-memory"))
+    assertEquals("512m", preset("driver-memory"))
+    val conf = preset("conf").asInstanceOf[Map[String, Any]]
+    assertEquals(4, conf("spark.sql.shuffle.partitions"))
+  }
+
+  @Test
+  def workflowWithoutPresetDirectoryStillLoads(): Unit = {
+    val wf = WorkflowLoader.load(resourcePath("minimal.yaml"))
+    assertEquals("minimal", wf.name)
+    // The preset/ folder may exist (shared with other test fixtures); we just assert load succeeded.
+  }
+}

--- a/pipeline/workflows/preset/small.yaml
+++ b/pipeline/workflows/preset/small.yaml
@@ -1,0 +1,6 @@
+executor-memory: 1g
+executor-cores: 1
+num-executors: 2
+driver-memory: 512m
+conf:
+  spark.sql.shuffle.partitions: 4

--- a/pipeline/workflows/spark-pi-steps.yaml
+++ b/pipeline/workflows/spark-pi-steps.yaml
@@ -1,0 +1,30 @@
+name: spark-pi-steps
+on:
+  workflow_dispatch:
+
+env:
+  SAMPLES: 1000000
+
+jobs:
+  pi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: StepsRunnerJob
+          config:
+            steps:
+              - step: SampleSource
+                args:
+                  n: ${{ env.SAMPLES }}
+                  columns: [x, y]
+              - step: SqlTransform
+                args:
+                  query: |
+                    SELECT
+                      4.0 * SUM(CASE WHEN x*x + y*y <= 1 THEN 1 ELSE 0 END) / COUNT(*) AS pi
+                    FROM _0
+              - step: ShowSink
+          submit:
+            preset: small

--- a/pipeline/workflows/spark-pi.yaml
+++ b/pipeline/workflows/spark-pi.yaml
@@ -1,0 +1,24 @@
+name: spark-pi
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  SAMPLES: 1000000
+
+jobs:
+  pi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kakao/actionbase/actions/pipeline-runner@v0.1.0
+        with:
+          class: SparkPiJob
+          config:
+            samples: ${{ env.SAMPLES }}
+          submit:
+            preset: small                       # loaded from workflows/preset/small.yaml
+            driver-memory: 1g                   # overrides preset's 512m
+            conf:
+              spark.sql.shuffle.partitions: 8   # deep-merged with preset's conf


### PR DESCRIPTION
## Summary

ADR #310 v1: declarative workflow YAML over arbitrary DAGs (multi-input join, split, multi-sink) and an in-process `EmbeddedRunner`. Spec keys mirror GitHub Actions where it makes sense; the rest is actionbase vocabulary.

Refs #310

## YAML

```yaml
name: spark-pi
env:
  SAMPLES: 1000000
jobs:
  pi:
    uses: actionbase/pipeline@0.x       # GHA short form ≡ com.kakao.actionbase:pipeline:0.x
    with:
      class: SparkPiJob                  # reserved key — spark-submit --class
      samples: ${{ env.SAMPLES }}        # everything else flows into the Job's Cfg
    submit:                              # 1:1 spark-submit flags (kebab)
      preset: small                      # workflows/preset/small.yaml
      driver-memory: 1g                  # top-level override
      conf: { spark.sql.shuffle.partitions: 8 }   # deep-merged
```

`StepsRunnerJob` lets a workflow inline a Source → Transform* → Sink chain. Label with `as:`, refer with `inputs:`; labels become SQL view names:

```yaml
with:
  class: StepsRunnerJob
  steps:
    - step: FileSource
      args: { path: u.parquet, format: parquet }
      as: users
    - step: FileSource
      args: { path: e.parquet, format: parquet }
      as: events
    - step: SqlTransform
      args: { query: "SELECT u.name, e.kind FROM users u JOIN events e ON u.id = e.user_id" }
      inputs: [users, events]
    - step: ShowSink
```

## Step model

| Step | In | Out |
|---|---|---|
| Source | 0 | 1 |
| Transform | N (≥1) | 1 |
| Sink | 1 | 0 |

Arbitrary DAGs: linear chain, fan-in (join), split (shared upstream + multiple transforms), diamond, multi-sink (shared upstream **or** independent sub-trees). The Executor memoizes per-AST materialization across all sinks, so a shared upstream is built once. `CacheTransform` pins it in-memory when Spark's lineage would otherwise re-execute. Multi-input on the Scala side: `(a.as("u") + b.as("e")) ~> SqlTransform(...)` — works on Source and Transform outputs alike.

## Notable bits

- **`uses:`** — GHA short form (`actionbase/pipeline@0.x`) is sugar over Maven coords (`com.kakao.actionbase:pipeline:0.x`). Owner alias `actionbase` → `com.kakao.actionbase`.
- **`with:`** — flat for `kind=spark`. `class:` is reserved (= `spark-submit --class`); every other key is bound onto the Job's Cfg.
- **`submit:` presets** — files in `<workflowDir>/preset/<name>.yaml` auto-load; per-job override deep-merges.
- **`env:` overrides** — `./gradlew :pipeline:runWorkflow --args="<yaml> SAMPLES=100"`. Resolution mirrors `ConfigLoader` / `ConfigPrinter` (yaml < args, per-key trace). Canonical key is `lower_snake_case`: `SOME_SAMPLES` ≡ `someSamples` ≡ `some_samples` ≡ `--some-samples`. Word boundaries preserved so `sample_s` stays distinct from `samples`.

## How to Test

```
./gradlew :pipeline:test
./gradlew :pipeline:runWorkflow --args="pipeline/workflows/spark-pi.yaml"
./gradlew :pipeline:runWorkflow --args="pipeline/workflows/spark-pi-steps.yaml"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)
