### PR TITLE
Preserve SYNC response contract under systemMutationMode=ASYNC

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.core.edge.MutationEvent
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.UnresolvedEvent
 import com.kakao.actionbase.core.edge.payload.MutationResult
+import com.kakao.actionbase.core.state.EventType
 import com.kakao.actionbase.core.state.transit
 import com.kakao.actionbase.engine.Audit
 import com.kakao.actionbase.engine.MutationContext
@@ -55,7 +56,7 @@ class MutationService(
                     .groupBy { it.key }
                     .flatMap { (key, groupMono) ->
                         if (ctx.mutationMode.queue) {
-                            groupMono.map { group -> MutationResult.of(key, group.size, QUEUED) }
+                            groupMono.map { group -> MutationResult.of(key, group.size, queuedStatus(ctx, group)) }
                         } else {
                             groupMono.flatMap { group ->
                                 val sorted = group.sortedBy { it.event.version }
@@ -72,6 +73,27 @@ class MutationService(
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }
+
+    /**
+     * For `system=ASYNC + label=SYNC` (no force), return the SYNC-shaped status derived from
+     * the highest-version event's EventType so clients keep their contract; mutations are
+     * still queued via the WAL. Intent-based, never `IDLE`. Otherwise `QUEUED`.
+     */
+    private fun queuedStatus(
+        ctx: MutationContext,
+        group: List<MutationEvent>,
+    ): String {
+        val mode = ctx.mutationMode
+        if (mode.force || mode.system != MutationMode.ASYNC || mode.label != MutationMode.SYNC) {
+            return QUEUED
+        }
+        val last = group.sortedBy { it.event.version }.last()
+        return when (last.event.type) {
+            EventType.INSERT -> "CREATED"
+            EventType.UPDATE -> "UPDATED"
+            EventType.DELETE -> "DELETED"
+        }
+    }
 
     private fun readModifyWrite(
         tb: TableBinding,

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceSystemAsyncSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MutationServiceSystemAsyncSpec.kt
@@ -102,9 +102,9 @@ class MutationServiceSystemAsyncSpec :
             }
         }
 
-        // ---- scenario 1: system=ASYNC overrides table ----
+        // ---- scenario 1: system=ASYNC overrides SYNC table — preserves SYNC response contract ----
 
-        "system=ASYNC overrides SYNC EDGE table" {
+        "system=ASYNC + SYNC EDGE table maps INSERT to CREATED" {
             val request =
                 mapper.readValue<EdgeBulkMutationRequest>(
                     """
@@ -121,7 +121,7 @@ class MutationServiceSystemAsyncSpec :
                 .map { EdgeMutationResponse.from(it) }
                 .test()
                 .assertNext {
-                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"QUEUED","count":1}]}"""
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"CREATED","count":1}]}"""
                 }.verifyComplete()
 
             verifyWal(graph, syncEdgeTable, 1, queue = true)
@@ -134,7 +134,110 @@ class MutationServiceSystemAsyncSpec :
                 .verifyComplete()
         }
 
-        "system=ASYNC overrides SYNC MULTI_EDGE table" {
+        "system=ASYNC + SYNC EDGE table maps UPDATE to UPDATED" {
+            val request =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "UPDATE", "edge": {"version": 10, "source": "1000", "target": "9000", "properties": {"permission": "rw"}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncEdgeTableName, request.mutations)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"UPDATED","count":1}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncEdgeTable, 1, queue = true)
+            verifyCdc(graph, syncEdgeTable)
+        }
+
+        "system=ASYNC + SYNC EDGE table maps DELETE to DELETED" {
+            val request =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "DELETE", "edge": {"version": 10, "source": "1000", "target": "9000"}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncEdgeTableName, request.mutations)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"DELETED","count":1}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncEdgeTable, 1, queue = true)
+            verifyCdc(graph, syncEdgeTable)
+        }
+
+        "system=ASYNC + SYNC EDGE table — multi-event same version, last input wins" {
+            // sortedBy is stable, so for equal versions the last input wins.
+            // [INSERT, DELETE] at v=10 → DELETED (last input).
+            val request =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 10, "source": "1000", "target": "9000", "properties": {"permission": "na", "createdAt": 10}}},
+                        {"type": "DELETE", "edge": {"version": 10, "source": "1000", "target": "9000"}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncEdgeTableName, request.mutations)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"DELETED","count":2}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncEdgeTable, 2, queue = true)
+            verifyCdc(graph, syncEdgeTable)
+        }
+
+        "system=ASYNC + SYNC EDGE table — multi-event ascending versions, highest wins" {
+            // [DELETE v=10, INSERT v=20, UPDATE v=15] → INSERT@v=20 is the max → CREATED
+            // (UPDATE @ v=15 < INSERT @ v=20, so INSERT wins by version not by position)
+            val request =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "DELETE", "edge": {"version": 10, "source": "1000", "target": "9000"}},
+                        {"type": "INSERT", "edge": {"version": 20, "source": "1000", "target": "9000", "properties": {"permission": "rw", "createdAt": 10}}},
+                        {"type": "UPDATE", "edge": {"version": 15, "source": "1000", "target": "9000", "properties": {"permission": "ro"}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncEdgeTableName, request.mutations)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"CREATED","count":3}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncEdgeTable, 3, queue = true)
+            verifyCdc(graph, syncEdgeTable)
+        }
+
+        "system=ASYNC + SYNC MULTI_EDGE table maps INSERT to CREATED" {
             val request =
                 mapper.readValue<MultiEdgeBulkMutationRequest>(
                     """
@@ -151,7 +254,7 @@ class MutationServiceSystemAsyncSpec :
                 .map { MultiEdgeMutationResponse.from(it) }
                 .test()
                 .assertNext {
-                    mapper.writeValueAsString(it) shouldBe """{"results":[{"id":100000,"status":"QUEUED","count":1}]}"""
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"id":100000,"status":"CREATED","count":1}]}"""
                 }.verifyComplete()
 
             verifyWal(graph, syncMultiEdgeTable, 1, queue = true)
@@ -162,6 +265,54 @@ class MutationServiceSystemAsyncSpec :
                 .test()
                 .assertNext { it.edges.size shouldBe 0 }
                 .verifyComplete()
+        }
+
+        "system=ASYNC + SYNC MULTI_EDGE table maps UPDATE to UPDATED" {
+            val request =
+                mapper.readValue<MultiEdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "UPDATE", "edge": {"version": 10, "id": 100000, "source": 1, "target": 2, "properties": {"paidAt": 9999999999}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncMultiEdgeTableName, request.mutations)
+                .map { MultiEdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"id":100000,"status":"UPDATED","count":1}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncMultiEdgeTable, 1, queue = true)
+            verifyCdc(graph, syncMultiEdgeTable)
+        }
+
+        "system=ASYNC + SYNC MULTI_EDGE table maps DELETE to DELETED" {
+            val request =
+                mapper.readValue<MultiEdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "DELETE", "edge": {"version": 10, "id": 100000, "source": 1, "target": 2}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncMultiEdgeTableName, request.mutations)
+                .map { MultiEdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"id":100000,"status":"DELETED","count":1}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncMultiEdgeTable, 1, queue = true)
+            verifyCdc(graph, syncMultiEdgeTable)
         }
 
         // ---- scenario 2: system=ASYNC overrides request=SYNC ----
@@ -286,6 +437,33 @@ class MutationServiceSystemAsyncSpec :
                 .test()
                 .assertNext { it.edges.size shouldBe 1 }
                 .verifyComplete()
+        }
+
+        // ---- scenario 4: force=true + request=ASYNC keeps QUEUED on SYNC table ----
+        // Client explicitly forced ASYNC; the SYNC contract preservation must not apply.
+
+        "force=true request=ASYNC on SYNC EDGE table returns QUEUED even when system=ASYNC" {
+            val request =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 10, "source": "1000", "target": "9000", "properties": {"permission": "na", "createdAt": 10}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, syncEdgeTableName, request.mutations, syncMode = EngineMutationMode.ASYNC, forceSyncMode = true)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext {
+                    mapper.writeValueAsString(it) shouldBe """{"results":[{"source":1000,"target":9000,"status":"QUEUED","count":1}]}"""
+                }.verifyComplete()
+
+            verifyWal(graph, syncEdgeTable, 1, queue = true)
+            verifyCdc(graph, syncEdgeTable)
         }
     }) {
     companion object {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationForceSyncTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationForceSyncTest.kt
@@ -85,7 +85,7 @@ class EdgeMutationForceSyncTest : E2ETestBase() {
     }
 
     @Test
-    fun `sync endpoint queues when system=ASYNC overrides`() {
+    fun `sync endpoint preserves SYNC contract when system=ASYNC overrides SYNC table`() {
         client
             .post()
             .uri("/graph/v3/databases/$db/tables/$table/edges/sync")
@@ -97,7 +97,7 @@ class EdgeMutationForceSyncTest : E2ETestBase() {
             .isOk
             .expectBody()
             .jsonPath("$.results[0].status")
-            .isEqualTo("QUEUED")
+            .isEqualTo("CREATED")
     }
 
     @Test


### PR DESCRIPTION
## Summary

When `systemMutationMode=ASYNC` overrides a table whose own mode is `SYNC`, derive the response status from the request's `EdgeOperation` (`INSERT → CREATED`, `UPDATE → UPDATED`, `DELETE → DELETED`) instead of returning `QUEUED`. Tables whose own mode is `ASYNC` keep returning `QUEUED`. Mutations are still queued via the WAL — only the response status changes.

Closes #335

## Changes

- Derive operation-based status in `MutationService` for `system=ASYNC + label=SYNC`
- Update `MutationServiceSystemAsyncSpec` — expect operation-based status for SYNC tables, add UPDATE/DELETE coverage
- Update `EdgeMutationForceSyncTest` — adjust the SYNC-table queue expectation

## How to Test

- `./gradlew :engine:test --tests "*MutationServiceSystemAsyncSpec"`
- `./gradlew :server:test --tests "*EdgeMutationForceSyncTest"`
- `./gradlew build`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.7)
