### PR TITLE
Drop HBase from spark-conventions (#309 regression)

### DIFF
--- a/conventions/src/main/kotlin/actionbase/SparkConventionsPlugin.kt
+++ b/conventions/src/main/kotlin/actionbase/SparkConventionsPlugin.kt
@@ -21,13 +21,8 @@ class SparkConventionsPlugin : Plugin<Project> {
     private fun configureDependencies(project: Project) {
         val dependencies = project.dependencies
 
-        // Spark dependencies
         dependencies.add("compileOnly", Dependencies.Spark.SQL)
         dependencies.add("compileOnly", Dependencies.Spark.STREAMING)
-
-        // HBase
-        dependencies.add("implementation", Dependencies.HBase.CLIENT)
-        dependencies.add("implementation", Dependencies.HBase.MAPREDUCE)
 
         dependencies.add("testImplementation", Dependencies.Spark.SQL)
         dependencies.add("testImplementation", Dependencies.Spark.STREAMING)


### PR DESCRIPTION
## Summary

Re-removes the HBase implementation dependencies from `SparkConventionsPlugin`. PR #312 already removed them; PR #309 (`feat/cache-dimension`) carried `2925a4a "Revert ... main into feat/cache-dimension"`, which restored those five lines, and the revert was carried into main when #309 merged.

`hbase-shaded-{client,mapreduce}` bundle Hadoop 2.x classes at the `org.apache.hadoop.*` namespace (incomplete shading). On the pipeline test classpath they mask the Hadoop 3.3.4 classes Spark expects, causing `NoSuchMethodError: FileSystem.openFile`.

Closes #

## Changes

- Remove `Dependencies.HBase.CLIENT` and `Dependencies.HBase.MAPREDUCE` from `SparkConventionsPlugin`

## How to Test

```
./gradlew :pipeline:test
```

CI on #314, which absorbs this change locally, passed end-to-end.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7, 1M context)
