### PR TITLE
Drop HBase from spark-conventions for now

### DIFF
--- a/conventions/src/main/kotlin/actionbase/SparkConventionsPlugin.kt
+++ b/conventions/src/main/kotlin/actionbase/SparkConventionsPlugin.kt
@@ -21,13 +21,8 @@ class SparkConventionsPlugin : Plugin<Project> {
     private fun configureDependencies(project: Project) {
         val dependencies = project.dependencies
 
-        // Spark dependencies
         dependencies.add("compileOnly", Dependencies.Spark.SQL)
         dependencies.add("compileOnly", Dependencies.Spark.STREAMING)
-
-        // HBase
-        dependencies.add("implementation", Dependencies.HBase.CLIENT)
-        dependencies.add("implementation", Dependencies.HBase.MAPREDUCE)
 
         dependencies.add("testImplementation", Dependencies.Spark.SQL)
         dependencies.add("testImplementation", Dependencies.Spark.STREAMING)


### PR DESCRIPTION
## Summary

While working on #311, Spark JSON / Parquet readers failed with `NoSuchMethodError: FileSystem.openFile`. Root cause: `hbase-shaded-{client,mapreduce}` ship Hadoop 2.x at `org.apache.hadoop.*`, masking Spark 3.4's Hadoop 3.3.4. No current `spark-conventions` consumer uses HBase, so drop it from the convention.

Re-adding is TBD — likely non-shaded `hbase-client` or `compileOnly` + submit-time `--jars` once a Spark+HBase job needs it.

## Changes

- Remove `hbase-shaded-{client,mapreduce}` from `SparkConventionsPlugin`

## How to Test

- `./gradlew build`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)
