### PR TITLE
Add in-job Step DSL (Source/Transform/Sink) for Spark jobs

### DIFF
--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Job.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Job.scala
@@ -1,0 +1,71 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import org.apache.spark.sql.SparkSession
+
+import scala.reflect.ClassTag
+
+// spark-submit entry point. Subclass and implement `plan(cfg)`. `main` binds `--key=value` argv into Cfg;
+// `planFromMap` binds a YAML-shaped Map (for in-process runners that need nested fields argv can't express).
+abstract class Job[C <: Product: ClassTag] {
+
+  def plan(cfg: C): Plan.Closed
+
+  protected def configure(builder: SparkSession.Builder): SparkSession.Builder = builder
+
+  def planFromMap(args: Map[String, Any]): Plan.Closed = {
+    val cls = implicitly[ClassTag[C]].runtimeClass.asInstanceOf[Class[C]]
+    val cfg = Job.mapper.convertValue(args, cls)
+    plan(cfg)
+  }
+
+  def main(argv: Array[String]): Unit = {
+    val args = Job.parseArgv(argv)
+    println(s"Running ${getClass.getSimpleName}: $args")
+
+    val spark = configure(
+      SparkSession.builder().appName(getClass.getCanonicalName.stripSuffix("$"))
+    ).getOrCreate()
+
+    try planFromMap(args).run()(spark)
+    finally {
+      println("Stopping Spark session...")
+      spark.stop()
+    }
+  }
+}
+
+object Job {
+
+  // Lax — Spark adds its own `--spark.*` flags we don't model.
+  private[pipeline] lazy val mapper: ObjectMapper with ClassTagExtensions =
+    buildMapper(failOnUnknownProperties = false)
+
+  // Strict — YAML-authored step args; typos must surface.
+  private[pipeline] lazy val stepMapper: ObjectMapper with ClassTagExtensions =
+    buildMapper(failOnUnknownProperties = true)
+
+  private def buildMapper(failOnUnknownProperties: Boolean): ObjectMapper with ClassTagExtensions = {
+    val m = new ObjectMapper() with ClassTagExtensions
+    m.registerModule(DefaultScalaModule)
+    m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, failOnUnknownProperties)
+    m.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+    m
+  }
+
+  private[pipeline] def parseArgv(argv: Array[String]): Map[String, Any] =
+    argv.iterator.flatMap { s =>
+      if (!s.startsWith("--") || !s.contains('=')) {
+        System.err.println(s"[Job] ignoring unrecognized arg: '$s' (expected --key=value)")
+        None
+      } else {
+        s.drop(2).split("=", 2) match {
+          case Array(k, v) => Some(k -> v)
+          case _ =>
+            System.err.println(s"[Job] ignoring malformed arg: '$s' (expected --key=value)")
+            None
+        }
+      }
+    }.toMap
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Plan.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Plan.scala
@@ -1,0 +1,135 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.util.IdentityHashMap
+
+// Type-state: Open = at a single output. Forked = at a Split's M outputs. Closed = ends in Sink/Fork/Group (runnable).
+sealed trait Plan {
+  private[dsl] def ast: Ast
+}
+
+object Plan {
+
+  final class Open private[dsl] (
+      private[dsl] val ast: Ast,
+      private[dsl] val edgeLabel: String = DefaultLabel
+  ) extends Plan {
+
+    // Label this output for downstream `as:` references (e.g., a SqlTransform temp view). Defaults to "_0".
+    def as(label: String): Open = new Open(ast, label)
+
+    def ~>(f: Flow): Open     = new Open(Ast.Fl(ast, f))
+    def ~>(m: Merge): Open    = new Open(Ast.Mg(Seq(edgeLabel -> ast), m))
+    def ~>(sp: Split): Forked = new Forked(Ast.Sp(ast, sp))
+    def ~>(s: Sink): Closed   = new Closed(Ast.Snk(ast, s))
+
+    def +(other: Open): MultiOpen =
+      new MultiOpen(Seq(edgeLabel -> ast, other.edgeLabel -> other.ast))
+
+    def fanOut(branches: (Open => Closed)*): Closed = {
+      require(branches.nonEmpty, "fanOut requires at least one branch")
+      val branchAsts = branches.map { b =>
+        val closed = b(new Open(Ast.Ref))
+        PlanValidation.validateBranch(closed.ast)
+        closed.ast
+      }
+      new Closed(Ast.Fork(ast, branchAsts))
+    }
+  }
+
+  final class MultiOpen private[dsl] (private[dsl] val parts: Seq[(String, Ast)]) {
+    def +(other: Open): MultiOpen = new MultiOpen(parts :+ (other.edgeLabel -> other.ast))
+    def ~>(m: Merge): Open        = new Open(Ast.Mg(parts, m))
+  }
+
+  final class Forked private[dsl] (private[dsl] val splitAst: Ast.Sp) {
+    def apply(port: String): Open = {
+      require(splitAst.sp.ports.contains(port), s"unknown port '$port'; known: ${splitAst.sp.ports.mkString(", ")}")
+      new Open(Ast.Port(splitAst, port))
+    }
+    def ports: Seq[String] = splitAst.sp.ports
+  }
+
+  final class Closed private[dsl] (private[dsl] val ast: Ast) extends Plan {
+    def run()(implicit spark: SparkSession): Unit = {
+      PlanValidation.validate(ast)
+      Executor.run(ast)
+    }
+  }
+
+  // Multiple Closeds share an execution memo, so a common upstream materializes once.
+  def bundle(closeds: Closed*): Closed = {
+    require(closeds.nonEmpty, "bundle requires at least one Closed")
+    if (closeds.size == 1) closeds.head
+    else new Closed(Ast.Group(closeds.map(_.ast)))
+  }
+
+  // Escape hatches for runners assembling the AST directly (e.g., StepsBuilder).
+  private[pipeline] def closed(ast: Ast): Closed = new Closed(ast)
+  private[pipeline] def open(ast: Ast): Open     = new Open(ast)
+}
+
+private[pipeline] sealed trait Ast
+private[pipeline] object Ast {
+  case class Src(s: Source)                              extends Ast
+  case class Fl(upstream: Ast, f: Flow)                  extends Ast
+  case class Mg(upstreams: Seq[(String, Ast)], m: Merge) extends Ast
+  case class Sp(upstream: Ast, sp: Split)                extends Ast
+  case class Port(splitNode: Sp, port: String)           extends Ast
+  case class Snk(upstream: Ast, s: Sink)                 extends Ast
+  case class Fork(upstream: Ast, branches: Seq[Ast])     extends Ast
+  case class Group(roots: Seq[Ast])                      extends Ast
+  // Placeholder for a fanOut branch's shared upstream; valid only inside a branch, where the Executor seeds the
+  // memo with Ref → the cached root. PlanValidation.validateBranch keeps it from escaping that context.
+  case object Ref extends Ast
+}
+
+private[dsl] object Executor {
+
+  // Identity-keyed: a shared upstream node materializes once; two separately-built Sources stay independent.
+  private type Memo      = IdentityHashMap[Ast, DataFrame]
+  private type SplitMemo = IdentityHashMap[Ast.Sp, Map[String, DataFrame]]
+
+  def run(ast: Ast)(implicit spark: SparkSession): Unit = runRoot(ast, new Memo(), new SplitMemo())
+
+  private def runRoot(ast: Ast, memo: Memo, splitMemo: SplitMemo)(implicit spark: SparkSession): Unit = ast match {
+    case Ast.Snk(up, sink) => sink.write(materialize(up, memo, splitMemo))
+    case Ast.Group(roots)  => roots.foreach(r => runRoot(r, memo, splitMemo))
+    case Ast.Fork(up, branches) =>
+      val df = materialize(up, memo, splitMemo).cache()
+      // Non-blocking: blocking would serialize against executor RPCs for no real benefit at job-termination.
+      try branches.foreach(runBranch(_, df))
+      finally df.unpersist(blocking = false)
+    case other => throw new IllegalStateException(s"Top-level Plan must end in a Sink, Fork, or Group, got: $other")
+  }
+
+  private def materialize(ast: Ast, memo: Memo, splitMemo: SplitMemo)(implicit spark: SparkSession): DataFrame =
+    memo.computeIfAbsent(
+      ast,
+      _ =>
+        ast match {
+          case Ast.Src(s)    => s.read()
+          case Ast.Fl(up, f) => f.apply(materialize(up, memo, splitMemo))
+          case Ast.Mg(ups, m) =>
+            m.apply(ups.map { case (label, up) => label -> materialize(up, memo, splitMemo) })
+          case Ast.Port(sp, port) =>
+            val splitMap = splitMemo.computeIfAbsent(sp, _ => sp.sp.split(materialize(sp.upstream, memo, splitMemo)))
+            splitMap.getOrElse(
+              port,
+              throw new IllegalStateException(s"unknown port '$port'; got: ${splitMap.keys.mkString(", ")}")
+            )
+          case Ast.Ref => throw new IllegalStateException("Ast.Ref outside fanOut branch — invalid Plan")
+          case other   => throw new IllegalStateException(s"materialize cannot handle: $other")
+        }
+    )
+
+  // Branches share the fork's cached root via a pre-seeded memo (Ast.Ref → root).
+  private def runBranch(ast: Ast, root: DataFrame)(implicit spark: SparkSession): Unit = ast match {
+    case Ast.Snk(up, sink) =>
+      val memo = new Memo()
+      memo.put(Ast.Ref, root)
+      sink.write(materialize(up, memo, new SplitMemo()))
+    case other => throw new IllegalStateException(s"fanOut branch must end in Sink, got: $other")
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/PlanValidation.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/PlanValidation.scala
@@ -1,0 +1,41 @@
+package com.kakao.actionbase.pipeline.dsl
+
+// Structural plan-time checks shared by both front-ends: the DSL runs `validate` from `Closed.run` and reuses
+// `validateBranch` for eager `fanOut` errors; the YAML builder produces a `Closed` that hits the same `validate`.
+// A single definition here keeps the two paths from drifting (their other checks are type- vs. string-specific).
+private[pipeline] object PlanValidation {
+
+  // Walk the finished AST and apply every whole-plan invariant before execution.
+  def validate(ast: Ast): Unit = ast match {
+    case Ast.Src(_)       =>
+    case Ast.Ref          =>
+    case Ast.Fl(up, _)    => validate(up)
+    case Ast.Mg(ups, _)   => ups.foreach { case (_, up) => validate(up) }
+    case Ast.Sp(up, _)    => validate(up)
+    case Ast.Port(sp, _)  => validate(sp)
+    case Ast.Snk(up, _)   => validate(up)
+    case Ast.Group(roots) => roots.foreach(validate)
+    case Ast.Fork(up, branches) =>
+      validate(up)
+      branches.foreach(validateBranch)
+  }
+
+  // A fanOut branch consumes the shared upstream and terminates in a Sink; it cannot start a new Source.
+  def validateBranch(ast: Ast): Unit = ast match {
+    case Ast.Snk(up, _) => validateBranchBody(up)
+    case other =>
+      throw new IllegalArgumentException(s"fanOut branch must end in a Sink, got ${other.getClass.getSimpleName}")
+  }
+
+  private def validateBranchBody(ast: Ast): Unit = ast match {
+    case Ast.Ref        =>
+    case Ast.Fl(up, _)  => validateBranchBody(up)
+    case Ast.Mg(ups, _) => ups.foreach { case (_, up) => validateBranchBody(up) }
+    case Ast.Src(_) =>
+      throw new IllegalArgumentException(
+        "fanOut branch cannot introduce a new Source; consume the shared upstream only"
+      )
+    case other =>
+      throw new IllegalArgumentException(s"fanOut branch cannot contain ${other.getClass.getSimpleName}")
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Step.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/Step.scala
@@ -1,0 +1,33 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+// Shapes: Source 0→1, Flow 1→1, Merge N→1, Split 1→M, Sink 1→0.
+sealed trait Step
+
+trait Source extends Step {
+  def read()(implicit spark: SparkSession): DataFrame
+}
+
+// DataFrame-to-DataFrame middle of the pipeline, varying only by arity (Flow/Merge/Split).
+sealed trait Transform extends Step
+
+trait Flow extends Transform {
+  def apply(in: DataFrame)(implicit spark: SparkSession): DataFrame
+}
+
+// Inputs arrive as (label, df) so consumers (e.g., SqlTransform) can address each by its producer's `as:` label.
+trait Merge extends Transform {
+  def apply(inputs: Seq[(String, DataFrame)])(implicit spark: SparkSession): DataFrame
+  def apply(in: DataFrame)(implicit spark: SparkSession): DataFrame = apply(Seq(DefaultLabel -> in))
+}
+
+// Ports declared up-front so the DSL validates references at plan time. Body runs once; ports share the result.
+trait Split extends Transform {
+  def ports: Seq[String]
+  def split(in: DataFrame)(implicit spark: SparkSession): Map[String, DataFrame]
+}
+
+trait Sink extends Step {
+  def write(in: DataFrame)(implicit spark: SparkSession): Unit
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/package.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/dsl/package.scala
@@ -1,0 +1,13 @@
+package com.kakao.actionbase.pipeline
+
+import scala.language.implicitConversions
+
+package object dsl {
+
+  // The implicit edge label for an unlabeled output: the linear-chain default and a Merge's single-input view name.
+  private[pipeline] val DefaultLabel: String = "_0"
+
+  // Lets a Source start a `~>` chain (the operator is defined on Plan.Open).
+  implicit def sourceToOpen(s: Source): Plan.Open =
+    new Plan.Open(Ast.Src(s))
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJob.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJob.scala
@@ -1,0 +1,12 @@
+package com.kakao.actionbase.pipeline.jobs
+
+import com.kakao.actionbase.pipeline.dsl.{Job, Plan}
+import com.kakao.actionbase.pipeline.runner.StepsBuilder
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+
+// Job whose Plan is assembled from a YAML `steps:` list — express a Source~>...~>Sink chain without writing a Job class.
+case class StepsRunnerCfg(steps: Seq[StepSpec])
+
+object StepsRunnerJob extends Job[StepsRunnerCfg] {
+  override def plan(cfg: StepsRunnerCfg): Plan.Closed = StepsBuilder.build(cfg.steps)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/ClassResolver.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/ClassResolver.scala
@@ -1,0 +1,83 @@
+package com.kakao.actionbase.pipeline.runner
+
+import java.io.File
+import java.net.{JarURLConnection, URL}
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
+
+// Resolves a YAML class name to a Class, loaded without running `<clinit>` so callers can reject non-Job/non-Step
+// candidates (e.g., `java.lang.Runtime`) before side-effecting init. A name resolves as (1) a fully-qualified name,
+// (2) `<root>.<name>` per root, or (3) failing those, by recursively scanning the classpath beneath each root for a
+// unique simple name. The scan is a convenience for the built-ins shipped under `…pipeline.steps.*`; third-party
+// steps live outside that package and so are reachable by FQN only. Results are memoized per (roots, name).
+object ClassResolver {
+
+  val JobRoots: Seq[String] = Seq("com.kakao.actionbase.pipeline.jobs")
+
+  // Single root; built-ins live in subpackages (source/transform/sink) found by the recursive scan.
+  val StepRoots: Seq[String] = Seq("com.kakao.actionbase.pipeline.steps")
+
+  private val cache = new ConcurrentHashMap[String, Class[_]]()
+
+  def resolve(name: String, roots: Seq[String]): Class[_] =
+    cache.computeIfAbsent(s"${roots.mkString(",")}::$name", _ => doResolve(name, roots))
+
+  private def doResolve(name: String, roots: Seq[String]): Class[_] = {
+    val direct = (name +: roots.map(r => s"$r.$name")).view.flatMap(tryLoad).headOption
+    direct.getOrElse(scanForSimpleName(name, roots))
+  }
+
+  // Distinct FQNs sharing the requested simple name. Zero → not found; one → load it; many → ambiguous, so refuse
+  // rather than pick by scan order (which varies across classpath layouts and would be silently nondeterministic).
+  private def scanForSimpleName(name: String, roots: Seq[String]): Class[_] = {
+    val matches = roots.flatMap(classNamesUnder).filter(fqn => fqn.substring(fqn.lastIndexOf('.') + 1) == name).distinct
+    matches match {
+      case Seq(only) =>
+        tryLoad(only).getOrElse(throw new ClassNotFoundException(only))
+      case Seq() =>
+        throw new ClassNotFoundException(
+          s"Cannot resolve '$name' as a full FQN or under any of: ${roots.mkString(", ")}"
+        )
+      case many =>
+        throw new IllegalArgumentException(
+          s"ambiguous step name '$name' matches ${many.mkString(", ")}; reference it by fully-qualified name"
+        )
+    }
+  }
+
+  private def loader: ClassLoader = Thread.currentThread().getContextClassLoader
+
+  private def tryLoad(fqn: String): Option[Class[_]] =
+    try Some(Class.forName(fqn, false, loader))
+    catch { case _: ClassNotFoundException => None }
+
+  // Top-level class FQNs (companion/anonymous `$` entries skipped) anywhere beneath `pkg` on the classpath.
+  private def classNamesUnder(pkg: String): Seq[String] = {
+    val path = pkg.replace('.', '/')
+    loader.getResources(path).asScala.toSeq.flatMap { url =>
+      url.getProtocol match {
+        case "file" => scanDir(new File(url.toURI), pkg)
+        case "jar"  => scanJar(url, path)
+        case _      => Nil
+      }
+    }
+  }
+
+  private def scanDir(dir: File, pkg: String): Seq[String] =
+    Option(dir.listFiles()).getOrElse(Array.empty[File]).toSeq.flatMap { f =>
+      if (f.isDirectory) scanDir(f, s"$pkg.${f.getName}")
+      else if (f.getName.endsWith(".class") && !f.getName.contains('$')) Seq(s"$pkg.${f.getName.stripSuffix(".class")}")
+      else Nil
+    }
+
+  private def scanJar(url: URL, pathPrefix: String): Seq[String] = {
+    val jar = url.openConnection().asInstanceOf[JarURLConnection].getJarFile
+    jar
+      .entries()
+      .asScala
+      .map(_.getName)
+      .filter(n => n.startsWith(pathPrefix) && n.endsWith(".class") && !n.contains('$'))
+      .map(_.stripSuffix(".class").replace('/', '.'))
+      .toSeq
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/StepsBuilder.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/runner/StepsBuilder.scala
@@ -1,0 +1,164 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.dsl._
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+// Assembles a runnable Plan.Closed from a list of StepSpecs. `inputs:` resolves by label; absent = previous step
+// (linear-chain default, label "_0"). A Split has no canonical "next", so downstream must reference port labels.
+object StepsBuilder {
+
+  def build(steps: Seq[StepSpec]): Plan.Closed = {
+    require(steps.nonEmpty, "`steps` must be non-empty")
+
+    val byLabel           = mutable.LinkedHashMap.empty[String, Ast]
+    val sinks             = mutable.ListBuffer.empty[Ast.Snk]
+    var prev: Option[Ast] = None
+
+    steps.foreach { spec =>
+      val instance = instantiate(spec)
+      val ast: Ast = instance match {
+        case s: Source =>
+          require(spec.inputs.isEmpty, s"Source `${spec.step}` cannot declare `inputs:`")
+          Ast.Src(s)
+        case f: Flow =>
+          val ups = resolveUpstreams(spec, byLabel, prev)
+          require(ups.size == 1, s"Flow `${spec.step}` is single-input; got ${ups.size}")
+          Ast.Fl(ups.head._2, f)
+        case m: Merge =>
+          Ast.Mg(resolveUpstreams(spec, byLabel, prev), m)
+        case sp: Split =>
+          val ups = resolveUpstreams(spec, byLabel, prev)
+          require(ups.size == 1, s"Split `${spec.step}` is single-input; got ${ups.size}")
+          Ast.Sp(ups.head._2, sp)
+        case k: Sink =>
+          require(spec.as.isEmpty, s"Sink `${spec.step}` cannot declare `as:`")
+          require(spec.inputs.size <= 1, s"Sink `${spec.step}` is single-input; got ${spec.inputs.size} inputs")
+          val snk = Ast.Snk(resolveUpstreams(spec, byLabel, prev).head._2, k)
+          sinks += snk
+          snk
+        case other =>
+          throw new IllegalArgumentException(s"${spec.step} is not a Step; got ${other.getClass.getName}")
+      }
+      registerLabels(spec, instance, ast, byLabel)
+      prev = instance match {
+        case _: Split => None
+        case _: Sink  => prev
+        case _        => Some(ast)
+      }
+    }
+
+    sinks.size match {
+      case 0 => throw new IllegalArgumentException("workflow must have at least one Sink")
+      case 1 => Plan.closed(sinks.head)
+      case _ => Plan.closed(Ast.Group(sinks.toSeq))
+    }
+  }
+
+  private def registerLabels(
+      spec: StepSpec,
+      instance: Step,
+      ast: Ast,
+      byLabel: mutable.LinkedHashMap[String, Ast]
+  ): Unit = spec.as match {
+    case None | Some(null) =>
+    case Some(label: String) =>
+      require(!instance.isInstanceOf[Split], s"Split `${spec.step}` requires `as: {port: label}` map form")
+      addLabel(byLabel, label, ast, spec)
+    case Some(jmap: java.util.Map[_, _]) =>
+      addPortLabels(
+        spec,
+        instance,
+        ast,
+        byLabel,
+        jmap.asScala.iterator.map { case (k, v) => k.toString -> v.toString }.toMap
+      )
+    case Some(smap: Map[_, _] @unchecked) =>
+      addPortLabels(spec, instance, ast, byLabel, smap.map { case (k, v) => k.toString -> v.toString })
+    case Some(other) =>
+      throw new IllegalArgumentException(
+        s"step `${spec.step}`: `as:` must be a string or {port: label} map, got ${other.getClass.getName}"
+      )
+  }
+
+  private def addPortLabels(
+      spec: StepSpec,
+      instance: Step,
+      ast: Ast,
+      byLabel: mutable.LinkedHashMap[String, Ast],
+      portLabels: Map[String, String]
+  ): Unit = (instance, ast) match {
+    case (sp: Split, spAst: Ast.Sp) =>
+      portLabels.keys.foreach { port =>
+        require(
+          sp.ports.contains(port),
+          s"Split `${spec.step}` has no port `$port`; declared: ${sp.ports.mkString(", ")}"
+        )
+      }
+      // Every declared port must be labeled, else its rows are silently dropped — almost always a wiring mistake.
+      val unlabeled = sp.ports.filterNot(portLabels.contains)
+      require(
+        unlabeled.isEmpty,
+        s"Split `${spec.step}` leaves port(s) ${unlabeled.mkString(", ")} unlabeled; map every declared port"
+      )
+      portLabels.foreach { case (port, label) => addLabel(byLabel, label, Ast.Port(spAst, port), spec) }
+    case _ =>
+      throw new IllegalArgumentException(
+        s"step `${spec.step}` is not a Split; `as: {port: label}` map form is only for Split"
+      )
+  }
+
+  private def addLabel(byLabel: mutable.LinkedHashMap[String, Ast], label: String, ast: Ast, spec: StepSpec): Unit = {
+    require(!byLabel.contains(label), s"duplicate step label `as: $label` (declared by `${spec.step}`)")
+    byLabel(label) = ast
+  }
+
+  private def resolveUpstreams(
+      spec: StepSpec,
+      byLabel: collection.Map[String, Ast],
+      prev: Option[Ast]
+  ): Seq[(String, Ast)] = {
+    val ups: Seq[(String, Ast)] =
+      if (spec.inputs.nonEmpty)
+        spec.inputs.map { label =>
+          val known = if (byLabel.isEmpty) "<none>" else byLabel.keys.mkString(", ")
+          label -> byLabel.getOrElse(
+            label,
+            throw new IllegalArgumentException(s"step `${spec.step}` references unknown input `$label`; known: $known")
+          )
+        }
+      else
+        Seq(
+          DefaultLabel -> prev.getOrElse(
+            throw new IllegalArgumentException(
+              s"step `${spec.step}` has no upstream — first step must be a Source, or specify `inputs:`"
+            )
+          )
+        )
+
+    ups.foreach {
+      case (_, _: Ast.Src | _: Ast.Fl | _: Ast.Mg | _: Ast.Port) =>
+      case (_, other) =>
+        throw new IllegalArgumentException(
+          s"step `${spec.step}` upstream must produce a DataFrame, got ${other.getClass.getSimpleName}"
+        )
+    }
+    ups
+  }
+
+  private def instantiate(spec: StepSpec): Step = {
+    val cls = ClassResolver.resolve(spec.step, ClassResolver.StepRoots)
+    // Reject non-Step FQNs before `<clinit>` runs (see ClassResolver).
+    require(classOf[Step].isAssignableFrom(cls), s"${spec.step} is not a Step; got ${cls.getName}")
+    try Job.stepMapper.convertValue(spec.args, cls).asInstanceOf[Step]
+    catch {
+      case e: RuntimeException =>
+        throw new IllegalArgumentException(
+          s"failed to bind args for step `${spec.step}` (args=${spec.args}): ${e.getMessage}",
+          e
+        )
+    }
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/FileSink.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/FileSink.scala
@@ -1,0 +1,15 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.dsl.Sink
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+// `mode` defaults to `errorifexists` (Spark default) to avoid silent overwrites on accidental rerun.
+case class FileSink(
+    path: String,
+    format: String,
+    mode: String = "errorifexists",
+    options: Map[String, String] = Map.empty
+) extends Sink {
+  override def write(in: DataFrame)(implicit spark: SparkSession): Unit =
+    in.write.format(format).mode(mode).options(options).save(path)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSink.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSink.scala
@@ -1,0 +1,9 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.dsl.Sink
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+case class ShowSink(numRows: Int = 20, truncate: Boolean = true) extends Sink {
+  override def write(in: DataFrame)(implicit spark: SparkSession): Unit =
+    in.show(numRows, truncate)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/FileSource.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/FileSource.scala
@@ -1,0 +1,13 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.dsl.Source
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+case class FileSource(
+    path: String,
+    format: String,
+    options: Map[String, String] = Map.empty
+) extends Source {
+  override def read()(implicit spark: SparkSession): DataFrame =
+    spark.read.format(format).options(options).load(path)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/SampleSource.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/source/SampleSource.scala
@@ -1,0 +1,12 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.dsl.Source
+import org.apache.spark.sql.functions.rand
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+case class SampleSource(n: Long, columns: Seq[String]) extends Source {
+  require(columns.nonEmpty, "SampleSource requires at least one column")
+
+  override def read()(implicit spark: SparkSession): DataFrame =
+    spark.range(n).select(columns.map(name => rand().as(name)): _*)
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransform.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransform.scala
@@ -1,0 +1,11 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.dsl.Flow
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.storage.StorageLevel
+
+// Materialize once when one upstream feeds multiple transforms; without it Spark re-executes the lineage per consumer.
+case class CacheTransform(level: String = "MEMORY_AND_DISK") extends Flow {
+  override def apply(in: DataFrame)(implicit spark: SparkSession): DataFrame =
+    in.persist(StorageLevel.fromString(level))
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransform.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransform.scala
@@ -1,0 +1,12 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.dsl.Merge
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+// Each input registers as a temp view named by its producer's `as:` label (or "_0" for the chain default).
+case class SqlTransform(query: String) extends Merge {
+  override def apply(inputs: Seq[(String, DataFrame)])(implicit spark: SparkSession): DataFrame = {
+    inputs.foreach { case (name, df) => df.createOrReplaceTempView(name) }
+    spark.sql(query)
+  }
+}

--- a/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/StepSpec.scala
+++ b/pipeline/src/main/scala/com/kakao/actionbase/pipeline/workflow/StepSpec.scala
@@ -1,0 +1,9 @@
+package com.kakao.actionbase.pipeline.workflow
+
+// `as` is `Any` so YAML can supply either a string (single output label) or a {port: label} map for a Split.
+case class StepSpec(
+    step: String,
+    args: Map[String, Any] = Map.empty,
+    as: Option[Any] = None,
+    inputs: Seq[String] = Seq.empty
+)

--- a/pipeline/src/test/java/com/kakao/actionbase/pipeline/runner/ThrowingClinitSentinel.java
+++ b/pipeline/src/test/java/com/kakao/actionbase/pipeline/runner/ThrowingClinitSentinel.java
@@ -1,0 +1,18 @@
+package com.kakao.actionbase.pipeline.runner;
+
+/**
+ * Test sentinel whose static initializer throws. Used to assert {@link ClassResolver} returns the
+ * class metadata without triggering {@code <clinit>}, and that {@code StepsBuilder} rejects
+ * non-Step FQNs before any initializer runs. Written in Java so the static initializer block is
+ * unambiguous (Scala objects emit their own MODULE$ init which makes "did init run?" harder to
+ * observe from outside).
+ */
+public final class ThrowingClinitSentinel {
+  static {
+    if (Boolean.parseBoolean("true")) {
+      throw new RuntimeException("ThrowingClinitSentinel.<clinit> must not run in this test");
+    }
+  }
+
+  private ThrowingClinitSentinel() {}
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
@@ -1,0 +1,17 @@
+package com.kakao.actionbase.pipeline
+
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Mix-in for unit tests that need an `implicit SparkSession`. The session is `local[2]` and shared across all
+  * `SparkTest` mixers in the JVM (Spark's own `getOrCreate` semantics).
+  */
+trait SparkTest {
+  protected implicit lazy val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[2]")
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .config("spark.ui.enabled", "false")
+    .appName(getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/JobTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/JobTest.scala
@@ -1,0 +1,67 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.kakao.actionbase.pipeline.steps.sink.ShowSink
+import com.kakao.actionbase.pipeline.steps.source.SampleSource
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+  * Direct unit coverage for `Job.parseArgv` and `Job.planFromMap` — the Cfg-binding seam between argv/YAML and a
+  * subclass's `plan(cfg)`. The `main` entry point itself needs SparkSession lifecycle and is exercised end-to-end via
+  * `StepsBuilderTest`.
+  */
+class JobTest {
+
+  @Test
+  def parseArgvHandlesKeyValuePairs(): Unit = {
+    val parsed = Job.parseArgv(Array("--in=path/to/file", "--n=10"))
+    assertEquals(Map("in" -> "path/to/file", "n" -> "10"), parsed)
+  }
+
+  @Test
+  def parseArgvSplitsOnFirstEqualsOnly(): Unit = {
+    // Values may legitimately contain `=` (e.g., SQL `WHERE k = 'v'`); only the first `=` separates key from value.
+    val parsed = Job.parseArgv(Array("--query=SELECT * FROM t WHERE k='v=1'"))
+    assertEquals(Map("query" -> "SELECT * FROM t WHERE k='v=1'"), parsed)
+  }
+
+  @Test
+  def parseArgvIgnoresUnrecognizedTokens(): Unit = {
+    // Non-`--` tokens and flags without `=` are dropped (with a stderr warning the test doesn't capture). The returned
+    // map must only contain well-formed pairs so downstream Cfg binding is predictable.
+    val parsed = Job.parseArgv(Array("positional", "--bare-flag", "--in=x"))
+    assertEquals(Map("in" -> "x"), parsed)
+  }
+
+  @Test
+  def planFromMapBindsNestedCfg(): Unit = {
+    val plan = JobTest.TestJob.planFromMap(Map("in" -> "p", "n" -> 5, "flag" -> true))
+    assertNotNull(plan, "planFromMap must return a runnable Plan.Closed")
+  }
+
+  @Test
+  def planFromMapFailsOnMissingRequiredPrimitive(): Unit = {
+    // `n: Int` has no default — its absence must throw rather than silently become 0.
+    assertThrows(
+      classOf[RuntimeException],
+      () => JobTest.TestJob.planFromMap(Map("in" -> "p"))
+    )
+  }
+
+  @Test
+  def planFromMapToleratesUnknownTopLevelKeys(): Unit = {
+    // Top-level Cfg uses the lax mapper so Spark's own `--spark.*` flags don't break job startup.
+    val plan = JobTest.TestJob.planFromMap(Map("in" -> "p", "n" -> 3, "spark.master" -> "local[*]"))
+    assertNotNull(plan)
+  }
+}
+
+object JobTest {
+  // Top-level case class avoids an outer-`this` reference that confuses Jackson's Scala module.
+  case class TestCfg(in: String, n: Int, flag: Boolean = false)
+
+  object TestJob extends Job[TestCfg] {
+    override def plan(cfg: TestCfg): Plan.Closed =
+      Plan.closed(Ast.Snk(Ast.Src(SampleSource(cfg.n.toLong, Seq("v"))), ShowSink()))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanExecutorTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanExecutorTest.scala
@@ -1,0 +1,145 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.kakao.actionbase.pipeline.SparkTest
+import com.kakao.actionbase.pipeline.steps.transform.SqlTransform
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.storage.StorageLevel
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+  * Executor-level tests: fanOut caching and AST-identity memoization. These exercise behavior the YAML-facing
+  * `StepsBuilderTest` cannot verify directly (no read-call counter on built-in Sources).
+  */
+class PlanExecutorTest extends SparkTest {
+
+  /** Source that counts how many times `read()` is invoked, so tests can assert single-materialization. */
+  private class CountingSource(rows: Long) extends Source {
+    @volatile var calls: Int = 0
+    override def read()(implicit spark: SparkSession): DataFrame = {
+      calls += 1
+      spark.range(rows).toDF("n")
+    }
+  }
+
+  /** Sink that captures the DataFrame it receives and its storage level at write time. */
+  private class CapturingSink extends Sink {
+    @volatile var received: DataFrame          = _
+    @volatile var storageAtWrite: StorageLevel = StorageLevel.NONE
+    override def write(in: DataFrame)(implicit spark: SparkSession): Unit = {
+      storageAtWrite = in.storageLevel
+      received = in
+    }
+  }
+
+  @Test
+  def fanOutCachesUpstreamAndUnpersistsAfter(): Unit = {
+    val src   = new CountingSource(5L)
+    val sinkA = new CapturingSink
+    val sinkB = new CapturingSink
+
+    src.fanOut(_ ~> sinkA, _ ~> sinkB).run()
+
+    assertEquals(1, src.calls, "source must be read only once across fanOut branches")
+    assertNotEquals(
+      StorageLevel.NONE,
+      sinkA.storageAtWrite,
+      "branch sink sees the cached upstream"
+    )
+    assertNotEquals(
+      StorageLevel.NONE,
+      sinkB.storageAtWrite,
+      "branch sink sees the cached upstream"
+    )
+    assertEquals(
+      StorageLevel.NONE,
+      sinkA.received.storageLevel,
+      "cached upstream is unpersisted after run"
+    )
+  }
+
+  @Test
+  def fanOutBranchSupportsFlowAndMerge(): Unit = {
+    val src   = new CountingSource(4L)
+    val sinkA = new CapturingSink
+    val sinkB = new CapturingSink
+
+    src
+      .fanOut(
+        _ ~> sinkA,
+        _ ~> SqlTransform("SELECT n * 2 AS n FROM _0") ~> sinkB
+      )
+      .run()
+
+    assertEquals(Set(0L, 1L, 2L, 3L), sinkA.received.collect().map(_.getLong(0)).toSet)
+    assertEquals(Set(0L, 2L, 4L, 6L), sinkB.received.collect().map(_.getLong(0)).toSet)
+  }
+
+  @Test
+  def fanOutRequiresAtLeastOneBranch(): Unit = {
+    val src = new CountingSource(1L)
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => src.fanOut(): Plan.Closed
+    )
+  }
+
+  @Test
+  def fanOutRejectsBranchIntroducingNewSource(): Unit = {
+    // The branch ignores the supplied fork-root Open and chains a fresh Source instead — this defeats the shared-
+    // upstream contract and must be caught at plan construction, not at run().
+    val src   = new CountingSource(1L)
+    val other = new CountingSource(1L)
+    val sink  = new CapturingSink
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => src.fanOut(_ => (other: Plan.Open) ~> sink)
+    )
+    assertTrue(ex.getMessage.contains("Source"), ex.getMessage)
+  }
+
+  @Test
+  def fanOutRejectsBranchJoiningNewSource(): Unit = {
+    // `+`-combining the fork root with another Source compiles but breaks the "branches consume shared upstream" rule.
+    val src   = new CountingSource(1L)
+    val other = new CountingSource(1L)
+    val sink  = new CapturingSink
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => src.fanOut(open => (open + (other: Plan.Open).as("x")) ~> SqlTransform("SELECT n FROM _0") ~> sink)
+    )
+    assertTrue(ex.getMessage.contains("Source"), ex.getMessage)
+  }
+
+  @Test
+  def memoizationSharesUpstreamAcrossSinks(): Unit = {
+    val src    = new CountingSource(3L)
+    val sinkA  = new CapturingSink
+    val sinkB  = new CapturingSink
+    val srcAst = Ast.Src(src)
+    val plan = Plan.closed(
+      Ast.Group(Seq(Ast.Snk(srcAst, sinkA), Ast.Snk(srcAst, sinkB)))
+    )
+
+    plan.run()
+
+    assertEquals(1, src.calls, "shared upstream materializes exactly once across multiple sinks")
+  }
+
+  @Test
+  def memoizationKeysOnAstIdentityNotEquality(): Unit = {
+    // Two separately-constructed Sources with identical args are distinct AST nodes — memo must not dedupe them.
+    val srcA  = new CountingSource(2L)
+    val srcB  = new CountingSource(2L)
+    val sinkA = new CapturingSink
+    val sinkB = new CapturingSink
+    val plan = Plan.closed(
+      Ast.Group(Seq(Ast.Snk(Ast.Src(srcA), sinkA), Ast.Snk(Ast.Src(srcB), sinkB)))
+    )
+
+    plan.run()
+
+    assertEquals(1, srcA.calls)
+    assertEquals(1, srcB.calls)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanSplitTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanSplitTest.scala
@@ -1,0 +1,137 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+  * Tests for the Split primitive: port selection, plan-time port validation, single-execution port memoization, and
+  * `Plan.bundle` composition of per-port Sinks.
+  */
+class PlanSplitTest extends SparkTest {
+
+  /** A Source that emits `(k: int, v: int)` rows we can route by `k`. */
+  private class KvSource(rows: Seq[(Int, Int)]) extends Source {
+    override def read()(implicit spark: SparkSession): DataFrame = {
+      import spark.implicits._
+      rows.toDF("k", "v")
+    }
+  }
+
+  /**
+    * A Split that partitions input rows by even/odd `k`. The number of `split()` invocations is observable so tests can
+    * assert the port memo runs the body exactly once per Plan execution.
+    */
+  private class ParitySplit extends Split {
+    @volatile var splitCalls: Int   = 0
+    override def ports: Seq[String] = Seq("even", "odd")
+    override def split(in: DataFrame)(implicit spark: SparkSession): Map[String, DataFrame] = {
+      splitCalls += 1
+      Map(
+        "even" -> in.where("k % 2 = 0"),
+        "odd"  -> in.where("k % 2 = 1")
+      )
+    }
+  }
+
+  private class CapturingSink extends Sink {
+    @volatile var received: DataFrame                                     = _
+    override def write(in: DataFrame)(implicit spark: SparkSession): Unit = received = in
+  }
+
+  @Test
+  def routesPortsToTheirRespectiveSinks(): Unit = {
+    val src      = new KvSource(Seq((0, 10), (1, 11), (2, 12), (3, 13)))
+    val splitter = new ParitySplit
+    val evenSink = new CapturingSink
+    val oddSink  = new CapturingSink
+
+    val forked: Plan.Forked = (src: Plan.Open) ~> splitter
+    Plan
+      .bundle(
+        forked("even") ~> evenSink,
+        forked("odd") ~> oddSink
+      )
+      .run()
+
+    assertEquals(Set(0 -> 10, 2 -> 12), evenSink.received.collect().map(r => r.getInt(0) -> r.getInt(1)).toSet)
+    assertEquals(Set(1 -> 11, 3 -> 13), oddSink.received.collect().map(r => r.getInt(0) -> r.getInt(1)).toSet)
+  }
+
+  @Test
+  def splitBodyRunsOnceAcrossMultiplePortConsumers(): Unit = {
+    val src      = new KvSource(Seq((0, 10), (1, 11)))
+    val splitter = new ParitySplit
+    val evenSink = new CapturingSink
+    val oddSink  = new CapturingSink
+
+    Plan
+      .bundle(
+        ((src: Plan.Open) ~> splitter)("even") ~> evenSink,
+        ((src: Plan.Open) ~> splitter)("odd") ~> oddSink
+      )
+      .run()
+
+    // Two independently-constructed `~> splitter` expressions are *different* AST nodes (different Ast.Sp identities),
+    // so each runs its split body once. Identity-based memo: not deduped structurally. Two calls total.
+    assertEquals(2, splitter.splitCalls, "AST identity guards against accidental structural dedup")
+  }
+
+  @Test
+  def splitBodyRunsOnceWhenForkedReused(): Unit = {
+    val src      = new KvSource(Seq((0, 10), (1, 11)))
+    val splitter = new ParitySplit
+    val evenSink = new CapturingSink
+    val oddSink  = new CapturingSink
+
+    val forked = (src: Plan.Open) ~> splitter
+    Plan
+      .bundle(
+        forked("even") ~> evenSink,
+        forked("odd") ~> oddSink
+      )
+      .run()
+
+    assertEquals(1, splitter.splitCalls, "shared Forked: split body runs once across both port consumers")
+  }
+
+  @Test
+  def rejectsUnknownPortAtPlanTime(): Unit = {
+    val src      = new KvSource(Seq.empty)
+    val splitter = new ParitySplit
+    val forked   = (src: Plan.Open) ~> splitter
+
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => forked("ghost"): Plan.Open
+    )
+    assertTrue(ex.getMessage.contains("ghost"), ex.getMessage)
+  }
+
+  @Test
+  def forkedExposesPortsList(): Unit = {
+    val src      = new KvSource(Seq.empty)
+    val splitter = new ParitySplit
+    val forked   = (src: Plan.Open) ~> splitter
+    assertEquals(Seq("even", "odd"), forked.ports)
+  }
+
+  @Test
+  def bundleOfSinglePassesThrough(): Unit = {
+    val src     = new KvSource(Seq((0, 10)))
+    val sink    = new CapturingSink
+    val one     = (src: Plan.Open) ~> sink
+    val bundled = Plan.bundle(one)
+    bundled.run()
+    assertNotNull(sink.received)
+  }
+
+  @Test
+  def bundleRequiresAtLeastOneClosed(): Unit = {
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => Plan.bundle(): Plan.Closed
+    )
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanTypeStateTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/dsl/PlanTypeStateTest.scala
@@ -1,0 +1,37 @@
+package com.kakao.actionbase.pipeline.dsl
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+  * Encodes the type-state guarantee that a chain without a Sink is not runnable — `Plan.Open` does not expose `run()`,
+  * `Plan.Closed` does. Compile-time enforcement is the actual guarantee; this is a regression sentinel that fires if
+  * `run` ever leaks onto the wrong type.
+  */
+class PlanTypeStateTest {
+
+  @Test
+  def planOpenDoesNotExposeRun(): Unit = {
+    assertFalse(
+      classOf[Plan.Open].getMethods.exists(_.getName == "run"),
+      "Plan.Open must not expose run() — a chain without a Sink is not runnable"
+    )
+  }
+
+  @Test
+  def planClosedExposesRun(): Unit = {
+    assertTrue(
+      classOf[Plan.Closed].getMethods.exists(_.getName == "run"),
+      "Plan.Closed must expose run() — a chain ending in a Sink is runnable"
+    )
+  }
+
+  @Test
+  def multiOpenDoesNotExposeRun(): Unit = {
+    // A combined multi-input chain (a + b) must still terminate via a Merge and then a Sink before it can run.
+    assertFalse(
+      classOf[Plan.MultiOpen].getMethods.exists(_.getName == "run"),
+      "Plan.MultiOpen must not expose run()"
+    )
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJobTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/jobs/StepsRunnerJobTest.scala
@@ -1,0 +1,92 @@
+package com.kakao.actionbase.pipeline.jobs
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.file.{Files, Paths}
+
+/**
+  * End-to-end YAML round-trip for `StepsRunnerJob`: parses a workflow-shaped YAML `args:` block into the loose
+  * `Map[String, Any]` shape that real runners hand to `Job.planFromMap`, then exercises Plan construction and
+  * execution. Catches `StepSpec` / Cfg deserialize regressions that `StepsBuilderTest` (which starts from already-
+  * constructed `StepSpec` values) cannot see — in particular, the polymorphic `as` field that resolves to either a
+  * String or a Map depending on the step kind.
+  */
+class StepsRunnerJobTest extends SparkTest {
+
+  private val yaml: ObjectMapper with ClassTagExtensions = {
+    val m = new ObjectMapper(new YAMLFactory()) with ClassTagExtensions
+    m.registerModule(DefaultScalaModule)
+    m
+  }
+
+  private def yamlAsMap(text: String): Map[String, Any] = yaml.readValue[Map[String, Any]](text)
+
+  @Test
+  def runsLinearChainFromYaml(): Unit = {
+    val text =
+      """steps:
+        |  - step: SampleSource
+        |    args: { n: 10, columns: [x] }
+        |  - step: SqlTransform
+        |    args: { query: "SELECT x * 2 AS y FROM _0" }
+        |  - step: ShowSink
+        |""".stripMargin
+
+    StepsRunnerJob.planFromMap(yamlAsMap(text)).run()
+  }
+
+  @Test
+  def bindsStringAsAndInputsForJoin(): Unit = {
+    val text =
+      """steps:
+        |  - step: SampleSource
+        |    args: { n: 4, columns: [u] }
+        |    as: users
+        |  - step: SampleSource
+        |    args: { n: 4, columns: [e] }
+        |    as: events
+        |  - step: SqlTransform
+        |    args: { query: "SELECT u.u, e.e FROM users u CROSS JOIN events e" }
+        |    inputs: [users, events]
+        |  - step: ShowSink
+        |""".stripMargin
+
+    StepsRunnerJob.planFromMap(yamlAsMap(text)).run()
+  }
+
+  @Test
+  def bindsMapAsForSplitPorts(): Unit = {
+    val tmpEven = Files.createTempDirectory("yaml-split-even-").resolve("out").toString
+    val tmpOdd  = Files.createTempDirectory("yaml-split-odd-").resolve("out").toString
+
+    val text =
+      s"""steps:
+         |  - step: SampleSource
+         |    args: { n: 6, columns: [v] }
+         |  - step: SqlTransform
+         |    args: { query: "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0" }
+         |  - step: com.kakao.actionbase.pipeline.steps.split.ParitySplit
+         |    as: { even: evenRows, odd: oddRows }
+         |  - step: FileSink
+         |    args: { path: "$tmpEven", format: parquet, mode: overwrite }
+         |    inputs: [evenRows]
+         |  - step: FileSink
+         |    args: { path: "$tmpOdd", format: parquet, mode: overwrite }
+         |    inputs: [oddRows]
+         |""".stripMargin
+
+    StepsRunnerJob.planFromMap(yamlAsMap(text)).run()
+
+    assertTrue(Files.exists(Paths.get(tmpEven)))
+    assertTrue(Files.exists(Paths.get(tmpOdd)))
+    val even = spark.read.parquet(tmpEven).collect().map(_.getInt(0)).toSet
+    val odd  = spark.read.parquet(tmpOdd).collect().map(_.getInt(0)).toSet
+    assertTrue(even.forall(_ % 2 == 0), s"even partition leaked odd rows: $even")
+    assertTrue(odd.forall(_ % 2 == 1), s"odd partition leaked even rows: $odd")
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/ClassResolverTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/ClassResolverTest.scala
@@ -1,0 +1,67 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class ClassResolverTest {
+
+  @Test
+  def resolvesShortNameUnderRoots(): Unit = {
+    val cls = ClassResolver.resolve("ShowSink", ClassResolver.StepRoots)
+    assertEquals("com.kakao.actionbase.pipeline.steps.sink.ShowSink", cls.getName)
+  }
+
+  @Test
+  def resolvesFullyQualifiedName(): Unit = {
+    val cls = ClassResolver.resolve(
+      "com.kakao.actionbase.pipeline.steps.source.SampleSource",
+      ClassResolver.StepRoots
+    )
+    assertEquals("com.kakao.actionbase.pipeline.steps.source.SampleSource", cls.getName)
+  }
+
+  @Test
+  def throwsOnUnresolvableName(): Unit = {
+    assertThrows(
+      classOf[ClassNotFoundException],
+      () => ClassResolver.resolve("DoesNotExist", ClassResolver.StepRoots)
+    )
+  }
+
+  @Test
+  def rejectsAmbiguousSimpleName(): Unit = {
+    // Two steps.* subpackages declare a `CollidingName`; resolving the bare name must refuse rather than pick one.
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => ClassResolver.resolve("CollidingName", ClassResolver.StepRoots)
+    )
+    assertTrue(ex.getMessage.contains("ambiguous"), ex.getMessage)
+    assertTrue(ex.getMessage.contains("steps.source.CollidingName"), ex.getMessage)
+    assertTrue(ex.getMessage.contains("steps.sink.CollidingName"), ex.getMessage)
+  }
+
+  @Test
+  def loadsClassWithoutTriggeringStaticInitializer(): Unit = {
+    // The sentinel's <clinit> throws. If `resolve` initializes the class, load fails. If it merely loads (per the
+    // `initialize = false` contract), load succeeds and we keep the un-initialized class reference.
+    val cls = ClassResolver.resolve(
+      "com.kakao.actionbase.pipeline.runner.ThrowingClinitSentinel",
+      Seq.empty
+    )
+    assertEquals("com.kakao.actionbase.pipeline.runner.ThrowingClinitSentinel", cls.getName)
+  }
+
+  @Test
+  def stepsBuilderRejectsNonStepFqnBeforeInit(): Unit = {
+    // End-to-end guard: a YAML naming a non-Step class must fail at the type-check, not at `convertValue` or later. The
+    // sentinel's <clinit> throws — if StepsBuilder triggered init before the type check, we'd see ExceptionInInitializer
+    // instead of the expected `not a Step` IllegalArgumentException.
+    val spec = StepSpec("com.kakao.actionbase.pipeline.runner.ThrowingClinitSentinel")
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(Seq(spec))
+    )
+    assertTrue(ex.getMessage.contains("not a Step"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/StepsBuilderTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/runner/StepsBuilderTest.scala
@@ -1,0 +1,250 @@
+package com.kakao.actionbase.pipeline.runner
+
+import com.kakao.actionbase.pipeline.SparkTest
+import com.kakao.actionbase.pipeline.workflow.StepSpec
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class StepsBuilderTest extends SparkTest {
+
+  private val ShowSinkFqn     = "com.kakao.actionbase.pipeline.steps.sink.ShowSink"
+  private val FileSinkFqn     = "com.kakao.actionbase.pipeline.steps.sink.FileSink"
+  private val SampleSourceFqn = "com.kakao.actionbase.pipeline.steps.source.SampleSource"
+  private val SqlTransformFqn = "com.kakao.actionbase.pipeline.steps.transform.SqlTransform"
+  private val ParitySplitFqn  = "com.kakao.actionbase.pipeline.steps.split.ParitySplit"
+
+  @Test
+  def buildsAndRunsSourceSinkChain(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 50L, "columns" -> Seq("a", "b"))),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def buildsAndRunsSourceMergeSinkChain(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 20L, "columns" -> Seq("x"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT x * 2 AS y FROM _0")),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def buildsAndRunsJoinAcrossLabeledSources(): Unit = {
+    val steps = Seq(
+      StepSpec(
+        SampleSourceFqn,
+        args = Map("n" -> 5L, "columns" -> Seq("u")),
+        as = Some("users")
+      ),
+      StepSpec(
+        SampleSourceFqn,
+        args = Map("n" -> 5L, "columns" -> Seq("e")),
+        as = Some("events")
+      ),
+      StepSpec(
+        SqlTransformFqn,
+        args = Map("query" -> "SELECT u.u, e.e FROM users u CROSS JOIN events e"),
+        inputs = Seq("users", "events")
+      ),
+      StepSpec(ShowSinkFqn)
+    )
+
+    StepsBuilder.build(steps).run()
+  }
+
+  @Test
+  def rejectsSinkWithoutUpstream(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(Seq(StepSpec(ShowSinkFqn)))
+    )
+    assertTrue(ex.getMessage.contains("no upstream"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsWorkflowWithNoSink(): Unit = {
+    val steps = Seq(StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a"))))
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("at least one Sink"), ex.getMessage)
+  }
+
+  @Test
+  def runsMultipleSinksOverSharedUpstream(): Unit = {
+    val tmpA = java.nio.file.Files.createTempDirectory("multi-sink-a-").resolve("out").toString
+    val tmpB = java.nio.file.Files.createTempDirectory("multi-sink-b-").resolve("out").toString
+
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("x")), as = Some("data")),
+      StepSpec(FileSinkFqn, Map("path" -> tmpA, "format" -> "parquet"), inputs = Seq("data")),
+      StepSpec(FileSinkFqn, Map("path" -> tmpB, "format" -> "parquet"), inputs = Seq("data"))
+    )
+
+    StepsBuilder.build(steps).run()
+
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpA)), s"sink A should write: $tmpA")
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpB)), s"sink B should write: $tmpB")
+  }
+
+  @Test
+  def runsIndependentSinkSubTrees(): Unit = {
+    val tmpA = java.nio.file.Files.createTempDirectory("indep-a-").resolve("out").toString
+    val tmpB = java.nio.file.Files.createTempDirectory("indep-b-").resolve("out").toString
+
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 3L, "columns" -> Seq("a"))),
+      StepSpec(FileSinkFqn, Map("path" -> tmpA, "format" -> "parquet")),
+      StepSpec(SampleSourceFqn, Map("n" -> 3L, "columns" -> Seq("b"))),
+      StepSpec(FileSinkFqn, Map("path" -> tmpB, "format" -> "parquet"))
+    )
+
+    StepsBuilder.build(steps).run()
+
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpA)), s"first subtree should write: $tmpA")
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpB)), s"second subtree should write: $tmpB")
+  }
+
+  @Test
+  def rejectsUnknownInputLabel(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a"))),
+      StepSpec(ShowSinkFqn, inputs = Seq("ghost"))
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("ghost"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsDuplicateLabel(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("a")), as = Some("dup")),
+      StepSpec(SampleSourceFqn, Map("n" -> 5L, "columns" -> Seq("b")), as = Some("dup")),
+      StepSpec(ShowSinkFqn)
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("duplicate"), ex.getMessage)
+  }
+
+  @Test
+  def buildsAndRunsSplitChain(): Unit = {
+    // Source → SqlTransform (project k from x) → ParitySplit → two FileSinks via port labels.
+    val tmpEven = java.nio.file.Files.createTempDirectory("split-even-").resolve("out").toString
+    val tmpOdd  = java.nio.file.Files.createTempDirectory("split-odd-").resolve("out").toString
+
+    // YAML-equivalent representation; `as: {even: ..., odd: ...}` is a Java map at the StepSpec level.
+    val portLabels = new java.util.LinkedHashMap[String, String]()
+    portLabels.put("even", "evenRows")
+    portLabels.put("odd", "oddRows")
+
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 6L, "columns" -> Seq("v"))),
+      // Synthesize a 0..5 `k` column so ParitySplit has something to route on.
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0")),
+      StepSpec(ParitySplitFqn, as = Some(portLabels)),
+      StepSpec(
+        FileSinkFqn,
+        Map("path" -> tmpEven, "format" -> "parquet", "mode" -> "overwrite"),
+        inputs = Seq("evenRows")
+      ),
+      StepSpec(
+        FileSinkFqn,
+        Map("path" -> tmpOdd, "format" -> "parquet", "mode" -> "overwrite"),
+        inputs = Seq("oddRows")
+      )
+    )
+
+    StepsBuilder.build(steps).run()
+
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpEven)))
+    assertTrue(java.nio.file.Files.exists(java.nio.file.Paths.get(tmpOdd)))
+
+    val even = spark.read.parquet(tmpEven).collect().map(_.getInt(0)).toSet
+    val odd  = spark.read.parquet(tmpOdd).collect().map(_.getInt(0)).toSet
+    assertTrue(even.forall(_ % 2 == 0), s"even partition leaked odd rows: $even")
+    assertTrue(odd.forall(_ % 2 == 1), s"odd partition leaked even rows: $odd")
+  }
+
+  @Test
+  def rejectsStringAsOnSplit(): Unit = {
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 4L, "columns" -> Seq("v"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0")),
+      StepSpec(ParitySplitFqn, as = Some("oneLabel")), // wrong shape for a Split
+      StepSpec(ShowSinkFqn, inputs = Seq("oneLabel"))
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("map form"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsUnknownPortInLabels(): Unit = {
+    val ghostPorts = new java.util.LinkedHashMap[String, String]()
+    ghostPorts.put("ghost", "x")
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 4L, "columns" -> Seq("v"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0")),
+      StepSpec(ParitySplitFqn, as = Some(ghostPorts)),
+      StepSpec(ShowSinkFqn, inputs = Seq("x"))
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("ghost"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsSplitWithUnlabeledPort(): Unit = {
+    // Only `even` is mapped; `odd` would be silently dropped, so the build must reject it.
+    val portLabels = new java.util.LinkedHashMap[String, String]()
+    portLabels.put("even", "evenRows")
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 4L, "columns" -> Seq("v"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0")),
+      StepSpec(ParitySplitFqn, as = Some(portLabels)),
+      StepSpec(ShowSinkFqn, inputs = Seq("evenRows"))
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("unlabeled"), ex.getMessage)
+    assertTrue(ex.getMessage.contains("odd"), ex.getMessage)
+  }
+
+  @Test
+  def rejectsLinearChainAfterSplit(): Unit = {
+    // After a Split, the linear-chain default upstream is dropped — next step must reference a port label explicitly.
+    val portLabels = new java.util.LinkedHashMap[String, String]()
+    portLabels.put("even", "evenRows")
+    portLabels.put("odd", "oddRows")
+    val steps = Seq(
+      StepSpec(SampleSourceFqn, Map("n" -> 4L, "columns" -> Seq("v"))),
+      StepSpec(SqlTransformFqn, Map("query" -> "SELECT CAST(monotonically_increasing_id() AS INT) AS k, v FROM _0")),
+      StepSpec(ParitySplitFqn, as = Some(portLabels)),
+      StepSpec(ShowSinkFqn) // no `inputs:` and no `prev` after Split
+    )
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => StepsBuilder.build(steps)
+    )
+    assertTrue(ex.getMessage.contains("no upstream"), ex.getMessage)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/CollidingName.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/CollidingName.scala
@@ -1,0 +1,4 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+// Fixture: shares its simple name with steps.source.CollidingName to exercise ClassResolver ambiguity detection.
+class CollidingName

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/FileSinkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/FileSinkTest.scala
@@ -1,0 +1,62 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.file.{Files, Paths}
+
+class FileSinkTest extends SparkTest {
+
+  @Test
+  def writesParquet(): Unit = {
+    import spark.implicits._
+    val df   = Seq(("a", 1), ("b", 2)).toDF("k", "v")
+    val tmp  = Files.createTempDirectory("file-sink-parquet-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "parquet").write(df)
+
+    assertTrue(Files.exists(Paths.get(path)))
+    assertEquals(2L, spark.read.parquet(path).count())
+  }
+
+  @Test
+  def writesJson(): Unit = {
+    import spark.implicits._
+    val df   = Seq(1, 2, 3).toDF("v")
+    val tmp  = Files.createTempDirectory("file-sink-json-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "json").write(df)
+
+    assertEquals(3L, spark.read.json(path).count())
+  }
+
+  @Test
+  def overwriteReplacesExisting(): Unit = {
+    import spark.implicits._
+    val df1  = Seq(1, 2).toDF("v")
+    val df2  = Seq(10, 20, 30).toDF("v")
+    val tmp  = Files.createTempDirectory("file-sink-mode-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "parquet", mode = "overwrite").write(df1)
+    FileSink(path, "parquet", mode = "overwrite").write(df2)
+
+    assertEquals(3L, spark.read.parquet(path).count())
+  }
+
+  @Test
+  def defaultModeFailsOnExisting(): Unit = {
+    // Default `mode = "errorifexists"` matches Spark's own default — a second write to the same path must throw rather
+    // than silently destroy the previous run's output.
+    import spark.implicits._
+    val df   = Seq(1).toDF("v")
+    val tmp  = Files.createTempDirectory("file-sink-default-")
+    val path = tmp.resolve("out").toString
+
+    FileSink(path, "parquet").write(df)
+    assertThrows(classOf[Throwable], () => FileSink(path, "parquet").write(df))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSinkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/sink/ShowSinkTest.scala
@@ -1,0 +1,16 @@
+package com.kakao.actionbase.pipeline.steps.sink
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Test
+
+class ShowSinkTest extends SparkTest {
+
+  @Test
+  def writesDataframeWithoutError(): Unit = {
+    import spark.implicits._
+    val in = Seq((1, "a"), (2, "b")).toDF("n", "name")
+
+    ShowSink().write(in)
+    ShowSink(numRows = 1, truncate = false).write(in)
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/CollidingName.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/CollidingName.scala
@@ -1,0 +1,4 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+// Fixture: shares its simple name with steps.sink.CollidingName to exercise ClassResolver ambiguity detection.
+class CollidingName

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/FileSourceTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/FileSourceTest.scala
@@ -1,0 +1,58 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+class FileSourceTest extends SparkTest {
+
+  @Test
+  def readsJson(): Unit = {
+    val tmp  = Files.createTempDirectory("file-source-json-")
+    val path = tmp.resolve("data.json").toString
+    Files.write(
+      Paths.get(path),
+      "{\"a\":1}\n{\"a\":2}\n".getBytes(StandardCharsets.UTF_8)
+    )
+
+    val df = FileSource(path, "json").read()
+
+    assertEquals(2L, df.count())
+    assertTrue(df.columns.contains("a"))
+  }
+
+  @Test
+  def readsParquet(): Unit = {
+    val tmp = Files.createTempDirectory("file-source-parquet-")
+    val src = tmp.resolve("src.json").toString
+    Files.write(
+      Paths.get(src),
+      "{\"a\":1}\n{\"a\":2}\n{\"a\":3}\n".getBytes(StandardCharsets.UTF_8)
+    )
+    val parquet = tmp.resolve("out.parquet").toString
+    spark.read.json(src).write.parquet(parquet)
+
+    val df = FileSource(parquet, "parquet").read()
+
+    assertEquals(3L, df.count())
+  }
+
+  @Test
+  def passesOptionsToReader(): Unit = {
+    val tmp  = Files.createTempDirectory("file-source-csv-")
+    val path = tmp.resolve("data.csv").toString
+    Files.write(
+      Paths.get(path),
+      "name,age\nalice,30\nbob,25\n".getBytes(StandardCharsets.UTF_8)
+    )
+
+    val df = FileSource(path, "csv", Map("header" -> "true")).read()
+
+    assertEquals(2L, df.count())
+    assertTrue(df.columns.toSet.contains("name"))
+    assertTrue(df.columns.toSet.contains("age"))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/SampleSourceTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/source/SampleSourceTest.scala
@@ -1,0 +1,38 @@
+package com.kakao.actionbase.pipeline.steps.source
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class SampleSourceTest extends SparkTest {
+
+  @Test
+  def producesRowsForRequestedColumns(): Unit = {
+    val df = SampleSource(1000L, Seq("x", "y")).read()
+    assertEquals(1000L, df.count())
+    assertEquals(Set("x", "y"), df.columns.toSet)
+  }
+
+  @Test
+  def supportsArbitraryColumnSet(): Unit = {
+    val df = SampleSource(50L, Seq("a", "b", "c", "d")).read()
+    assertEquals(50L, df.count())
+    assertEquals(Set("a", "b", "c", "d"), df.columns.toSet)
+  }
+
+  @Test
+  def valuesAreInUnitInterval(): Unit = {
+    val df   = SampleSource(200L, Seq("x", "y")).read()
+    val rows = df.collect()
+    assertTrue(rows.forall { r =>
+      val x = r.getAs[Double]("x")
+      val y = r.getAs[Double]("y")
+      x >= 0.0 && x < 1.0 && y >= 0.0 && y < 1.0
+    })
+  }
+
+  @Test
+  def rejectsEmptyColumnList(): Unit = {
+    assertThrows(classOf[IllegalArgumentException], () => SampleSource(10L, Seq.empty))
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/split/ParitySplit.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/split/ParitySplit.scala
@@ -1,0 +1,19 @@
+package com.kakao.actionbase.pipeline.steps.split
+
+import com.kakao.actionbase.pipeline.dsl.Split
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/**
+  * Test-only Split that routes input rows by even/odd value of column `k`. Used by `StepsBuilderTest` to exercise the
+  * Split DSL/YAML wiring without depending on a heavier production Split class. Lives under `steps.split` so
+  * `ClassResolver` resolves the short name during tests; the package itself is also the future home of production Split
+  * built-ins.
+  */
+case class ParitySplit() extends Split {
+  override def ports: Seq[String] = Seq("even", "odd")
+  override def split(in: DataFrame)(implicit spark: SparkSession): Map[String, DataFrame] =
+    Map(
+      "even" -> in.where("k % 2 = 0"),
+      "odd"  -> in.where("k % 2 = 1")
+    )
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransformTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/CacheTransformTest.scala
@@ -1,0 +1,42 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.apache.spark.storage.StorageLevel
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class CacheTransformTest extends SparkTest {
+
+  @Test
+  def persistsAtDefaultLevel(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = CacheTransform().apply(in)
+
+    assertEquals(StorageLevel.MEMORY_AND_DISK, out.storageLevel)
+    out.unpersist()
+  }
+
+  @Test
+  def respectsExplicitStorageLevel(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = CacheTransform(level = "MEMORY_ONLY").apply(in)
+
+    assertEquals(StorageLevel.MEMORY_ONLY, out.storageLevel)
+    out.unpersist()
+  }
+
+  @Test
+  def passesRowsThroughUnchanged(): Unit = {
+    import spark.implicits._
+    val in = Seq(("a", 1), ("b", 2)).toDF("k", "v")
+
+    val out = CacheTransform().apply(in)
+
+    assertEquals(in.collect().toSet, out.collect().toSet)
+    out.unpersist()
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransformTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/steps/transform/SqlTransformTest.scala
@@ -1,0 +1,54 @@
+package com.kakao.actionbase.pipeline.steps.transform
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class SqlTransformTest extends SparkTest {
+
+  @Test
+  def projectsAndComputesColumns(): Unit = {
+    import spark.implicits._
+    val in = Seq((1, 2), (3, 4)).toDF("a", "b")
+
+    val out = SqlTransform("SELECT a, b, a + b AS sum FROM _0").apply(in)
+
+    assertEquals(Set("a", "b", "sum"), out.columns.toSet)
+    val sums = out.collect().map(_.getAs[Int]("sum")).toSet
+    assertEquals(Set(3, 7), sums)
+  }
+
+  @Test
+  def usesProvidedLabelAsViewName(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3).toDF("n")
+
+    val out = SqlTransform("SELECT SUM(n) AS total FROM nums").apply(Seq("nums" -> in))
+
+    assertEquals(6L, out.first().getLong(0))
+  }
+
+  @Test
+  def filtersRowsViaWhere(): Unit = {
+    import spark.implicits._
+    val in = Seq(1, 2, 3, 4).toDF("n")
+
+    val out = SqlTransform("SELECT n FROM _0 WHERE n > 2").apply(in)
+
+    assertEquals(Set(3, 4), out.collect().map(_.getInt(0)).toSet)
+  }
+
+  @Test
+  def joinsTwoLabeledInputs(): Unit = {
+    import spark.implicits._
+    val users  = Seq((1, "alice"), (2, "bob")).toDF("id", "name")
+    val events = Seq((1, "login"), (2, "click"), (2, "logout")).toDF("user_id", "kind")
+
+    val out = SqlTransform(
+      "SELECT u.name, e.kind FROM users u JOIN events e ON u.id = e.user_id"
+    ).apply(Seq("users" -> users, "events" -> events))
+
+    val rows = out.collect().map(r => r.getString(0) -> r.getString(1)).toSet
+    assertEquals(Set("alice" -> "login", "bob" -> "click", "bob" -> "logout"), rows)
+  }
+}


### PR DESCRIPTION
## Summary

Introduces the in-job **Step** model for Spark jobs. A job is a DAG of steps composed via either a type-state Scala DSL or an inline YAML `steps:` list interpreted by `StepsRunnerJob`.

Steps map onto three pipeline phases, with the middle phase split by arity:

- **Source** (0→1) — reads data in
- **Transform** — the DataFrame→DataFrame middle; a sealed trait with three arities:
  - **Flow** (1→1) · **Merge** (N→1) · **Split** (1→M)
- **Sink** (1→0) — writes data out

The `Step` type hierarchy and the `steps.{source,transform,sink}` package layout mirror each other one-to-one.

Inner counterpart to the workflow DSL ADR (#310), which covers job-to-job relationships only.

Closes #313

## Changes

- `Step` sealed hierarchy — `Source` / `Transform` (`Flow` / `Merge` / `Split`) / `Sink`
- Type-state `Plan` DSL — `~>`, `+`, `.as`, `fanOut`, `forked("port")`
- `Executor` — AST identity memo, `fanOut` cache/unpersist, Split per-execution memo, plan-time validation
- `StepsRunnerJob` + `StepsBuilder` for inline YAML chains; the builder requires every declared Split port to be labeled
- `ClassResolver` — resolves a step by FQN or, failing that, by a memoized recursive scan under a single `steps` root for a matching simple name (across subpackages, directories, and jar entries); rejects ambiguous simple names
- Built-ins: `FileSource`, `SampleSource`, `SqlTransform`, `CacheTransform`, `FileSink`, `ShowSink`
- Tests for each step, builder, and DSL

## How to Test

```
./gradlew :pipeline:test
./gradlew :pipeline:spotlessCheck
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7, 1M context)
