### PR TITLE
Replace discussion references with migrated issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Likes, recent views, follows—look simple, but get complex as you scale, and en
 
 Actionbase solves this by precomputing everything at write time, so reads are just lookups. Currently backed by HBase, handling over a million requests per minute for years at Kakao.
 
-[Documentation](https://actionbase.io) · [Open-sourced](https://actionbase.io/blog/open-source-announcement/) · [Why we built this](https://github.com/kakao/actionbase/discussions/32) · [Production stories](https://actionbase.io/stories/kakaotalk-gift-wish/)
+[Documentation](https://actionbase.io) · [Open-sourced](https://actionbase.io/blog/open-source-announcement/) · [Why we built this](https://github.com/kakao/actionbase/issues/358) · [Production stories](https://actionbase.io/stories/kakaotalk-gift-wish/)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Follow-up to #219. Since the discussion was removed, references have been replaced with the migrated issue.

## Changes

- #32 -> #358

## How to Test

- - In preview, check that the links are valid.

## AI Assistance

- [ ] This PR was written largely with AI assistance.
  - Tool / model:

