### PR TITLE
Preserve next-page cursor on scan with post-filter

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/sql/DataFrame.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/sql/DataFrame.kt
@@ -110,7 +110,10 @@ data class DataFrame(
                     predicate.eval(row, schema)
                 }
             }
-        return DataFrame(filteredRows, schema)
+        // Preserve offsets/hasNext/stats: the post-filter is transparent
+        // to the underlying paginated scan, whose cursor must survive
+        // even when zero rows pass the predicate on this page.
+        return copy(rows = filteredRows)
     }
 
     companion object {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/QueryServiceSpec.kt
@@ -129,6 +129,40 @@ class QueryServiceSpec :
                 }.verifyComplete()
         }
 
+        "scan with offset and filters" {
+            // Regression: post-filter (`filters`) must not strip the next-page cursor.
+            // src=100 edges sorted by createdAt DESC: [15(na), 14(me), 13(others), 12(me), 11(others), 10(na)].
+            // With limit=2 and filters=permission:eq:me, page 1 reads [15, 14] and only 14
+            // passes the post-filter, but the underlying scan still has more rows so the cursor
+            // must be returned. Page 2 resumes via that cursor and yields the remaining match (12).
+            val database = GraphFixtures.serviceName
+            val table = GraphFixtures.hbaseIndexed
+            val index = GraphFixtures.index2 // created_at_desc
+            val sampleEdge = GraphFixtures.sampleEdges.first()
+            val filters = "permission:eq:me"
+
+            val expectedMatches =
+                GraphFixtures.sampleEdges
+                    .filter { it.src == sampleEdge.src && it.props["permission"] == "me" }
+                    .map { EdgePayload(it.ts, it.src, it.tgt, mapOf("receivedFrom" to null) + it.props, emptyMap()) }
+                    .sortedByDescending { it.properties["createdAt"].toString().toLong() }
+
+            queryService
+                .scan(database, table, index, sampleEdge.src, Direction.OUT, limit = 2, filters = filters)
+                .flatMap { firstPage ->
+                    val cursor =
+                        requireNotNull(firstPage.offset) {
+                            "first page must carry a cursor even when the post-filter drops rows"
+                        }
+                    queryService
+                        .scan(database, table, index, sampleEdge.src, Direction.OUT, limit = 10, offset = cursor, filters = filters)
+                        .map { secondPage -> firstPage.edges + secondPage.edges }
+                }.test()
+                .assertNext { combined ->
+                    combined.map { it.toStringValues() } shouldBe expectedMatches.map { it.toStringValues() }
+                }.verifyComplete()
+        }
+
         "scan with features=total" {
             val database = GraphFixtures.serviceName
             val table = GraphFixtures.hbaseIndexed


### PR DESCRIPTION
## Summary

`DataFrame.where()` was constructing a new instance and dropping `offsets` / `hasNext` / `stats`, so any scan invoked with a `filters` (post-filter) argument returned `offset: null` / `hasNext: false`, breaking pagination.

`offset` is a property of the underlying paginated scan, not of the filter mode. A post-filter must be transparent to scan metadata: even if every row on a page is rejected by the filter, the cursor must survive as long as the underlying scan has more rows to read.

Closes #323

## Changes

- `DataFrame.where()` now returns `copy(rows = filteredRows)`, preserving `offsets` / `hasNext` / `stats` instead of dropping them.
- Added `scan with offset and filters` regression test in `QueryServiceSpec` (not `IndexFilterSpec` as originally written in the issue — that spec only covers the `ranges` channel via `otherPredicates`, not the `filters` post-filter channel).

## How to Test

```
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.QueryServiceSpec"
```

The regression test paginates with `limit=2 + filters=permission:eq:me` and verifies that page 1 returns a non-null cursor and that page 2, resuming via that cursor, yields the remaining matching row.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.7)