### PR TITLE
Replace unused failover with fanout for WAL/CDC writes

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerList.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerList.kt
@@ -9,6 +9,10 @@ import reactor.core.publisher.Mono
 class ProducerList(
     private val producers: List<Producer>,
 ) : Producer {
+    init {
+        require(producers.isNotEmpty())
+    }
+
     companion object {
         private val logger = getLogger()
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerList.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerList.kt
@@ -7,43 +7,17 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 class ProducerList(
-    producers: List<Producer>,
+    private val producers: List<Producer>,
 ) : Producer {
     companion object {
         private val logger = getLogger()
     }
 
-    private val producers: List<Producer>
-
-    private val primaryIdx = 0
-    private val backUpIdx = 1
-
-    init {
-        assert(producers.size <= 2) { "producers size should be less than 2" }
-        this.producers = producers
-    }
-
-    private fun producePrimaryAndBackUp(message: Log): Mono<Void> {
-        val primary = producers[primaryIdx].produce(message)
-        return primary
-            .onErrorResume { error ->
-                logger.error("primary producer send failed: {}", error.toString(), error)
-                producers[backUpIdx]
-                    .produce(message)
-                    .doOnError {
-                        logger.error("secondary producer send failed: {}", error.toString(), it)
-                    }
-            }
-    }
-
-    private fun producePrimaryOnly(message: Log): Mono<Void> = producers[0].produce(message)
-
     override fun produce(message: Log): Mono<Void> =
-        if (producers.size == 1) {
-            producePrimaryOnly(message)
-        } else {
-            producePrimaryAndBackUp(message)
-        }
+        Flux
+            .fromIterable(producers)
+            .flatMap { it.produce(message) }
+            .then()
 
     override fun produceHeartBeat(
         labelName: EntityName,

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
@@ -16,7 +16,7 @@ import reactor.kotlin.test.test
 class CdcSpec :
     StringSpec({
 
-        "all producers succeed, cdc write succeed" {
+        "all producers succeed, cdc write succeeds" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
@@ -16,13 +16,13 @@ import reactor.kotlin.test.test
 class CdcSpec :
     StringSpec({
 
-        "primary success, cdc write succeed" {
+        "all producers succeed, cdc write succeed" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()
 
             val mockWal2 = mockk<Producer>()
-            every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
+            every { mockWal2.produce(any()) } returns Mono.empty()
 
             val cdcLog =
                 CdcContext(
@@ -40,36 +40,13 @@ class CdcSpec :
             cdc.write(cdcLog).test().verifyComplete()
         }
 
-        "primary failed, but secondary success, cdc write succeed" {
+        "any producer fails, cdc write failed" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()
 
             val mockWal2 = mockk<Producer>()
             every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
-
-            val cdcLog =
-                CdcContext(
-                    EntityName("test", "alias"),
-                    Edge(1, "src", "tgt", emptyMap<String, Any>()).toTraceEdge(),
-                    EdgeOperation.INSERT,
-                    EdgeOperationStatus.CREATED,
-                    null,
-                    null,
-                    0,
-                    EntityName("test", "alias"),
-                    emptyList(),
-                )
-            val cdc = DefaultCdc(ProducerList(listOf(mockWal2, mockWal1)))
-            cdc.write(cdcLog).test().verifyComplete()
-        }
-
-        "all cdc failed, cdc write failed" {
-            val mockWal2 = mockk<Producer>()
-            every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
-
-            val mockWal1 = mockk<Producer>()
-            every { mockWal1.produce(any()) } returns Mono.error(RuntimeException("mock error"))
 
             val cdcLog =
                 CdcContext(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/cdc/CdcSpec.kt
@@ -40,7 +40,7 @@ class CdcSpec :
             cdc.write(cdcLog).test().verifyComplete()
         }
 
-        "any producer fails, cdc write failed" {
+        "any producer fails, cdc write fails" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerListSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerListSpec.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.producer
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -31,6 +32,12 @@ class ProducerListSpec :
             every { producer2.produce(message) } returns Mono.error(RuntimeException("mock error"))
 
             ProducerList(listOf(producer1, producer2)).produce(message).test().verifyError()
+        }
+
+        "empty producer list throws IllegalArgumentException" {
+            shouldThrow<IllegalArgumentException> {
+                ProducerList(emptyList())
+            }
         }
 
         "fanout works with more than two producers" {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerListSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/producer/ProducerListSpec.kt
@@ -1,0 +1,51 @@
+package com.kakao.actionbase.v2.engine.producer
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+
+class ProducerListSpec :
+    StringSpec({
+
+        "all producers receive the message" {
+            val message = mockk<Log>()
+            val producer1 = mockk<Producer>()
+            val producer2 = mockk<Producer>()
+            every { producer1.produce(message) } returns Mono.empty()
+            every { producer2.produce(message) } returns Mono.empty()
+
+            ProducerList(listOf(producer1, producer2)).produce(message).test().verifyComplete()
+
+            verify { producer1.produce(message) }
+            verify { producer2.produce(message) }
+        }
+
+        "any producer fails, produce fails" {
+            val message = mockk<Log>()
+            val producer1 = mockk<Producer>()
+            val producer2 = mockk<Producer>()
+            every { producer1.produce(message) } returns Mono.empty()
+            every { producer2.produce(message) } returns Mono.error(RuntimeException("mock error"))
+
+            ProducerList(listOf(producer1, producer2)).produce(message).test().verifyError()
+        }
+
+        "fanout works with more than two producers" {
+            val message = mockk<Log>()
+            val producer1 = mockk<Producer>()
+            val producer2 = mockk<Producer>()
+            val producer3 = mockk<Producer>()
+            every { producer1.produce(message) } returns Mono.empty()
+            every { producer2.produce(message) } returns Mono.empty()
+            every { producer3.produce(message) } returns Mono.empty()
+
+            ProducerList(listOf(producer1, producer2, producer3)).produce(message).test().verifyComplete()
+
+            verify { producer1.produce(message) }
+            verify { producer2.produce(message) }
+            verify { producer3.produce(message) }
+        }
+    })

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
@@ -34,7 +34,7 @@ class WalSpec :
             wal.write(walLog).test().verifyComplete()
         }
 
-        "any producer fails, wal write failed" {
+        "any producer fails, wal write fails" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
@@ -15,13 +15,13 @@ import reactor.kotlin.test.test
 class WalSpec :
     StringSpec({
 
-        "primary success, wal write succeed" {
+        "all producers succeed, wal write succeed" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()
 
             val mockWal2 = mockk<Producer>()
-            every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
+            every { mockWal2.produce(any()) } returns Mono.empty()
 
             val walLog =
                 WalLog(
@@ -34,31 +34,13 @@ class WalSpec :
             wal.write(walLog).test().verifyComplete()
         }
 
-        "primary failed, but secondary success, wal write succeed" {
+        "any producer fails, wal write failed" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()
 
             val mockWal2 = mockk<Producer>()
             every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
-
-            val walLog =
-                WalLog(
-                    EntityName("test", "alias"),
-                    EntityName("test", "label"),
-                    Edge(1, "src", "tgt", emptyMap<String, Any>()).toTraceEdge(),
-                    EdgeOperation.INSERT,
-                )
-            val wal = DefaultWal(ProducerList(listOf(mockWal2, mockWal1)))
-            wal.write(walLog).test().verifyComplete()
-        }
-
-        "all wals failed, wal write failed" {
-            val mockWal2 = mockk<Producer>()
-            every { mockWal2.produce(any()) } returns Mono.error(RuntimeException("mock error"))
-
-            val mockWal1 = mockk<Producer>()
-            every { mockWal1.produce(any()) } returns Mono.error(RuntimeException("mock error"))
 
             val walLog =
                 WalLog(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/wal/WalSpec.kt
@@ -15,7 +15,7 @@ import reactor.kotlin.test.test
 class WalSpec :
     StringSpec({
 
-        "all producers succeed, wal write succeed" {
+        "all producers succeed, wal write succeeds" {
 
             val mockWal1 = mockk<Producer>()
             every { mockWal1.produce(any()) } returns Mono.empty()


### PR DESCRIPTION
## Summary

~~Unify `produce()` with `produceHeartBeat()` by replacing the primary/backup failover logic with an N-fanout.~~ **(see Note below)** Replace the (effectively unused) primary/backup failover in `produce()` with an N-way fanout for WAL/CDC writes; `produceHeartBeat()` is unchanged (already a fanout, monitoring-only). All configured producers receive every message; any per-producer error propagates and fails the overall `Mono<Void>`.

Closes #343

## Changes

- Rewrite `produce()` using `Flux.fromIterable(producers).flatMap { it.produce(message) }.then()`
- Remove `assert(producers.size <= 2)`, `primaryIdx`, `backUpIdx`, `producePrimaryOnly`, and `producePrimaryAndBackUp`
- Add `require(producers.isNotEmpty())` in `init` block to fail fast on empty configuration
- Update `WalSpec` and `CdcSpec`: replace failover-based scenarios with "all succeed → complete" and "any fails → error" cases
- Add `ProducerListSpec`: directly test `ProducerList` fanout behavior with N=2 and N=3 producers, including `verify` assertions that all producers receive the message

### Test cases (WalSpec / CdcSpec)

| Spec | Before | After |
|---|---|---|
| WalSpec | primary success, wal write succeed | all producers succeed, wal write succeeds |
| WalSpec | primary failed, but secondary success, wal write succeed | any producer fails, wal write fails |
| WalSpec | all wals failed, wal write failed | *(removed — covered by above)* |
| CdcSpec | primary success, cdc write succeed | all producers succeed, cdc write succeeds |
| CdcSpec | primary failed, but secondary success, cdc write succeed | any producer fails, cdc write fails |
| CdcSpec | all cdc failed, cdc write failed | *(removed — covered by above)* |

### Test cases (ProducerListSpec — new)

| Test | Description |
|---|---|
| all producers receive the message | N=2, both producers' `produce()` verified via mockk `verify` |
| any producer fails, produce fails | N=2, one error → `verifyError()` |
| empty producer list throws IllegalArgumentException | `ProducerList(emptyList())` → `IllegalArgumentException` |
| fanout works with more than two producers | N=3, all three producers' `produce()` verified |

## How to Test

```
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.wal.WalSpec" --tests "com.kakao.actionbase.v2.engine.cdc.CdcSpec" --tests "com.kakao.actionbase.v2.engine.producer.ProducerListSpec"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Sonnet 4.6 via Claude Code

---

Note by @em3s

Reframed the summary to match the issue (#343): this **replaces the effectively-unused primary/backup failover** with an N-way fanout for WAL/CDC writes, rather than "unifying `produce()` with `produceHeartBeat()`." `produceHeartBeat()` is out of scope — it already fans out and is monitoring-only. Chosen semantics: any per-producer error fails the overall `Mono<Void>` (we want to know when a dual-write cluster drops writes). The code already matches; only the summary wording changed.
