### PR TITLE
Add Vertex support

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -70,7 +70,8 @@ public class BulkEdgeEncoder {
     // encode a single hash edge
     if (labelType == LabelType.HASH
         || labelType == LabelType.INDEXED
-        || labelType == LabelType.MULTI_EDGE) {
+        || labelType == LabelType.MULTI_EDGE
+        || labelType == LabelType.VERTEX) {
       EncodedKey<T> key = encoder.encodeHashEdgeKey(edgeForEdgeState, labelId);
       Long insertTs = null;
       Long deleteTs = null;
@@ -179,7 +180,10 @@ public class BulkEdgeEncoder {
         }
       }
 
-      // EdgeCount is compatible with existing code as is
+      // EdgeCount: Vertex stores State only, no count records
+      if (labelType == LabelType.VERTEX) {
+        return edges;
+      }
       if (label.getDirType() == DirectionType.BOTH) {
         T outboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.OUT, labelId);
         T inboundKey = encoder.encodeCounterEdgeKey(castedEdge, Direction.IN, labelId);

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/LabelType.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/LabelType.java
@@ -9,6 +9,7 @@ public enum LabelType {
   INDEXED(EdgeType.INDEXED, true),
   IMMUTABLE_INDEXED(EdgeType.INDEXED, true),
   MULTI_EDGE(EdgeType.MULTI_EDGE, true),
+  VERTEX(EdgeType.INDEXED, true),
   ;
 
   private static final Map<String, LabelType> NAME_TO_VALUE_MAP = new HashMap<>();

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -436,6 +436,65 @@ public class BulkEdgeEncoderTests {
     return a.length - b.length;
   }
 
+  // VERTEX label: active edge → State only (1 hash row). No index, no counter.
+  @Test
+  void testVertexActiveEdgeProducesStateOnly() throws JsonProcessingException {
+    String vertexLabelJson =
+        labelJsonString
+            .replace("\"type\":\"INDEXED\"", "\"type\":\"VERTEX\"")
+            .replace("\"dirType\":\"BOTH\"", "\"dirType\":\"OUT\"")
+            .replace(
+                "\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}]",
+                "\"indices\":[]")
+            .replace(
+                ",\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+                "");
+    LabelDTO label = objectMapper.readValue(vertexLabelJson, LabelDTO.class);
+    LabelDTO newLabel = label.copy("vertex_table_20240101", "vertex_table_20240101");
+
+    BulkLoadEdge edge = objectMapper.readValue(edgeJsonString, BulkLoadEdge.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
+
+    // Vertex: State only — 1 hash row, no index, no counter
+    assertEquals(1, encodedEdges.size());
+    assertEquals(EncodedEdgeType.HASH_EDGE_TYPE, encodedEdges.get(0).getEncodedEdgeType());
+  }
+
+  // VERTEX label: inactive edge → 1 hash tombstone only.
+  @Test
+  void testVertexInactiveEdgeProducesHashTombstoneOnly() throws JsonProcessingException {
+    String vertexLabelJson =
+        labelJsonString
+            .replace("\"type\":\"INDEXED\"", "\"type\":\"VERTEX\"")
+            .replace("\"dirType\":\"BOTH\"", "\"dirType\":\"OUT\"")
+            .replace(
+                "\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}]",
+                "\"indices\":[]")
+            .replace(
+                ",\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+                "");
+    LabelDTO label = objectMapper.readValue(vertexLabelJson, LabelDTO.class);
+    LabelDTO newLabel = label.copy("vertex_table_20240101", "vertex_table_20240101");
+
+    String inactiveEdgeJson = edgeJsonString.replace("\"active\":true", "\"active\":false");
+    BulkLoadEdge edge = objectMapper.readValue(inactiveEdgeJson, BulkLoadEdge.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
+
+    // Inactive vertex: tombstone hash row only
+    assertEquals(1, encodedEdges.size());
+    assertEquals(EncodedEdgeType.HASH_EDGE_TYPE, encodedEdges.get(0).getEncodedEdgeType());
+  }
+
   /**
    * Backward-compatibility: a label JSON without a `caches` entry must still deserialize, and the
    * bulk encoder must skip cache-row generation without error.

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -1,6 +1,10 @@
 package com.kakao.actionbase.core
 
 object Constants {
+    const val VERTEX_MARKER: String = "-"
+
+    const val VERTEX_TARGET_COMMENT: String = "<vertex>"
+
     const val EDGE_TABLE_NAME: String = "edges"
 
     const val LOCK_TABLE_NAME: String = "locks"

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
@@ -42,6 +42,11 @@ object EdgeMutationBuilder {
         caches: List<Cache>,
     ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.MultiEdge, before, after, directionType, indexes, groups, caches)
 
+    fun buildForVertex(
+        before: EdgeStateRecord,
+        after: EdgeStateRecord,
+    ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.Vertex, before, after, DirectionType.OUT, emptyList(), emptyList(), emptyList())
+
     private fun buildWith(
         strategy: EdgeMutationStrategy,
         before: EdgeStateRecord,
@@ -65,7 +70,7 @@ object EdgeMutationBuilder {
                     acc = 1L,
                     stateRecord = after,
                     createIndexRecords = buildIndexRecords(strategy, after, directionType, indexes),
-                    countRecords = buildCountRecords(strategy, after, directionType, 1L),
+                    countRecords = if (strategy.producesCount) buildCountRecords(strategy, after, directionType, 1L) else emptyList(),
                     groupRecords = buildGroupRecords(strategy, after, groups, 1L),
                     createCacheRecords = buildCacheRecords(strategy, after, directionType, caches),
                 )
@@ -78,7 +83,7 @@ object EdgeMutationBuilder {
                     acc = -1L,
                     stateRecord = after,
                     deleteIndexRecordKeys = buildIndexRecords(strategy, before, directionType, indexes).map { it.key },
-                    countRecords = buildCountRecords(strategy, countSource, directionType, -1L),
+                    countRecords = if (strategy.producesCount) buildCountRecords(strategy, countSource, directionType, -1L) else emptyList(),
                     groupRecords = buildGroupRecords(strategy, before, groups, -1L),
                     deleteCacheRecordQualifiers =
                         buildCacheRecords(strategy, before, directionType, caches)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
@@ -6,13 +6,14 @@ import com.kakao.actionbase.core.metadata.common.Direction
 import com.kakao.actionbase.core.metadata.common.DirectionType
 
 /**
- * Strategy that encapsulates the behavioral differences between Edge and MultiEdge mutation building.
+ * Strategy that encapsulates the behavioral differences between Edge, MultiEdge, and Vertex mutation building.
  *
- * The four axes of difference:
- * 1. Source resolution: Edge uses key.source/target, MultiEdge uses properties._source/_target
- * 2. Target resolution (index suffix): Edge swaps source/target, MultiEdge always uses key.source (id)
+ * The five axes of difference:
+ * 1. Source resolution: Edge/Vertex uses key.source/target, MultiEdge uses properties._source/_target
+ * 2. Target resolution (index suffix): Edge/Vertex swaps source/target, MultiEdge always uses key.source (id)
  * 3. DELETE count source: Edge uses after record, MultiEdge uses before record
- * 4. UPDATE count: Edge produces none, MultiEdge produces conditionally (when source/target changed)
+ * 4. UPDATE count: Edge/Vertex produces none, MultiEdge produces conditionally (when source/target changed)
+ * 5. Count generation: Edge/MultiEdge produces count records, Vertex suppresses all count records
  */
 sealed interface EdgeMutationStrategy {
     fun directedSource(
@@ -24,6 +25,8 @@ sealed interface EdgeMutationStrategy {
         record: EdgeStateRecord,
         direction: Direction,
     ): Any
+
+    val producesCount: Boolean
 
     fun countRecordOnDelete(
         before: EdgeStateRecord,
@@ -38,6 +41,7 @@ sealed interface EdgeMutationStrategy {
     ): List<EdgeCountRecord>
 
     data object Edge : EdgeMutationStrategy {
+        override val producesCount: Boolean = true
         override fun directedSource(
             record: EdgeStateRecord,
             direction: Direction,
@@ -70,6 +74,7 @@ sealed interface EdgeMutationStrategy {
     }
 
     data object MultiEdge : EdgeMutationStrategy {
+        override val producesCount: Boolean = true
         override fun directedSource(
             record: EdgeStateRecord,
             direction: Direction,
@@ -106,5 +111,31 @@ sealed interface EdgeMutationStrategy {
                 emptyList()
             }
         }
+    }
+
+    data object Vertex : EdgeMutationStrategy {
+        override val producesCount: Boolean = false
+
+        override fun directedSource(
+            record: EdgeStateRecord,
+            direction: Direction,
+        ): Any = Edge.directedSource(record, direction)
+
+        override fun directedTarget(
+            record: EdgeStateRecord,
+            direction: Direction,
+        ): Any = Edge.directedTarget(record, direction)
+
+        override fun countRecordOnDelete(
+            before: EdgeStateRecord,
+            after: EdgeStateRecord,
+        ): EdgeStateRecord = after
+
+        override fun countRecordsOnUpdate(
+            before: EdgeStateRecord,
+            after: EdgeStateRecord,
+            directionType: DirectionType,
+            buildCountRecords: (EdgeStateRecord, DirectionType, Long) -> List<EdgeCountRecord>,
+        ): List<EdgeCountRecord> = emptyList()
     }
 }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
@@ -42,6 +42,7 @@ sealed interface EdgeMutationStrategy {
 
     data object Edge : EdgeMutationStrategy {
         override val producesCount: Boolean = true
+
         override fun directedSource(
             record: EdgeStateRecord,
             direction: Direction,
@@ -75,6 +76,7 @@ sealed interface EdgeMutationStrategy {
 
     data object MultiEdge : EdgeMutationStrategy {
         override val producesCount: Boolean = true
+
         override fun directedSource(
             record: EdgeStateRecord,
             direction: Direction,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
@@ -14,7 +14,7 @@ import com.kakao.actionbase.core.state.EventType
  *
  * Throws [IllegalArgumentException] on violation so the global exception handler maps it to 400.
  */
-fun checkNonNullableFields(
+internal fun checkNonNullableFields(
     eventType: EventType,
     properties: List<StructField>,
     payload: Map<String, Any?>,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
@@ -14,7 +14,7 @@ import com.kakao.actionbase.core.state.EventType
  *
  * Throws [IllegalArgumentException] on violation so the global exception handler maps it to 400.
  */
-internal fun checkNonNullableFields(
+fun checkNonNullableFields(
     eventType: EventType,
     properties: List<StructField>,
     payload: Map<String, Any?>,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 @JsonSubTypes(
     JsonSubTypes.Type(value = TableDescriptor.Edge::class, name = "edge"),
     JsonSubTypes.Type(value = TableDescriptor.MultiEdge::class, name = "multiEdge"),
+    JsonSubTypes.Type(value = TableDescriptor.Vertex::class, name = "vertex"),
 )
 sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
     abstract val database: String
@@ -65,6 +66,26 @@ sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
         override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
         override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
     ) : TableDescriptor<ModelSchema.MultiEdge>() {
+        @JsonIgnore
+        override val id: TableId = TableId(tenant, database, table)
+    }
+
+    @JsonTypeName("vertex")
+    data class Vertex(
+        override val tenant: String,
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.Vertex,
+        override val mode: MutationMode,
+        override val storage: String,
+        override val active: Boolean = true,
+        override val comment: String = Constants.DEFAULT_COMMENT,
+        override val revision: Long = Constants.DEFAULT_REVISION,
+        override val createdAt: Long = Constants.DEFAULT_CREATED_AT,
+        override val createdBy: String = Constants.DEFAULT_CREATED_BY,
+        override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
+        override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
+    ) : TableDescriptor<ModelSchema.Vertex>() {
         @JsonIgnore
         override val id: TableId = TableId(tenant, database, table)
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -45,7 +45,7 @@ sealed class ModelSchema : AbstractSchema {
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false))
 
-    @JsonTypeName("VERTEX")
+    @JsonTypeName("vertex")
     data class Vertex(
         val id: Field,
         override val properties: List<StructField> = emptyList(),

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 @JsonSubTypes(
     JsonSubTypes.Type(value = ModelSchema.Edge::class, name = "EDGE"),
     JsonSubTypes.Type(value = ModelSchema.MultiEdge::class, name = "MULTI_EDGE"),
+    JsonSubTypes.Type(value = ModelSchema.Vertex::class, name = "VERTEX"),
 )
 sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
@@ -43,4 +44,11 @@ sealed class ModelSchema : AbstractSchema {
         val caches: List<Cache> = emptyList(),
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false))
+
+    @JsonTypeName("VERTEX")
+    data class Vertex(
+        val id: Field,
+        override val properties: List<StructField> = emptyList(),
+    ) : ModelSchema(),
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable })
 }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/Vertex.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/Vertex.kt
@@ -1,0 +1,7 @@
+package com.kakao.actionbase.core.vertex
+
+data class Vertex(
+    val version: Long,
+    val id: Any,
+    val properties: Map<String, Any?> = emptyMap(),
+)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/DataFrameVertexPayload.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/DataFrameVertexPayload.kt
@@ -1,0 +1,20 @@
+package com.kakao.actionbase.core.vertex.payload
+
+import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
+
+data class DataFrameVertexPayload(
+    val vertices: List<VertexPayload>,
+    val count: Int,
+    val total: Long,
+    val context: Map<String, Any?>,
+) {
+    companion object {
+        fun from(frame: DataFrameEdgePayload): DataFrameVertexPayload =
+            DataFrameVertexPayload(
+                vertices = frame.edges.map { VertexPayload(version = it.version, id = it.source, properties = it.properties, context = it.context) },
+                count = frame.count,
+                total = frame.total,
+                context = frame.context,
+            )
+    }
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexBulkMutationRequest.kt
@@ -1,0 +1,40 @@
+package com.kakao.actionbase.core.vertex.payload
+
+import com.kakao.actionbase.core.Constants.VERTEX_MARKER
+import com.kakao.actionbase.core.edge.EdgeEvent
+import com.kakao.actionbase.core.edge.MutationEvent
+import com.kakao.actionbase.core.edge.UnresolvedEvent
+import com.kakao.actionbase.core.edge.payload.checkNonNullableFields
+import com.kakao.actionbase.core.metadata.common.ModelSchema
+import com.kakao.actionbase.core.state.Event
+import com.kakao.actionbase.core.state.EventType
+import com.kakao.actionbase.core.vertex.Vertex
+
+data class VertexBulkMutationRequest(
+    val mutations: List<MutationItem>,
+) {
+    data class MutationItem(
+        val type: EventType,
+        val vertex: Vertex,
+    ) : UnresolvedEvent {
+        override fun createEvent(schema: ModelSchema): MutationEvent {
+            require(schema is ModelSchema.Vertex) { "Expected ModelSchema.Vertex, but got ${schema::class.simpleName}" }
+            val id = schema.id.type.cast(vertex.id)
+            require(id.toString() != VERTEX_MARKER) { "Vertex id cannot be '$VERTEX_MARKER' (reserved marker)" }
+            checkNonNullableFields(type, schema.properties, vertex.properties)
+            val event =
+                Event.create(
+                    type = type,
+                    version = vertex.version,
+                    properties =
+                        schema.properties
+                            .filter { field -> field.name in vertex.properties.keys }
+                            .associate { field ->
+                                val value = vertex.properties[field.name]
+                                field.name to if (value != null) field.type.cast(value) else null
+                            },
+                )
+            return EdgeEvent(id, VERTEX_MARKER, event)
+        }
+    }
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexMutationResponse.kt
@@ -1,9 +1,10 @@
 package com.kakao.actionbase.core.vertex.payload
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.kakao.actionbase.core.Constants
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.payload.MutationResult
+
+import com.fasterxml.jackson.annotation.JsonInclude
 
 data class VertexMutationResponse(
     val results: List<Item>,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexMutationResponse.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexMutationResponse.kt
@@ -1,0 +1,40 @@
+package com.kakao.actionbase.core.vertex.payload
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.kakao.actionbase.core.Constants
+import com.kakao.actionbase.core.edge.MutationKey
+import com.kakao.actionbase.core.edge.payload.MutationResult
+
+data class VertexMutationResponse(
+    val results: List<Item>,
+) {
+    data class Item(
+        val id: Any,
+        val status: String,
+        val count: Int,
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val context: Map<String, Any?>? = null,
+    )
+
+    companion object {
+        fun from(results: List<MutationResult>) =
+            VertexMutationResponse(
+                results
+                    .map {
+                        // vertex uses the edge mutation with source=id, target=VERTEX_MARKER.
+                        val key =
+                            it.key as? MutationKey.SourceTarget
+                                ?: error("VertexMutationResponse requires SourceTarget key, got ${it.key::class.simpleName}")
+                        require(key.target == Constants.VERTEX_MARKER) {
+                            "VertexMutationResponse requires target=${Constants.VERTEX_MARKER}, got ${key.target}"
+                        }
+                        Item(
+                            id = key.source,
+                            count = it.count,
+                            status = it.status,
+                            context = it.context,
+                        )
+                    }.sortedBy { it.id.toString() },
+            )
+    }
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexPayload.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexPayload.kt
@@ -1,0 +1,8 @@
+package com.kakao.actionbase.core.vertex.payload
+
+data class VertexPayload(
+    val version: Long,
+    val id: Any,
+    val properties: Map<String, Any?>,
+    val context: Map<String, Any?>,
+)

--- a/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilderTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilderTest.kt
@@ -666,4 +666,61 @@ class EdgeMutationBuilderTest {
             )
         }
     }
+
+    @Nested
+    inner class VertexStrategy {
+        @Test
+        fun `IDLE when before equals after`() {
+            val record = edgeRecord(source = "user1", target = "-", active = true)
+            val result = EdgeMutationBuilder.buildForVertex(record, record)
+
+            assertEquals("IDLE", result.status)
+            assertEquals(0L, result.acc)
+            assertTrue(result.countRecords.isEmpty())
+            assertTrue(result.createIndexRecords.isEmpty())
+        }
+
+        @Test
+        fun `CREATED produces no count records`() {
+            val before = edgeRecord(source = "user1", target = "-", active = false, version = 0)
+            val after = edgeRecord(source = "user1", target = "-", active = true, version = 1)
+            val result = EdgeMutationBuilder.buildForVertex(before, after)
+
+            assertEquals("CREATED", result.status)
+            assertEquals(1L, result.acc)
+            assertTrue(result.countRecords.isEmpty())
+            assertTrue(result.createIndexRecords.isEmpty())
+        }
+
+        @Test
+        fun `DELETED produces no count records`() {
+            val before = edgeRecord(source = "user1", target = "-", active = true, version = 1)
+            val after = edgeRecord(source = "user1", target = "-", active = false, version = 2)
+            val result = EdgeMutationBuilder.buildForVertex(before, after)
+
+            assertEquals("DELETED", result.status)
+            assertEquals(-1L, result.acc)
+            assertTrue(result.countRecords.isEmpty())
+        }
+
+        @Test
+        fun `UPDATED produces no count records`() {
+            val before = edgeRecord(source = "user1", target = "-", active = true, version = 1)
+            val after = edgeRecord(source = "user1", target = "-", active = true, version = 2)
+            val result = EdgeMutationBuilder.buildForVertex(before, after)
+
+            assertEquals("UPDATED", result.status)
+            assertEquals(0L, result.acc)
+            assertTrue(result.countRecords.isEmpty())
+        }
+
+        @Test
+        fun `stateRecord is always written`() {
+            val before = edgeRecord(source = "user1", target = "-", active = false, version = 0)
+            val after = edgeRecord(source = "user1", target = "-", active = true, version = 1)
+            val result = EdgeMutationBuilder.buildForVertex(before, after)
+
+            assertEquals(after, result.stateRecord)
+        }
+    }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategyTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategyTest.kt
@@ -19,6 +19,7 @@ class EdgeMutationStrategyTest {
         when (name) {
             "Edge" -> EdgeMutationStrategy.Edge
             "MultiEdge" -> EdgeMutationStrategy.MultiEdge
+            "Vertex" -> EdgeMutationStrategy.Vertex
             else -> error("unknown strategy: $name")
         }
 
@@ -32,8 +33,19 @@ class EdgeMutationStrategyTest {
         when (strategy) {
             "Edge" -> edgeRecord(source = source, target = target, active = active, version = version)
             "MultiEdge" -> multiEdgeRecord(id = "edgeId1", source = source, target = target, active = active, version = version)
+            "Vertex" -> edgeRecord(source = source, target = "-", active = active, version = version)
             else -> error("unknown strategy: $strategy")
         }
+
+    @Nested
+    inner class ProducesCount {
+        @Test
+        fun `Edge and MultiEdge produce count, Vertex does not`() {
+            assertEquals(true, EdgeMutationStrategy.Edge.producesCount)
+            assertEquals(true, EdgeMutationStrategy.MultiEdge.producesCount)
+            assertEquals(false, EdgeMutationStrategy.Vertex.producesCount)
+        }
+    }
 
     @Nested
     inner class DirectedSource {
@@ -45,6 +57,8 @@ class EdgeMutationStrategyTest {
             - Edge       | IN        | postX   # Edge IN   → key.target
             - MultiEdge  | OUT       | userA   # MultiEdge → properties._source
             - MultiEdge  | IN        | postX   # MultiEdge → properties._target
+            - Vertex     | OUT       | userA   # Vertex delegates to Edge: key.source
+            - Vertex     | IN        | -       # Vertex delegates to Edge: key.target (VERTEX_MARKER)
             """,
         )
         fun `returns the configured source for the direction`(
@@ -67,6 +81,8 @@ class EdgeMutationStrategyTest {
             - Edge       | IN        | userA
             - MultiEdge  | OUT       | edgeId1  # MultiEdge always uses key.source (id)
             - MultiEdge  | IN        | edgeId1
+            - Vertex     | OUT       | -        # Vertex: target is always VERTEX_MARKER
+            - Vertex     | IN        | userA    # Vertex delegates to Edge: key.source on IN
             """,
         )
         fun `returns the configured target for the direction`(

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
@@ -1,0 +1,107 @@
+package com.kakao.actionbase.core.payload
+
+import com.kakao.actionbase.core.Constants.VERTEX_MARKER
+import com.kakao.actionbase.core.edge.EdgeEvent
+import com.kakao.actionbase.core.metadata.common.Field
+import com.kakao.actionbase.core.metadata.common.ModelSchema
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.state.EventType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.core.vertex.Vertex
+import com.kakao.actionbase.core.vertex.payload.VertexBulkMutationRequest
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.Test
+
+class VertexBulkMutationRequestTest {
+    private val schema =
+        ModelSchema.Vertex(
+            id = Field(PrimitiveType.STRING, "user id"),
+            properties =
+                listOf(
+                    StructField(name = "name", type = PrimitiveType.STRING, comment = "user name", nullable = false),
+                    StructField(name = "age", type = PrimitiveType.LONG, comment = "user age", nullable = true),
+                ),
+        )
+
+    private fun item(
+        type: EventType,
+        id: Any = "user1",
+        properties: Map<String, Any?> = emptyMap(),
+    ) = VertexBulkMutationRequest.MutationItem(
+        type = type,
+        vertex = Vertex(id = id, version = 1L, properties = properties),
+    )
+
+    @Test
+    fun `createEvent sets source=id and target=VERTEX_MARKER`() {
+        val event = item(EventType.INSERT, id = "user1", properties = mapOf("name" to "Alice")) .createEvent(schema) as EdgeEvent
+        assertEquals("user1", event.source)
+        assertEquals(VERTEX_MARKER, event.target)
+    }
+
+    @Test
+    fun `INSERT with all required fields succeeds`() {
+        val event = item(EventType.INSERT, properties = mapOf("name" to "Alice")).createEvent(schema)
+        assertEquals("Alice", event.event.properties["name"])
+    }
+
+    @Test
+    fun `INSERT missing non-nullable field throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, properties = mapOf("age" to 20L)).createEvent(schema)
+        }
+    }
+
+    @Test
+    fun `INSERT with explicit null for non-nullable field throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, properties = mapOf("name" to null)).createEvent(schema)
+        }
+    }
+
+    @Test
+    fun `UPDATE missing non-nullable field succeeds (keeps existing value)`() {
+        val event = item(EventType.UPDATE, properties = mapOf("age" to 21L)).createEvent(schema)
+        assertTrue(event.event.properties.containsKey("age"))
+    }
+
+    @Test
+    fun `UPDATE with explicit null for non-nullable field throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.UPDATE, properties = mapOf("name" to null)).createEvent(schema)
+        }
+    }
+
+    @Test
+    fun `DELETE missing non-nullable field succeeds (tombstone)`() {
+        val event = item(EventType.DELETE, properties = emptyMap()).createEvent(schema)
+        assertTrue(event.event.properties.isEmpty())
+    }
+
+    @Test
+    fun `nullable field may be absent or explicitly null`() {
+        val absentEvent = item(EventType.INSERT, properties = mapOf("name" to "Alice")).createEvent(schema)
+        assertTrue(!absentEvent.event.properties.containsKey("age"))
+
+        val nullEvent = item(EventType.INSERT, properties = mapOf("name" to "Alice", "age" to null)).createEvent(schema)
+        assertNull(nullEvent.event.properties["age"])
+    }
+
+    @Test
+    fun `createEvent rejects wrong schema type`() {
+        val edgeSchema =
+            ModelSchema.Edge(
+                source = Field(PrimitiveType.STRING, "src"),
+                target = Field(PrimitiveType.STRING, "tgt"),
+                direction = com.kakao.actionbase.core.metadata.common.DirectionType.OUT,
+            )
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, properties = mapOf("name" to "Alice")).createEvent(edgeSchema)
+        }
+    }
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
@@ -39,7 +39,7 @@ class VertexBulkMutationRequestTest {
 
     @Test
     fun `createEvent sets source=id and target=VERTEX_MARKER`() {
-        val event = item(EventType.INSERT, id = "user1", properties = mapOf("name" to "Alice")) .createEvent(schema) as EdgeEvent
+        val event = item(EventType.INSERT, id = "user1", properties = mapOf("name" to "Alice")).createEvent(schema) as EdgeEvent
         assertEquals("user1", event.source)
         assertEquals(VERTEX_MARKER, event.target)
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.engine.service
 
+import com.kakao.actionbase.core.Constants.VERTEX_MARKER
 import com.kakao.actionbase.core.edge.EdgeField
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
@@ -93,6 +94,15 @@ class QueryService(
             .getTableBinding(database, table)
             .gets(keys, filters)
             .map { it.toEdgePayload() }
+    }
+
+    fun getVertices(
+        database: String,
+        table: String,
+        keys: List<Any>,
+        filters: String? = null,
+    ): Mono<DataFrameEdgePayload> {
+        return gets(database, table, keys, listOf(VERTEX_MARKER), filters = filters)
     }
 
     @Suppress("UnusedParameter")

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -101,9 +101,7 @@ class QueryService(
         table: String,
         keys: List<Any>,
         filters: String? = null,
-    ): Mono<DataFrameEdgePayload> {
-        return gets(database, table, keys, listOf(VERTEX_MARKER), filters = filters)
-    }
+    ): Mono<DataFrameEdgePayload> = gets(database, table, keys, listOf(VERTEX_MARKER), filters = filters)
 
     @Suppress("UnusedParameter")
     fun gets(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
@@ -91,8 +91,8 @@ data class LabelEntity(
                         }
                     }
                 }
-                LabelType.INDEXED, LabelType.MULTI_EDGE -> {
-                    // MultiEdge is a variant of the INDEXED type in the v2 engine.
+                LabelType.INDEXED, LabelType.MULTI_EDGE, LabelType.VERTEX -> {
+                    // MultiEdge and Vertex are both backed by the INDEXED storage path in the v2 engine.
                     if (type == LabelType.MULTI_EDGE && !readOnly) {
                         logger.error("MULTI_EDGE type should be read-only in the v2 engine. Fallback to NilLabel")
                         return NilLabel(this.copy(type = LabelType.NIL))

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
@@ -62,6 +62,17 @@ data class LabelEntity(
         require(type.edgeType != EdgeType.HASH || dirType == DirectionType.OUT) {
             "The hash LabelV0 $type supports only OUT direction. Input direction: $dirType"
         }
+        // Vertex stores State only — indices/groups/caches/IN-direction are silently ignored
+        // by BulkEdgeEncoder and toV3ModelSchemaVertex. Reject at construction so the data
+        // never reaches storage in an inconsistent state.
+        if (type == LabelType.VERTEX) {
+            require(dirType == DirectionType.OUT) {
+                "VERTEX label supports only OUT direction. Input direction: $dirType"
+            }
+            require(indices.isEmpty()) { "VERTEX label does not support indices, got ${indices.size}" }
+            require(groups.isEmpty()) { "VERTEX label does not support groups, got ${groups.size}" }
+            require(caches.isEmpty()) { "VERTEX label does not support caches, got ${caches.size}" }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod")

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -377,6 +377,8 @@ class V2BackedTableBinding(
                 EdgeMutationBuilder.buildForUniqueEdge(before, after, schema.direction, schema.indexes, schema.groups, schema.caches)
             is ModelSchema.MultiEdge ->
                 EdgeMutationBuilder.buildForMultiEdge(before, after, schema.direction, schema.indexes, schema.groups, schema.caches)
+            is ModelSchema.Vertex ->
+                EdgeMutationBuilder.buildForVertex(before, after)
         }
     }
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
@@ -35,12 +35,32 @@ sealed class V3TableDescriptor {
         override val schema: ModelSchema.MultiEdge,
     ) : V3TableDescriptor()
 
+    data class Vertex(
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.Vertex,
+    ) : V3TableDescriptor()
+
     companion object {
         fun create(entity: LabelEntity): V3TableDescriptor {
             val database = entity.name.service
             val table = entity.name.nameNotNull
 
+            val isVertexTable = entity.type == LabelType.VERTEX
             val isMultiEdgeTable = entity.type == LabelType.MULTI_EDGE
+            if (isVertexTable) {
+                val schema =
+                    ModelSchema.Vertex(
+                        id = entity.schema.src.toV3(),
+                        properties =
+                            entity.schema.fields.map { it.toV3() },
+                    )
+                return Vertex(
+                    database = database,
+                    table = table,
+                    schema = schema,
+                )
+            }
             return if (isMultiEdgeTable) {
                 val schema =
                     ModelSchema.MultiEdge(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelEntitySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelEntitySpec.kt
@@ -1,12 +1,22 @@
 package com.kakao.actionbase.v2.engine.label
 
 import com.kakao.actionbase.core.metadata.common.Cache
+import com.kakao.actionbase.core.metadata.common.Group
+import com.kakao.actionbase.core.metadata.common.GroupType
+import com.kakao.actionbase.v2.core.code.Index
+import com.kakao.actionbase.v2.core.code.hbase.Order
 import com.kakao.actionbase.v2.core.metadata.Active
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.LabelType
 import com.kakao.actionbase.v2.core.types.DataType
+import com.kakao.actionbase.v2.core.types.EdgeSchema
 import com.kakao.actionbase.v2.core.types.Field
 import com.kakao.actionbase.v2.core.types.StructType
+import com.kakao.actionbase.v2.core.types.VertexField
+import com.kakao.actionbase.v2.core.types.VertexType
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.edge.HashEdge
+import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.entity.LabelEntity
 import com.kakao.actionbase.v2.engine.metadata.Metadata
 import com.kakao.actionbase.v2.engine.sql.Row
@@ -15,6 +25,7 @@ import com.kakao.actionbase.v2.engine.test.GraphFixtures
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -113,6 +124,80 @@ class LabelEntitySpec :
             LabelEntity.toEntity(rowWithSchema)
         }
 
+        // Vertex stores State only — indices/groups/caches/IN-direction are silently dropped
+        // by BulkEdgeEncoder and the v3 schema converter. Reject them at construction so the
+        // data never reaches storage in an inconsistent state.
+        "VERTEX label rejects non-OUT direction" {
+            shouldThrow<IllegalArgumentException> {
+                LabelEntity(
+                    active = true,
+                    name = EntityName("db", "users"),
+                    desc = "",
+                    type = LabelType.VERTEX,
+                    schema = vertexSchema(),
+                    dirType = DirectionType.BOTH,
+                    storage = "test",
+                )
+            }
+        }
+
+        "VERTEX label rejects indices" {
+            shouldThrow<IllegalArgumentException> {
+                LabelEntity(
+                    active = true,
+                    name = EntityName("db", "users"),
+                    desc = "",
+                    type = LabelType.VERTEX,
+                    schema = vertexSchema(),
+                    dirType = DirectionType.OUT,
+                    storage = "test",
+                    indices = listOf(Index("name_asc", listOf(Index.Field("name", Order.ASC)))),
+                )
+            }
+        }
+
+        "VERTEX label rejects groups" {
+            shouldThrow<IllegalArgumentException> {
+                LabelEntity(
+                    active = true,
+                    name = EntityName("db", "users"),
+                    desc = "",
+                    type = LabelType.VERTEX,
+                    schema = vertexSchema(),
+                    dirType = DirectionType.OUT,
+                    storage = "test",
+                    groups = listOf(Group(group = "g1", type = GroupType.COUNT, fields = emptyList())),
+                )
+            }
+        }
+
+        "VERTEX label rejects caches" {
+            shouldThrow<IllegalArgumentException> {
+                LabelEntity(
+                    active = true,
+                    name = EntityName("db", "users"),
+                    desc = "",
+                    type = LabelType.VERTEX,
+                    schema = vertexSchema(),
+                    dirType = DirectionType.OUT,
+                    storage = "test",
+                    caches = listOf(Cache(cache = "c1", fields = emptyList())),
+                )
+            }
+        }
+
+        "VERTEX label accepts the canonical empty shape" {
+            LabelEntity(
+                active = true,
+                name = EntityName("db", "users"),
+                desc = "",
+                type = LabelType.VERTEX,
+                schema = vertexSchema(),
+                dirType = DirectionType.OUT,
+                storage = "test",
+            )
+        }
+
         "LabelEntity JSON serializes caches field" {
             val entity =
                 Metadata.serviceLabelEntity.copy(
@@ -127,4 +212,13 @@ class LabelEntitySpec :
             roundTripped.caches.size shouldBe 1
             roundTripped.caches[0].cache shouldBe "c1"
         }
-    })
+    }) {
+    companion object {
+        private fun vertexSchema() =
+            EdgeSchema(
+                VertexField(VertexType.STRING, "id"),
+                VertexField(VertexType.STRING, "<vertex>"),
+                listOf(Field("name", DataType.STRING, false, "")),
+            )
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
@@ -10,7 +10,6 @@ import com.kakao.actionbase.engine.service.MutationService
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.engine.util.runEvenIfCancelled
 import com.kakao.actionbase.v2.core.metadata.Direction
-import com.kakao.actionbase.v2.core.metadata.LabelType
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.metadata.Metadata

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
@@ -1,12 +1,16 @@
 package com.kakao.actionbase.v2.engine.v3
 
+import com.kakao.actionbase.core.Constants.VERTEX_MARKER
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
 import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.core.vertex.payload.VertexBulkMutationRequest
+import com.kakao.actionbase.core.vertex.payload.VertexMutationResponse
 import com.kakao.actionbase.engine.service.MutationService
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.engine.util.runEvenIfCancelled
 import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.LabelType
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.metadata.Metadata
@@ -439,6 +443,108 @@ class MutationServiceSpec :
                 }.verifyComplete()
 
             executionCompleted.get() shouldBe true
+        }
+        "vertex mutation and query" {
+            val database = GraphFixtures.serviceName
+            val table = "users"
+
+            // Create vertex table (LabelType.VERTEX, no index)
+            val createRequest =
+                mapper.readValue<LabelCreateRequest>(
+                    """
+                    {
+                      "desc": "users vertex table",
+                      "type": "VERTEX",
+                      "schema": {
+                        "src": { "type": "STRING", "desc": "user id" },
+                        "tgt": { "type": "STRING", "desc": "<vertex>" },
+                        "fields": [
+                          { "name": "name", "type": "STRING", "nullable": false }
+                        ]
+                      },
+                      "dirType": "OUT",
+                      "storage": "${GraphFixtures.datastoreStorage}",
+                      "indices": []
+                    }
+                    """.trimIndent(),
+                )
+            graph.labelDdl.create(EntityName(database, table), createRequest).block()
+
+            // Insert two vertices
+            val insertRequest =
+                mapper.readValue<VertexBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "vertex": {"version": 1, "id": "user1", "properties": {"name": "Alice"}}},
+                        {"type": "INSERT", "vertex": {"version": 1, "id": "user2", "properties": {"name": "Bob"}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            val mutateResult =
+                mutationService
+                    .mutate(database, table, insertRequest.mutations)
+                    .map { VertexMutationResponse.from(it) }
+                    .block()!!
+
+            mutateResult.results.map { it.status } shouldBe listOf("CREATED", "CREATED")
+            mutateResult.results.map { it.id.toString() } shouldBe listOf("user1", "user2")
+
+            // Multi-Get: user1, user2 found; user3 absent
+            val getResult =
+                queryService
+                    .getVertices(database, table, listOf("user1", "user2", "user3"))
+                    .block()!!
+
+            getResult.edges.size shouldBe 2
+            getResult.edges.all { it.target == VERTEX_MARKER } shouldBe true
+            getResult.edges.map { it.source.toString() }.sorted() shouldBe listOf("user1", "user2")
+
+            // Update user1
+            val updateRequest =
+                mapper.readValue<VertexBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "UPDATE", "vertex": {"version": 2, "id": "user1", "properties": {"name": "Alice Updated"}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+            val updateResult =
+                mutationService
+                    .mutate(database, table, updateRequest.mutations)
+                    .map { VertexMutationResponse.from(it) }
+                    .block()!!
+            updateResult.results[0].status shouldBe "UPDATED"
+
+            // Delete user2
+            val deleteRequest =
+                mapper.readValue<VertexBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "DELETE", "vertex": {"version": 3, "id": "user2", "properties": {}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+            val deleteResult =
+                mutationService
+                    .mutate(database, table, deleteRequest.mutations)
+                    .map { VertexMutationResponse.from(it) }
+                    .block()!!
+            deleteResult.results[0].status shouldBe "DELETED"
+
+            // After delete: only user1 remains
+            val afterDeleteResult =
+                queryService
+                    .getVertices(database, table, listOf("user1", "user2"))
+                    .block()!!
+            afterDeleteResult.edges.size shouldBe 1
+            afterDeleteResult.edges[0].source.toString() shouldBe "user1"
         }
     }) {
     companion object {

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexMutationController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexMutationController.kt
@@ -1,0 +1,46 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.core.vertex.payload.VertexBulkMutationRequest
+import com.kakao.actionbase.core.vertex.payload.VertexMutationResponse
+import com.kakao.actionbase.engine.context.RequestContext
+import com.kakao.actionbase.engine.metadata.MutationMode
+import com.kakao.actionbase.engine.service.MutationService
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
+@RestController
+class VertexMutationController(
+    private val mutationService: MutationService,
+) {
+    @PostMapping("/graph/v3/databases/{database}/tables/{table}/vertices")
+    fun mutateVertex(
+        @PathVariable database: String,
+        @PathVariable table: String,
+        @RequestBody request: VertexBulkMutationRequest,
+        @RequestParam(required = false) lock: Boolean = true,
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<VertexMutationResponse>> =
+        mutationService
+            .mutate(database, table, request.mutations, lock, syncMode = null, requestContext = requestContext)
+            .map { ResponseEntity.ok(VertexMutationResponse.from(it)) }
+
+    @PostMapping("/graph/v3/databases/{database}/tables/{table}/vertices/sync")
+    fun mutateVertexSync(
+        @PathVariable database: String,
+        @PathVariable table: String,
+        @RequestBody request: VertexBulkMutationRequest,
+        @RequestParam(required = false) lock: Boolean = true,
+        @RequestParam(required = false) force: Boolean = false,
+        requestContext: RequestContext,
+    ): Mono<ResponseEntity<VertexMutationResponse>> =
+        mutationService
+            .mutate(database, table, request.mutations, lock, syncMode = MutationMode.SYNC, forceSyncMode = force, requestContext = requestContext)
+            .map { ResponseEntity.ok(VertexMutationResponse.from(it)) }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
@@ -1,0 +1,28 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.core.vertex.payload.DataFrameVertexPayload
+import com.kakao.actionbase.engine.service.QueryService
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
+@RestController
+class VertexQueryController(
+    private val queryService: QueryService,
+) {
+    @GetMapping("/graph/v3/databases/{database}/tables/{table}/vertices/get")
+    fun getVertices(
+        @PathVariable database: String,
+        @PathVariable table: String,
+        @RequestParam key: List<String>,
+        @RequestParam(required = false) filters: String? = null,
+    ): Mono<ResponseEntity<DataFrameVertexPayload>> =
+        queryService
+            .getVertices(database, table, key, filters)
+            .map { ResponseEntity.ok(DataFrameVertexPayload.from(it)) }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
@@ -19,10 +19,10 @@ class VertexQueryController(
     fun getVertices(
         @PathVariable database: String,
         @PathVariable table: String,
-        @RequestParam key: List<String>,
+        @RequestParam id: List<String>,
         @RequestParam(required = false) filters: String? = null,
     ): Mono<ResponseEntity<DataFrameVertexPayload>> =
         queryService
-            .getVertices(database, table, key, filters)
+            .getVertices(database, table, id, filters)
             .map { ResponseEntity.ok(DataFrameVertexPayload.from(it)) }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexQueryController.kt
@@ -19,7 +19,7 @@ class VertexQueryController(
     fun getVertices(
         @PathVariable database: String,
         @PathVariable table: String,
-        @RequestParam id: List<String>,
+        @RequestParam id: List<Any>,
         @RequestParam(required = false) filters: String? = null,
     ): Mono<ResponseEntity<DataFrameVertexPayload>> =
         queryService

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.v2.core.code.Index as V2Index
 import com.kakao.actionbase.v2.core.metadata.DirectionType as V2DirectionType
 import com.kakao.actionbase.v2.core.types.Field as V2Field
 
+import com.kakao.actionbase.core.Constants.VERTEX_TARGET_COMMENT
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.metadata.common.MutationMode
 import com.kakao.actionbase.server.api.graph.v3.metadata.V3MetadataConverter.toV2DataType
@@ -61,23 +62,34 @@ data class TableCreateRequest(
                         },
                 )
             }
+            is ModelSchema.Vertex ->
+                EdgeSchema(
+                    VertexField(schema.id.type.toV2VertexType(), schema.id.comment),
+                    VertexField(com.kakao.actionbase.v2.core.types.VertexType.STRING, VERTEX_TARGET_COMMENT),
+                    schema.properties.map {
+                        V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
+                    },
+                )
         }
 
     fun toV2DirectionType(): V2DirectionType =
         when (schema) {
             is ModelSchema.Edge -> schema.direction.toV2DirectionType()
             is ModelSchema.MultiEdge -> schema.direction.toV2DirectionType()
+            is ModelSchema.Vertex -> V2DirectionType.OUT
         }
 
     fun toV2Indices(): List<V2Index> =
         when (schema) {
             is ModelSchema.Edge -> schema.indexes.map { it.toV2Index() }
             is ModelSchema.MultiEdge -> schema.indexes.map { it.toV2Index() }
+            is ModelSchema.Vertex -> emptyList()
         }
 
     fun labelType(): LabelType =
         when (schema) {
             is ModelSchema.Edge -> LabelType.INDEXED
             is ModelSchema.MultiEdge -> LabelType.MULTI_EDGE
+            is ModelSchema.Vertex -> LabelType.VERTEX
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -46,6 +46,7 @@ data class TableUpdateRequest(
                             },
                     )
                 }
+                is ModelSchema.Vertex -> null
             }
         }
 
@@ -54,6 +55,7 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.indexes.map { idx -> idx.toV2Index() }
                 is ModelSchema.MultiEdge -> it.indexes.map { idx -> idx.toV2Index() }
+                is ModelSchema.Vertex -> emptyList()
             }
         }
 
@@ -62,6 +64,7 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.groups
                 is ModelSchema.MultiEdge -> it.groups
+                is ModelSchema.Vertex -> emptyList()
             }
         }
 
@@ -70,6 +73,7 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.caches
                 is ModelSchema.MultiEdge -> it.caches
+                is ModelSchema.Vertex -> emptyList()
             }
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -55,7 +55,9 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.indexes.map { idx -> idx.toV2Index() }
                 is ModelSchema.MultiEdge -> it.indexes.map { idx -> idx.toV2Index() }
-                is ModelSchema.Vertex -> emptyList()
+                // Vertex has no indices; return null so LabelUpdateRequest treats it as no-op
+                // instead of overwriting any existing serialized list with `[]`.
+                is ModelSchema.Vertex -> null
             }
         }
 
@@ -64,7 +66,7 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.groups
                 is ModelSchema.MultiEdge -> it.groups
-                is ModelSchema.Vertex -> emptyList()
+                is ModelSchema.Vertex -> null
             }
         }
 
@@ -73,7 +75,7 @@ data class TableUpdateRequest(
             when (it) {
                 is ModelSchema.Edge -> it.caches
                 is ModelSchema.MultiEdge -> it.caches
-                is ModelSchema.Vertex -> emptyList()
+                is ModelSchema.Vertex -> null
             }
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -113,11 +113,13 @@ class V3CompatService(
             when (val s = request.schema) {
                 is ModelSchema.Edge -> s.groups
                 is ModelSchema.MultiEdge -> s.groups
+                is ModelSchema.Vertex -> emptyList()
             }
         val caches =
             when (val s = request.schema) {
                 is ModelSchema.Edge -> s.caches
                 is ModelSchema.MultiEdge -> s.caches
+                is ModelSchema.Vertex -> emptyList()
             }
         val v2Request =
             V2LabelCreateRequest(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
@@ -76,9 +76,22 @@ object V3MetadataConverter {
             comment = desc,
         )
 
+    fun LabelEntity.toV3TableDescriptorVertex(tenant: String): TableDescriptor.Vertex =
+        TableDescriptor.Vertex(
+            tenant = tenant,
+            database = name.service,
+            table = name.nameNotNull,
+            schema = schema.toV3ModelSchemaVertex(),
+            mode = mode.toV3MutationMode(),
+            storage = storage,
+            active = active,
+            comment = desc,
+        )
+
     fun LabelEntity.toV3TableDescriptor(tenant: String): TableDescriptor<*> =
         when (type) {
             LabelType.MULTI_EDGE -> toV3TableDescriptorMultiEdge(tenant)
+            LabelType.VERTEX -> toV3TableDescriptorVertex(tenant)
             else -> toV3TableDescriptorEdge(tenant)
         }
 
@@ -176,6 +189,12 @@ object V3MetadataConverter {
     // endregion
 
     // region Schema conversion (V3 ModelSchema <-> V2 EdgeSchema)
+
+    fun EdgeSchema.toV3ModelSchemaVertex(): ModelSchema.Vertex =
+        ModelSchema.Vertex(
+            id = V3Field(type = src.type.toV3PrimitiveType(), comment = src.desc),
+            properties = fields.map { it.toV3StructField() },
+        )
 
     fun EdgeSchema.toV3ModelSchemaEdge(
         direction: V3DirectionType,

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType
 class VertexIntegrationTest : E2ETestBase() {
     private val db = "vertex-db"
     private val vertexTable = "users"
+    private val longIdTable = "users_long"
 
     @BeforeAll
     fun setup() {
@@ -44,6 +45,31 @@ class VertexIntegrationTest : E2ETestBase() {
                   "storage": "datastore://vertex_ns/users",
                   "mode": "SYNC",
                   "comment": "users vertex table"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        // 3. Create vertex table with LONG id (regression: id must round-trip as Long)
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$longIdTable",
+                  "schema": {
+                    "type": "VERTEX",
+                    "id": {"type": "long", "comment": "numeric user id"},
+                    "properties": [
+                      {"name": "name", "type": "string", "comment": "user name"}
+                    ]
+                  },
+                  "storage": "datastore://vertex_ns/users_long",
+                  "mode": "SYNC",
+                  "comment": "users vertex table with numeric id"
                 }
                 """.trimIndent(),
             ).exchange()
@@ -204,5 +230,44 @@ class VertexIntegrationTest : E2ETestBase() {
             .expectBody()
             .jsonPath("$.vertices.length()")
             .isEqualTo(0)
+    }
+
+    @Test
+    fun `test vertex with LONG id type`() {
+        // Insert a vertex with numeric id; the id arrives in JSON as a number, not a string.
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$longIdTable/vertices")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "vertex": {"version": 1, "id": 100, "properties": {"name": "Alice"}}},
+                    {"type": "INSERT", "vertex": {"version": 1, "id": 200, "properties": {"name": "Bob"}}}
+                  ]
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results.length()")
+            .isEqualTo(2)
+
+        // Multi-Get with numeric ids over query string. Spring binds List<Any> from comma-split.
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$longIdTable/vertices/get?id=100,200,300")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.vertices.length()")
+            .isEqualTo(2)
+            .jsonPath("$.vertices[0].id")
+            .isEqualTo(100)
+            .jsonPath("$.vertices[1].id")
+            .isEqualTo(200)
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
@@ -99,7 +99,7 @@ class VertexIntegrationTest : E2ETestBase() {
         // 2. Get vertices (Multi-Get)
         client
             .get()
-            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1,user2,user3")
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?id=user1,user2,user3")
             .exchange()
             .expectStatus()
             .isOk
@@ -151,7 +151,7 @@ class VertexIntegrationTest : E2ETestBase() {
         // 4. Get updated vertex
         client
             .get()
-            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1")
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?id=user1")
             .exchange()
             .expectStatus()
             .isOk
@@ -197,7 +197,7 @@ class VertexIntegrationTest : E2ETestBase() {
         // 6. Get deleted vertex (should be empty since active = false)
         client
             .get()
-            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1")
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?id=user1")
             .exchange()
             .expectStatus()
             .isOk

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.api.graph.v3
 
 import com.kakao.actionbase.server.test.E2ETestBase
+
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -44,7 +45,7 @@ class VertexIntegrationTest : E2ETestBase() {
                   "mode": "SYNC",
                   "comment": "users vertex table"
                 }
-                """.trimIndent()
+                """.trimIndent(),
             ).exchange()
             .expectStatus()
             .isOk
@@ -79,16 +80,21 @@ class VertexIntegrationTest : E2ETestBase() {
                     }
                   ]
                 }
-                """.trimIndent()
+                """.trimIndent(),
             ).exchange()
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.results.length()").isEqualTo(2)
-            .jsonPath("$.results[0].status").isEqualTo("CREATED")
-            .jsonPath("$.results[0].id").isEqualTo("user1")
-            .jsonPath("$.results[1].status").isEqualTo("CREATED")
-            .jsonPath("$.results[1].id").isEqualTo("user2")
+            .jsonPath("$.results.length()")
+            .isEqualTo(2)
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[0].id")
+            .isEqualTo("user1")
+            .jsonPath("$.results[1].status")
+            .isEqualTo("CREATED")
+            .jsonPath("$.results[1].id")
+            .isEqualTo("user2")
 
         // 2. Get vertices (Multi-Get)
         client
@@ -98,13 +104,20 @@ class VertexIntegrationTest : E2ETestBase() {
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.vertices.length()").isEqualTo(2)
-            .jsonPath("$.vertices[0].id").isEqualTo("user1")
-            .jsonPath("$.vertices[0].properties.name").isEqualTo("Alice")
-            .jsonPath("$.vertices[0].properties.age").isEqualTo(20)
-            .jsonPath("$.vertices[1].id").isEqualTo("user2")
-            .jsonPath("$.vertices[1].properties.name").isEqualTo("Bob")
-            .jsonPath("$.vertices[1].properties.age").isEqualTo(25)
+            .jsonPath("$.vertices.length()")
+            .isEqualTo(2)
+            .jsonPath("$.vertices[0].id")
+            .isEqualTo("user1")
+            .jsonPath("$.vertices[0].properties.name")
+            .isEqualTo("Alice")
+            .jsonPath("$.vertices[0].properties.age")
+            .isEqualTo(20)
+            .jsonPath("$.vertices[1].id")
+            .isEqualTo("user2")
+            .jsonPath("$.vertices[1].properties.name")
+            .isEqualTo("Bob")
+            .jsonPath("$.vertices[1].properties.age")
+            .isEqualTo(25)
 
         // 3. Update vertex
         client
@@ -125,13 +138,15 @@ class VertexIntegrationTest : E2ETestBase() {
                     }
                   ]
                 }
-                """.trimIndent()
+                """.trimIndent(),
             ).exchange()
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.results.length()").isEqualTo(1)
-            .jsonPath("$.results[0].status").isEqualTo("UPDATED")
+            .jsonPath("$.results.length()")
+            .isEqualTo(1)
+            .jsonPath("$.results[0].status")
+            .isEqualTo("UPDATED")
 
         // 4. Get updated vertex
         client
@@ -141,10 +156,14 @@ class VertexIntegrationTest : E2ETestBase() {
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.vertices.length()").isEqualTo(1)
-            .jsonPath("$.vertices[0].id").isEqualTo("user1")
-            .jsonPath("$.vertices[0].properties.name").isEqualTo("Alice In Wonderland")
-            .jsonPath("$.vertices[0].properties.age").isEqualTo(21)
+            .jsonPath("$.vertices.length()")
+            .isEqualTo(1)
+            .jsonPath("$.vertices[0].id")
+            .isEqualTo("user1")
+            .jsonPath("$.vertices[0].properties.name")
+            .isEqualTo("Alice In Wonderland")
+            .jsonPath("$.vertices[0].properties.age")
+            .isEqualTo(21)
 
         // 5. Delete vertex
         client
@@ -165,13 +184,15 @@ class VertexIntegrationTest : E2ETestBase() {
                     }
                   ]
                 }
-                """.trimIndent()
+                """.trimIndent(),
             ).exchange()
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.results.length()").isEqualTo(1)
-            .jsonPath("$.results[0].status").isEqualTo("DELETED")
+            .jsonPath("$.results.length()")
+            .isEqualTo(1)
+            .jsonPath("$.results[0].status")
+            .isEqualTo("DELETED")
 
         // 6. Get deleted vertex (should be empty since active = false)
         client
@@ -181,6 +202,7 @@ class VertexIntegrationTest : E2ETestBase() {
             .expectStatus()
             .isOk
             .expectBody()
-            .jsonPath("$.vertices.length()").isEqualTo(0)
+            .jsonPath("$.vertices.length()")
+            .isEqualTo(0)
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
@@ -1,0 +1,186 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VertexIntegrationTest : E2ETestBase() {
+    private val db = "vertex-db"
+    private val vertexTable = "users"
+
+    @BeforeAll
+    fun setup() {
+        // 1. Create database
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "vertex integration test db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        // 2. Create vertex table
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$vertexTable",
+                  "schema": {
+                    "type": "VERTEX",
+                    "id": {"type": "string", "comment": "user unique key"},
+                    "properties": [
+                      {"name": "name", "type": "string", "comment": "user name"},
+                      {"name": "age", "type": "long", "comment": "user age", "nullable": true}
+                    ]
+                  },
+                  "storage": "datastore://vertex_ns/users",
+                  "mode": "SYNC",
+                  "comment": "users vertex table"
+                }
+                """.trimIndent()
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `test vertex mutations and get queries`() {
+        // 1. Insert vertices
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {
+                      "type": "INSERT",
+                      "vertex": {
+                        "version": 1,
+                        "id": "user1",
+                        "properties": {"name": "Alice", "age": 20}
+                      }
+                    },
+                    {
+                      "type": "INSERT",
+                      "vertex": {
+                        "version": 1,
+                        "id": "user2",
+                        "properties": {"name": "Bob", "age": 25}
+                      }
+                    }
+                  ]
+                }
+                """.trimIndent()
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results.length()").isEqualTo(2)
+            .jsonPath("$.results[0].status").isEqualTo("CREATED")
+            .jsonPath("$.results[0].id").isEqualTo("user1")
+            .jsonPath("$.results[1].status").isEqualTo("CREATED")
+            .jsonPath("$.results[1].id").isEqualTo("user2")
+
+        // 2. Get vertices (Multi-Get)
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1,user2,user3")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.vertices.length()").isEqualTo(2)
+            .jsonPath("$.vertices[0].id").isEqualTo("user1")
+            .jsonPath("$.vertices[0].properties.name").isEqualTo("Alice")
+            .jsonPath("$.vertices[0].properties.age").isEqualTo(20)
+            .jsonPath("$.vertices[1].id").isEqualTo("user2")
+            .jsonPath("$.vertices[1].properties.name").isEqualTo("Bob")
+            .jsonPath("$.vertices[1].properties.age").isEqualTo(25)
+
+        // 3. Update vertex
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {
+                      "type": "UPDATE",
+                      "vertex": {
+                        "version": 2,
+                        "id": "user1",
+                        "properties": {"name": "Alice In Wonderland", "age": 21}
+                      }
+                    }
+                  ]
+                }
+                """.trimIndent()
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results.length()").isEqualTo(1)
+            .jsonPath("$.results[0].status").isEqualTo("UPDATED")
+
+        // 4. Get updated vertex
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.vertices.length()").isEqualTo(1)
+            .jsonPath("$.vertices[0].id").isEqualTo("user1")
+            .jsonPath("$.vertices[0].properties.name").isEqualTo("Alice In Wonderland")
+            .jsonPath("$.vertices[0].properties.age").isEqualTo(21)
+
+        // 5. Delete vertex
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {
+                      "type": "DELETE",
+                      "vertex": {
+                        "version": 3,
+                        "id": "user1",
+                        "properties": {}
+                      }
+                    }
+                  ]
+                }
+                """.trimIndent()
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results.length()").isEqualTo(1)
+            .jsonPath("$.results[0].status").isEqualTo("DELETED")
+
+        // 6. Get deleted vertex (should be empty since active = false)
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$vertexTable/vertices/get?key=user1")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.vertices.length()").isEqualTo(0)
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -412,7 +412,10 @@ class V3MetadataConverterTest {
                 EdgeSchema(
                     idField,
                     targetField,
-                    listOf(com.kakao.actionbase.v2.core.types.Field("name", DataType.STRING, false, "user name")),
+                    listOf(
+                        com.kakao.actionbase.v2.core.types
+                            .Field("name", DataType.STRING, false, "user name"),
+                    ),
                 )
             val v2Entity =
                 LabelEntity(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -38,6 +38,7 @@ import com.kakao.actionbase.v2.engine.entity.ServiceEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 class V3MetadataConverterTest {
     private val tenant = "test-tenant"
@@ -401,6 +402,43 @@ class V3MetadataConverterTest {
             assertThat(schema.caches[0].fields).hasSize(1)
             assertThat(schema.caches[0].fields[0].field).isEqualTo("score")
             assertThat(schema.caches[0].fields[0].order).isEqualTo(V3Order.DESC)
+        }
+
+        @Test
+        fun `LabelType VERTEX LabelEntity is restored as V3TableDescriptor Vertex`() {
+            val idField = VertexField(VertexType.STRING, "user id")
+            val targetField = VertexField(VertexType.STRING, "<vertex>")
+            val edgeSchema =
+                EdgeSchema(
+                    idField,
+                    targetField,
+                    listOf(com.kakao.actionbase.v2.core.types.Field("name", DataType.STRING, false, "user name")),
+                )
+            val v2Entity =
+                LabelEntity(
+                    active = true,
+                    name = EntityName("mydb", "users"),
+                    desc = "vertex table",
+                    type = LabelType.VERTEX,
+                    schema = edgeSchema,
+                    dirType = V2DirectionType.OUT,
+                    storage = "datastore://test_namespace/users",
+                    indices = emptyList(),
+                    groups = emptyList(),
+                    event = false,
+                    readOnly = false,
+                    mode = V2MutationMode.SYNC,
+                )
+
+            val v3Descriptor = v2Entity.toV3TableDescriptor(tenant) as TableDescriptor.Vertex
+            assertThat(v3Descriptor.tenant).isEqualTo(tenant)
+            assertThat(v3Descriptor.database).isEqualTo("mydb")
+            assertThat(v3Descriptor.table).isEqualTo("users")
+            assertThat(v3Descriptor.active).isTrue()
+            val schema = v3Descriptor.schema
+            assertThat(schema.id.type).isEqualTo(PrimitiveType.STRING)
+            assertThat(schema.properties).hasSize(1)
+            assertThat(schema.properties[0].name).isEqualTo("name")
         }
     }
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -38,7 +38,6 @@ import com.kakao.actionbase.v2.engine.entity.ServiceEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 
 class V3MetadataConverterTest {
     private val tenant = "test-tenant"
@@ -404,28 +403,61 @@ class V3MetadataConverterTest {
             assertThat(schema.caches[0].fields[0].order).isEqualTo(V3Order.DESC)
         }
 
-        @Test
-        fun `LabelType VERTEX LabelEntity is restored as V3TableDescriptor Vertex`() {
-            val idField = VertexField(VertexType.STRING, "user id")
-            val targetField = VertexField(VertexType.STRING, "<vertex>")
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - database: mydb
+              table: users
+              idType: STRING
+              idComment: user id
+              propertyName: name
+              propertyType: STRING
+              propertyNullable: false
+              propertyComment: user name
+              storage: "datastore://test_namespace/users"
+              comment: vertex table
+            - database: mydb
+              table: users_long
+              idType: LONG
+              idComment: numeric user id
+              propertyName: score
+              propertyType: INT
+              propertyNullable: true
+              propertyComment: user score
+              storage: "datastore://test_namespace/users_long"
+              comment: vertex table with numeric id
+            """,
+        )
+        fun `LabelType VERTEX LabelEntity is restored as V3TableDescriptor Vertex`(
+            database: String,
+            table: String,
+            idType: String,
+            idComment: String,
+            propertyName: String,
+            propertyType: String,
+            propertyNullable: Boolean,
+            propertyComment: String,
+            storage: String,
+            comment: String,
+        ) {
             val edgeSchema =
                 EdgeSchema(
-                    idField,
-                    targetField,
+                    VertexField(VertexType.valueOf(idType), idComment),
+                    VertexField(VertexType.STRING, "<vertex>"),
                     listOf(
                         com.kakao.actionbase.v2.core.types
-                            .Field("name", DataType.STRING, false, "user name"),
+                            .Field(propertyName, DataType.valueOf(propertyType), propertyNullable, propertyComment),
                     ),
                 )
             val v2Entity =
                 LabelEntity(
                     active = true,
-                    name = EntityName("mydb", "users"),
-                    desc = "vertex table",
+                    name = EntityName(database, table),
+                    desc = comment,
                     type = LabelType.VERTEX,
                     schema = edgeSchema,
                     dirType = V2DirectionType.OUT,
-                    storage = "datastore://test_namespace/users",
+                    storage = storage,
                     indices = emptyList(),
                     groups = emptyList(),
                     event = false,
@@ -435,13 +467,19 @@ class V3MetadataConverterTest {
 
             val v3Descriptor = v2Entity.toV3TableDescriptor(tenant) as TableDescriptor.Vertex
             assertThat(v3Descriptor.tenant).isEqualTo(tenant)
-            assertThat(v3Descriptor.database).isEqualTo("mydb")
-            assertThat(v3Descriptor.table).isEqualTo("users")
+            assertThat(v3Descriptor.database).isEqualTo(database)
+            assertThat(v3Descriptor.table).isEqualTo(table)
             assertThat(v3Descriptor.active).isTrue()
+            assertThat(v3Descriptor.comment).isEqualTo(comment)
+            assertThat(v3Descriptor.storage).isEqualTo(storage)
+
             val schema = v3Descriptor.schema
-            assertThat(schema.id.type).isEqualTo(PrimitiveType.STRING)
+            assertThat(schema.id.type).isEqualTo(PrimitiveType.valueOf(idType))
+            assertThat(schema.id.comment).isEqualTo(idComment)
             assertThat(schema.properties).hasSize(1)
-            assertThat(schema.properties[0].name).isEqualTo("name")
+            assertThat(schema.properties[0].name).isEqualTo(propertyName)
+            assertThat(schema.properties[0].nullable).isEqualTo(propertyNullable)
+            assertThat(schema.properties[0].comment).isEqualTo(propertyComment)
         }
     }
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -174,6 +174,7 @@ class ReadOnlyRequestFilterTest {
                 "GET /graph/v3/databases/{database}/tables/{table}/edges/get",
                 "GET /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}",
                 "GET /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",
+                "GET /graph/v3/databases/{database}/tables/{table}/vertices/get",
                 "GET /graph/v3/datastore",
                 // read-only POST
                 "POST /graph/v3/query",
@@ -227,6 +228,8 @@ class ReadOnlyRequestFilterTest {
                 "POST /graph/v3/databases/{database}/tables/{table}/edges/sync",
                 "POST /graph/v3/databases/{database}/tables/{table}/multi-edges",
                 "POST /graph/v3/databases/{database}/tables/{table}/multi-edges/sync",
+                "POST /graph/v3/databases/{database}/tables/{table}/vertices",
+                "POST /graph/v3/databases/{database}/tables/{table}/vertices/sync",
                 "PUT /graph/v3/databases/{database}",
                 "PUT /graph/v3/databases/{database}/aliases/{alias}",
                 "PUT /graph/v3/databases/{database}/tables/{table}",


### PR DESCRIPTION
## Summary

Add `Vertex` as a first-class entity type alongside `Edge` and `MultiEdge`. Vertex reuses the existing `EdgeState` encoding with `source=key, target="-"` (VERTEX_MARKER), so existing storage format and encoding pipeline are shared.

Key design decisions:
- `LabelType.VERTEX` added to codec-java so Vertex is identified by type. 
- `EdgeMutationStrategy.Vertex` suppresses all EdgeCount writes (`producesCount = false`)

Closes #361

## Changes

- **codec-java**: `LabelType.VERTEX`, `BulkEdgeEncoder` encodes State only (no index, no counter)
- **core**: `ModelSchema.Vertex`, `TableDescriptor.Vertex`, `EdgeMutationStrategy.Vertex`, `VertexBulkMutationRequest`, `VertexMutationResponse`, `DataFrameVertexPayload`
- **engine**: `V3TableDescriptor.create()` restores `LabelType.VERTEX → V3TableDescriptor.Vertex` on reload; `V2BackedTableBinding` routes Vertex to `buildForVertex()`
- **server**: `VertexMutationController` (`POST /vertices`, `POST /vertices/sync`), `VertexQueryController` (`GET /vertices/get`), schema/DDL wiring in `TableCreateRequest`, `V3CompatService`, `V3MetadataConverter`

## How to Test

```bash
./gradlew test
```

New test coverage:
- `VertexBulkMutationRequestTest`: `createEvent` — source=id, target=VERTEX_MARKER, nullability validation, reserved id guard
- `EdgeMutationStrategyTest` / `EdgeMutationBuilderTest`: `Vertex` strategy — `producesCount=false`, no count records on CREATED/UPDATED/DELETED
- `BulkEdgeEncoderTests`: active/inactive Vertex → State only, no counter rows
- `V3MetadataConverterTest`: `LabelType.VERTEX` → `TableDescriptor.Vertex` round-trip
- `MutationServiceSpec`: Vertex insert/update/delete/get engine-level flow
- `VertexIntegrationTest`: full E2E — table create, mutation, get, update, delete

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (claude-sonnet-4-6)