### PR TITLE
test(pipeline): add SparkTest trait with example

### DIFF
--- a/pipeline/build.gradle.kts
+++ b/pipeline/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
 }
 
 tasks.withType<JavaExec> {
-    jvmArgs = listOf("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED")
+    if (JavaVersion.current().isJava9Compatible) {
+        jvmArgs = listOf("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED")
+    }
 }
 
 dependencies {

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/SparkTest.scala
@@ -1,0 +1,18 @@
+package com.kakao.actionbase.pipeline
+
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Mix-in for unit tests that need an `implicit SparkSession`. The session is `local[2]` and shared across all
+  * `SparkTest` mixers in the JVM (Spark's own `getOrCreate` semantics).
+  */
+trait SparkTest {
+
+  protected implicit lazy val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[2]")
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .config("spark.ui.enabled", "false")
+    .appName(getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/app/SparkPiDemoTest.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/app/SparkPiDemoTest.scala
@@ -1,0 +1,14 @@
+package com.kakao.actionbase.pipeline.app
+
+import com.kakao.actionbase.pipeline.SparkTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SparkPiDemoTest extends SparkTest {
+
+  @Test
+  def testEstimatePiIsCloseToPi(): Unit = {
+    val pi = SparkPiDemo.estimatePi(spark, slices = 2)
+    assertTrue(pi > 3.0 && pi < 3.3, s"Estimated Pi=$pi out of expected range [3.0, 3.3]")
+  }
+}

--- a/pipeline/src/test/scala/com/kakao/actionbase/pipeline/app/SparkPiMain.scala
+++ b/pipeline/src/test/scala/com/kakao/actionbase/pipeline/app/SparkPiMain.scala
@@ -1,0 +1,27 @@
+package com.kakao.actionbase.pipeline.app
+
+import org.apache.spark.sql.SparkSession
+
+/** Minimal standalone Spark entry point — useful for ad-hoc exploration in an IDE.
+  *
+  * Unlike `SparkPiDemo` (which goes through `AbstractPipelineApplication`), this object builds the `SparkSession`
+  * directly so the full boilerplate is visible.
+  */
+object SparkPiMain {
+
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .config("spark.ui.enabled", "false")
+      .appName("SparkPiMain")
+      .getOrCreate()
+
+    try {
+      val pi = SparkPiDemo.estimatePi(spark, slices = 2)
+      println(s"Pi is roughly $pi")
+    } finally {
+      spark.stop()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a minimal Spark test harness so that pipeline unit tests can mix in an implicit `SparkSession` without each test rebuilding one, plus standalone examples covering both JUnit-driven and `main`-driven flows. Also unbreaks running mains via Gradle on JDK 8.

## Changes

- Add `SparkTest` trait providing an implicit `local[2]` `SparkSession` shared across mixers via Spark's `getOrCreate` semantics. `spark.ui.enabled=false` and `spark.driver.bindAddress=127.0.0.1` keep test runs quiet and deterministic on dev/CI.
- Add `SparkPiDemoTest` as a JUnit usage example exercising `SparkPiDemo.estimatePi` with `assertTrue` (CI-verifiable).
- Add `SparkPiMain` as a standalone `def main` example that builds the `SparkSession` directly, for ad-hoc IDE exploration where no assertions are needed.
- Guard the `--add-exports=java.base/sun.nio.ch=ALL-UNNAMED` `JavaExec` jvmArg behind `JavaVersion.current().isJava9Compatible`. On JDK 8 the JVM treats the flag as unknown and exits immediately, which broke IntelliJ's "Run main()" flow (it routes through a Gradle `JavaExec` task). JDK 17 behaviour is preserved.

## How to Test

Run the JUnit example:

```
./gradlew :pipeline:test --tests "com.kakao.actionbase.pipeline.app.SparkPiDemoTest"
```

Expected: build succeeds, test passes, `SparkContext` shuts down cleanly.

Run the standalone `main`:

- From an IDE: Run `SparkPiMain.main` — prints `Pi is roughly ~3.14`.
- Verified on both JDK 8 (zulu-8) and JDK 17 (zulu-17).

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (claude-opus-4-7)
