### PR TITLE
Enforce Javadoc-style docstrings in scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,3 +7,4 @@ runner.dialect = scala212
 align.preset = more
 maxColumn = 120
 docstrings.wrap = no
+docstrings.blankFirstLine = yes

--- a/conventions/src/main/kotlin/actionbase/tasks/GenerateCodeStyleTask.kt
+++ b/conventions/src/main/kotlin/actionbase/tasks/GenerateCodeStyleTask.kt
@@ -157,6 +157,7 @@ open class GenerateCodeStyleTask : DefaultTask() {
             align.preset = more
             maxColumn = 120
             docstrings.wrap = no
+            docstrings.blankFirstLine = yes
             """.trimIndent(),
         )
 


### PR DESCRIPTION
## Summary

Force scalafmt to keep the opening `/**` on its own line so Scala docstrings match the Javadoc layout that the Java and Kotlin code in this repo already use. With the scalafmt default, the first line of the docstring is folded onto `/**`, producing the Scaladoc one-line shape that looks foreign next to the rest of the codebase.

Closes #

## Changes

- Add `docstrings.blankFirstLine = yes` to `.scalafmt.conf`.
- Add the same line to `GenerateCodeStyleTask.generate()` so `./gradlew generateCodeStyle` produces a matching file.

### Example

Author writes:

```scala
/**
 * Some doc.
 *
 * More details.
 */
```

Default scalafmt rewrites this to:

```scala
/** Some doc.
  *
  * More details.
  */
```

With `docstrings.blankFirstLine = yes`:

```scala
/**
  * Some doc.
  *
  * More details.
  */
```

The leading-asterisk style (`  *`) is left at the scalafmt default; only the first line is forced to be blank, which is the single switch that flips Scaladoc-shape into Javadoc-shape.

## How to Test

- `./gradlew generateCodeStyle` regenerates `.scalafmt.conf` with the `docstrings.blankFirstLine = yes` line present.
- Drop the "author writes" snippet into a Scala source file and run `./gradlew spotlessApply` — the opening `/**` should stay on its own line.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)