### PR TITLE
Disable scalafmt docstring wrapping

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,3 +6,4 @@ runner.dialect = scala212
 
 align.preset = more
 maxColumn = 120
+docstrings.wrap = no

--- a/conventions/src/main/kotlin/actionbase/tasks/GenerateCodeStyleTask.kt
+++ b/conventions/src/main/kotlin/actionbase/tasks/GenerateCodeStyleTask.kt
@@ -156,6 +156,7 @@ open class GenerateCodeStyleTask : DefaultTask() {
 
             align.preset = more
             maxColumn = 120
+            docstrings.wrap = no
             """.trimIndent(),
         )
 


### PR DESCRIPTION
## Summary

Scalafmt 3.8.3 defaults `docstrings.wrap = yes`, which reflows the body of a `/** ... */` block as if it were one paragraph and then hard-wraps it at `maxColumn`. For docstrings that intentionally use multi-line structure — numbered lists, step-by-step rules — this destroys the layout. Setting `docstrings.wrap = no` preserves the line breaks the author wrote, which is what every existing docstring in the repo already assumes.

Closes #

## Changes

- Add `docstrings.wrap = no` to `.scalafmt.conf`.
- Add the same line to `GenerateCodeStyleTask.generate()` so that `./gradlew generateCodeStyle` produces a matching file.
- The other two docstring options (`docstrings.style`, `docstrings.oneline`) are already at sensible defaults, so only `wrap` needs to change.

### Example

Author writes:

```scala
/**
 * Returns an iterator that batches events into groups.
 *
 * Grouping rules:
 * 1. Within a group, the same (a, b) key may not appear twice
 * 2. Group size must not exceed batchSize
 * 3. A repeated (a, b) key starts a new group
 * 4. Reaching batchSize closes the current group
 */
```

With the default (`docstrings.wrap = yes`), scalafmt rewrites this to:

```scala
/** Returns an iterator that batches events into groups.
  *
  * Grouping rules:
  *   1. Within a group, the same (a, b) key may not appear twice 2. Group size must not exceed batchSize 3. A repeated
  *      (a, b) key starts a new group 4. Reaching batchSize closes the current group
  */
```

The four numbered items are joined into one paragraph and the line is then hard-wrapped at `maxColumn`, leaving `1.`, `2.`, `3.`, `4.` sitting side by side. With `docstrings.wrap = no` the original line structure is left alone.

## How to Test

- Drop the "author writes" snippet above into any Scala source file and run `./gradlew spotlessApply` — the docstring should be left unchanged (modulo leading-asterisk style).
- `./gradlew generateCodeStyle` regenerates `.scalafmt.conf` and the `docstrings.wrap = no` line is present.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)