### PR TITLE
Remove leftover println in TokenAuthenticationFilter.warmUp

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/filter/TokenAuthenticationFilter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/filter/TokenAuthenticationFilter.kt
@@ -47,7 +47,6 @@ class TokenAuthenticationFilter(
     }
 
     fun warmUp() {
-        println("warming up token cache...")
         customTokenFilter?.warmUp()
     }
 }


### PR DESCRIPTION
## Summary

Drop a leftover `println` in `TokenAuthenticationFilter.warmUp()`.

Closes #

## Changes

- Remove `println("warming up token cache...")` from `warmUp()`.

## How to Test

`./gradlew :server:build`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)