### PR TITLE
Ensure warmup validates WAL write before readiness UP

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
@@ -17,6 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.WebFilter
 
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Component
 @ConditionalOnProperty(name = ["kc.graph.warmup.enabled"], havingValue = "true")
@@ -48,7 +49,7 @@ class ServiceLabelEdgeControllerWarmUp(
         if (serverProperties.readOnly) {
             listOf(HttpMethod.GET)
         } else {
-            listOf(HttpMethod.POST, HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE)
+            listOf(HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.GET)
         }
 
     fun warmUpInfo(
@@ -72,12 +73,12 @@ class ServiceLabelEdgeControllerWarmUp(
                 if (i == 0) {
                     log.info("ServiceLabelEdgeControllerWarmUp is started")
                 }
-                val method = allMethods.random()
+                val method = allMethods[i % allMethods.size]
                 val uri =
-                    if (method != HttpMethod.GET) {
-                        "/graph/v2/service/sys/label/info/edge"
-                    } else {
+                    if (method == HttpMethod.GET) {
                         "/graph/v2/service/sys/label/info/edge?src=origin&tgt=warmup"
+                    } else {
+                        "/graph/v2/service/sys/label/info/edge"
                     }
                 webClient
                     .method(method)
@@ -93,7 +94,28 @@ class ServiceLabelEdgeControllerWarmUp(
                             else -> {}
                         }
                     }.retrieve()
-                    .bodyToMono(String::class.java)
+                    .bodyToMono(Map::class.java)
+                    .flatMap { body ->
+                        if (method == HttpMethod.GET) {
+                            Mono.just(body)
+                        } else {
+                            @Suppress("UNCHECKED_CAST")
+                            val results = body["result"] as? List<*> ?: emptyList<Any>()
+                            val erroredItem =
+                                results.firstOrNull {
+                                    (it as? Map<*, *>)?.get("status") == "ERROR"
+                                }
+                            if (erroredItem != null) {
+                                Mono.error(
+                                    IllegalStateException(
+                                        "Warm-up mutation returned ERROR status: $erroredItem",
+                                    ),
+                                )
+                            } else {
+                                Mono.just(body)
+                            }
+                        }
+                    }
             }, warmUpConfig.concurrency)
             .count()
             .flatMap {
@@ -107,8 +129,9 @@ class ServiceLabelEdgeControllerWarmUp(
                     }.doOnError { ex ->
                         log.error("💔 readiness DOWN  💔", ex)
                     }.thenReturn(it)
-            }.subscribe {
-                log.info("Warm-up is completed: $it tires.")
-            }
+            }.subscribe(
+                { log.info("Warm-up is completed: $it tires.") },
+                { ex -> log.error("💔 Warm-up FAILED — readiness stays DOWN 💔", ex) },
+            )
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServiceLabelEdgeControllerWarmUp.kt
@@ -49,7 +49,7 @@ class ServiceLabelEdgeControllerWarmUp(
         if (serverProperties.readOnly) {
             listOf(HttpMethod.GET)
         } else {
-            listOf(HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.GET)
+            listOf(HttpMethod.POST, HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE)
         }
 
     fun warmUpInfo(
@@ -64,8 +64,12 @@ class ServiceLabelEdgeControllerWarmUp(
         )
 
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        // Round up warmUpConfig.count to the nearest multiple of allMethods.size.
+        val warmUpCount =
+            ((warmUpConfig.count + allMethods.size - 1) / allMethods.size) * allMethods.size
+
         Flux
-            .range(0, warmUpConfig.count)
+            .range(0, warmUpCount)
             .flatMap({ i ->
                 if (tokenAuthenticationFilter is TokenAuthenticationFilter) {
                     tokenAuthenticationFilter.warmUp()
@@ -75,10 +79,10 @@ class ServiceLabelEdgeControllerWarmUp(
                 }
                 val method = allMethods[i % allMethods.size]
                 val uri =
-                    if (method == HttpMethod.GET) {
-                        "/graph/v2/service/sys/label/info/edge?src=origin&tgt=warmup"
-                    } else {
+                    if (method != HttpMethod.GET) {
                         "/graph/v2/service/sys/label/info/edge"
+                    } else {
+                        "/graph/v2/service/sys/label/info/edge?src=origin&tgt=warmup"
                     }
                 webClient
                     .method(method)

--- a/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/StartUpTest.kt
@@ -1,11 +1,13 @@
 package com.kakao.actionbase.server
 
 import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.server.test.InvalidWalConfig
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 
 import kotlin.test.Test
 
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestPropertySource
 
 class StartUpTest : E2ETestBase() {
@@ -173,5 +175,24 @@ class StartUpWithReadOnlyAndWarmUpEnabledTest : E2ETestBase() {
             .exchange()
             .expectStatus()
             .isOk
+    }
+}
+
+@TestPropertySource(
+    properties = [
+        "kc.graph.warmup.enabled=true",
+        "kc.graph.warmup.count=4",
+    ],
+)
+@Import(InvalidWalConfig::class)
+class StartUpWithWarmUpAndInvalidWalProducerTest : E2ETestBase() {
+    @Test
+    fun `readiness stays DOWN when WAL producer is invalid during warmup`() {
+        client
+            .get()
+            .uri("/graph/health/readiness")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(503)
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/test/InvalidWalConfig.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/test/InvalidWalConfig.kt
@@ -1,0 +1,37 @@
+package com.kakao.actionbase.server.test
+
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.producer.Log
+import com.kakao.actionbase.v2.engine.producer.LoggerProducer
+import com.kakao.actionbase.v2.engine.producer.Producer
+import com.kakao.actionbase.v2.engine.producer.ProducerList
+import com.kakao.actionbase.v2.engine.wal.DefaultWal
+import com.kakao.actionbase.v2.engine.wal.Wal
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+import reactor.core.publisher.Mono
+
+@TestConfiguration
+class InvalidWalConfig {
+    @Bean
+    @Primary
+    fun wal(): Wal =
+        DefaultWal(
+            ProducerList(
+                listOf(
+                    LoggerProducer(),
+                    object : Producer {
+                        override fun produce(message: Log): Mono<Void> = Mono.error(RuntimeException("simulated invalid producer"))
+
+                        override fun produceHeartBeat(
+                            labelName: EntityName,
+                            hostName: String,
+                        ): Mono<Void> = Mono.empty()
+                    },
+                ),
+            ),
+        )
+}


### PR DESCRIPTION
## Summary

Fix warmup logic so that a broken WAL producer causes readiness to stay DOWN at boot time.

In production, if one WAL producer in `ProducerList` is unreachable, the server currently boots successfully and readiness transitions to UP — but any subsequent DML request fails with 500 because WAL write is blocking. This fix detects the broken producer at bootstrap so the pod never becomes Ready in the first place.

Two problems allowed a broken producer to slip through previously:
1. `allMethods.random()` could select GET, bypassing the WAL write path entirely
2. The v2 mutation endpoint returns HTTP 200 even on WAL failure — body has
   `result[].status = "ERROR"` but this was not detected

Closes #

Related to #344 

## Changes

- Round up warmUpConfig.count to the nearest multiple of allMethods.size.
- Replace `allMethods.random()` with round-robin `allMethods[i % allMethods.size]`(order: POST → PUT → DELETE → GET) to guarantee write ops run each cycle
- Switch `bodyToMono(String::class.java)` → `bodyToMono(Map::class.java)` and add  a `flatMap` chain that throws `IllegalStateException` when any `result[].status == "ERROR"`
- Add `subscribe` error consumer to log `💔 Warm-up FAILED — readiness stays DOWN`
- Add `StartUpWithWarmUpAndInvalidWalProducerTest` with `InvalidWalConfig` fixture
  (`ProducerList` containing `LoggerProducer` + failing producer) to verify 503 on broken WAL

## How to Test

```bash
./gradlew :server:test --tests \
  "com.kakao.actionbase.server.StartUpWithWarmUpAndInvalidWalProducerTest"
```

Or boot with an invalid WAL broker and confirm `/graph/health/readiness` returns 503.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Sonnet 4.6 via Claude Code (Happy)