### PR TITLE
Rename ObjectSourceExtension to SourceExtension

### DIFF
--- a/core/src/test/kotlin/com/kakao/actionbase/test/TableSourceTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/test/TableSourceTest.kt
@@ -1,7 +1,7 @@
 package com.kakao.actionbase.test
 
-import com.kakao.actionbase.test.documentations.params.ObjectSourceExtension
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.test.documentations.params.SourceExtension
 import com.kakao.actionbase.test.documentations.params.TableSource
 
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -141,7 +141,7 @@ class TableSourceTest {
 
     @Nested
     inner class ErrorTest {
-        private val extension = ObjectSourceExtension()
+        private val extension = SourceExtension()
 
         private val twoCols = listOf("a", "b")
         private val threeCols = listOf("a", "b", "c")

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceParameterizedTest.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/ObjectSourceParameterizedTest.kt
@@ -6,6 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 @Retention
 @TestTemplate
 @MustBeDocumented
-@ExtendWith(ObjectSourceExtension::class)
+@ExtendWith(SourceExtension::class)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 annotation class ObjectSourceParameterizedTest

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceExtension.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceExtension.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
-class ObjectSourceExtension : TestTemplateInvocationContextProvider {
+class SourceExtension : TestTemplateInvocationContextProvider {
     override fun supportsTestTemplate(context: ExtensionContext): Boolean {
         val method = context.requiredTestMethod
         return method.isAnnotationPresent(ObjectSource::class.java) ||
@@ -39,7 +39,7 @@ class ObjectSourceExtension : TestTemplateInvocationContextProvider {
 
         return testCases
             .mapIndexed { index, testCase ->
-                ObjectSourceInvocationContext(index + 1, testCases.size, parameterNames, testCase) as TestTemplateInvocationContext
+                SourceInvocationContext(index + 1, testCases.size, parameterNames, testCase) as TestTemplateInvocationContext
             }.stream()
     }
 

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceInvocationContext.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceInvocationContext.kt
@@ -3,7 +3,7 @@ package com.kakao.actionbase.test.documentations.params
 import org.junit.jupiter.api.extension.ParameterResolver
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext
 
-class ObjectSourceInvocationContext(
+class SourceInvocationContext(
     private val index: Int,
     private val total: Int,
     private val parameterNames: List<String>,
@@ -11,5 +11,5 @@ class ObjectSourceInvocationContext(
 ) : TestTemplateInvocationContext {
     override fun getDisplayName(invocationIndex: Int): String = "[$index/$total] ${testCase.entries.joinToString(", ") { "${it.key}=${it.value}" }}"
 
-    override fun getAdditionalExtensions(): List<ParameterResolver> = listOf(ObjectSourceParameterResolver(parameterNames, testCase))
+    override fun getAdditionalExtensions(): List<ParameterResolver> = listOf(SourceParameterResolver(parameterNames, testCase))
 }

--- a/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceParameterResolver.kt
+++ b/core/src/testFixtures/kotlin/com/kakao/actionbase/test/documentations/params/SourceParameterResolver.kt
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.type.CollectionType
 import com.fasterxml.jackson.databind.type.MapType
 
-class ObjectSourceParameterResolver(
+class SourceParameterResolver(
     private val parameterNames: List<String>,
     private val testCase: Map<String, Any?>,
 ) : ParameterResolver {


### PR DESCRIPTION
## Summary

Closes #276.

Since #273, `ObjectSourceExtension` dispatches for both `@ObjectSource` and `@TableSource`, so the name no longer reflects the class's role. Rename it to a neutral name.

## Changes

- `ObjectSourceExtension` → `SourceExtension`
- `ObjectSourceInvocationContext` → `SourceInvocationContext`
- `ObjectSourceParameterResolver` → `SourceParameterResolver`
- Update call sites: `@ExtendWith(SourceExtension::class)`, `TableSourceTest`

## How to Test

- `./gradlew :core:test`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)