### PR TITLE
Add Question issue template, drop Discussions contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,3 @@ contact_links:
   - name: Documentation
     url: https://actionbase.io/
     about: Read the documentation
-  - name: Question
-    url: https://github.com/kakao/actionbase/discussions/new?category=q-a
-    about: Ask questions and get help from the community
-  - name: Discussion
-    url: https://github.com/kakao/actionbase/discussions/new
-    about: Start a general discussion

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Ask a question or get help
+title: ''
+labels: question
+assignees: ''
+---
+
+## Question
+
+What would you like to know?
+
+## Context
+
+What have you tried, or what are you trying to do?

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Early open-source preparation phase. The first release focuses on introducing co
 
 We welcome contributions. See our [Contributing Guide](CONTRIBUTING.md).
 
-For questions, ideas, or feedback, join us on [GitHub Discussions](https://github.com/kakao/actionbase/discussions/).
+For questions, ideas, or feedback, open an [issue](https://github.com/kakao/actionbase/issues).
 
 ## Learn More
 


### PR DESCRIPTION
## Summary

GitHub Discussions was disabled in #219 — Q&A and general discussion were folded into Issues. A few references to `/discussions` URLs still remain across the repo and now 404.

This PR cleans up the remaining references in the issue-template config and the README:

- Add a proper *Question* issue template (sitting alongside Bug Report, Feature Request, Task) and drop the broken *Question* / *Discussion* contact links from the new-issue chooser. The standalone *Discussion* entry is dropped — blank issues already cover free-form starts.
- Replace the *GitHub Discussions* link in the README's Contribute section with an Issues link.

Follow-up to #219 and #360.

## Changes

- Add `.github/ISSUE_TEMPLATE/question.md` with the same shape as the other templates (auto-applies the existing `question` label)
- Remove the *Question* and *Discussion* contact links from `.github/ISSUE_TEMPLATE/config.yml`
- Update `README.md`: *Contribute* section now points to Issues instead of Discussions

## How to Test

On the branch, open `https://github.com/kakao/actionbase/issues/new/choose` (or the equivalent on a fork) and confirm:

- *Question* now appears in the template list and prefills the `question` label
- *Discussion* and the broken `/discussions` URLs are gone
- *Bug Report*, *Feature Request*, *Task* still work as before

Then visual-review the README preview — the Contribute section should link to Issues.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7 1M)
