### PR TITLE
docs: update codec-java compatibility for 0.3.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -128,6 +128,7 @@ Each module releases independently.
 
 | codec-java | Actionbase (server) |
 | ---------- | ------------------- |
+| 0.3.0      | 0.4.x               |
 | 0.2.0      | 0.3.x               |
 
 Release announcements are posted in [GitHub Releases](https://github.com/kakao/actionbase/releases).


### PR DESCRIPTION
## Summary
- Adds the `codec-java 0.3.0 ↔ server 0.4.x` row to the compatibility table in `RELEASES.md`.

Post-release follow-up for #326.

## Test plan
- [x] Visually verify the table renders correctly on GitHub.