### PR TITLE
Bind HBase mini cluster to loopback in tests

### DIFF
--- a/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/HBaseTestingCluster.kt
+++ b/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/HBaseTestingCluster.kt
@@ -97,6 +97,14 @@ object HBaseTestingCluster {
     private fun configureHBase(util: HBaseTestingUtility) {
         val conf = util.configuration
 
+        // Force loopback so the mini cluster does not depend on the host's hostname
+        // resolving to a currently-bindable interface (laptops change networks).
+        conf.set("hbase.master.ipc.address", "127.0.0.1")
+        conf.set("hbase.regionserver.ipc.address", "127.0.0.1")
+        conf.set("hbase.master.hostname", "localhost")
+        conf.set("hbase.regionserver.hostname", "localhost")
+        conf.set("hbase.localcluster.assign.random.ports", "true")
+
         // Minimal/core tuning only (focus on significant ones)
         conf.setInt("hbase.master.info.port", -1)
         conf.setInt("hbase.regionserver.info.port", -1)


### PR DESCRIPTION
## Summary

The HBase test mini cluster derives its RPC bind address from the host's hostname. On laptops where the hostname resolves through mDNS to a stale interface (e.g. after a network change), `NettyRpcServer` fails with `Can't assign requested address` before any test runs, so the whole `HBaseAdminTest` class reports an `initializationError`. Force the mini cluster to bind to loopback so it works regardless of the host's current network state.

## Changes

- `HBaseTestingCluster.configureHBase` sets `hbase.{master,regionserver}.ipc.address` to `127.0.0.1` and `{master,regionserver}.hostname` to `localhost`
- Enable `hbase.localcluster.assign.random.ports` so concurrent test JVMs don't collide on leftover ports

## How to Test

- `./gradlew :engine:test --tests "*.HBaseAdminTest"` — 7/7 pass on a machine where the previous fixture failed with `BindException` during mini cluster startup

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)
