### PR TITLE
Add tolerance to cache metadata

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/Cache.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/Cache.kt
@@ -9,10 +9,12 @@ data class Cache(
     val cache: String,
     val fields: List<CacheField>,
     val limit: Int = 100,
+    val tolerance: Int = limit * 2,
     val comment: String = Constants.DEFAULT_COMMENT,
 ) {
     init {
         require(limit > 0) { "Cache limit must be positive, got: $limit" }
+        require(tolerance > 0) { "Cache tolerance must be positive, got: $tolerance" }
     }
 
     @JsonIgnore

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -5,7 +5,9 @@ import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterized
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Test
 
@@ -308,6 +310,23 @@ class EdgeSchemaSerializationTest {
             """.trimIndent()
 
         assertEquals(100, objectMapper.readValue<Cache>(json).tolerance)
+    }
+
+    @Test
+    fun `cache with explicit null tolerance is rejected`() {
+        val json =
+            """
+            {
+              "cache": "created_at_desc",
+              "fields": [{"field": "version", "order": "DESC"}],
+              "limit": 50,
+              "tolerance": null
+            }
+            """.trimIndent()
+
+        assertFailsWith<JsonProcessingException> {
+            objectMapper.readValue<Cache>(json)
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -7,6 +7,7 @@ import com.kakao.actionbase.test.json.PrettyObjectWriter
 import kotlin.test.assertEquals
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
 
 class EdgeSchemaSerializationTest {
     val prettyWriter = PrettyObjectWriter.DEFAULT
@@ -107,6 +108,51 @@ class EdgeSchemaSerializationTest {
                 }
               ]
             }
+        - name: with caches and tolerance
+          input: |-
+            {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "indexes": [
+                {
+                  "index": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}]
+                }
+              ],
+              "groups": [],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "limit": 50,
+                  "tolerance": 30
+                }
+              ]
+            }
+          expected: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "indexes": [
+                {
+                  "index": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}]
+                }
+              ],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "limit": 50,
+                  "tolerance": 30
+                }
+              ]
+            }
         """,
     )
     fun `deserializes edge schema from JSON`(
@@ -170,6 +216,77 @@ class EdgeSchemaSerializationTest {
               "groups": [],
               "caches": []
             }
+        - schema: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "groups": [],
+              "indexes": [],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "limit": 50,
+                  "tolerance": 30
+                }
+              ]
+            }
+          expected: |-
+            {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "indexes": [],
+              "groups": [],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC", "dimension": null}],
+                  "limit": 50,
+                  "tolerance": 30,
+                  "comment": ""
+                }
+              ]
+            }
+        - schema: {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "groups": [],
+              "indexes": [],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC"}],
+                  "limit": 50
+                }
+              ]
+            }
+          expected: |-
+            {
+              "type": "edge",
+              "source": {"type": "long", "comment": "Source node ID"},
+              "target": {"type": "long", "comment": "Target node ID"},
+              "properties": [],
+              "direction": "OUT",
+              "indexes": [],
+              "groups": [],
+              "caches": [
+                {
+                  "cache": "created_at_desc",
+                  "fields": [{"field": "version", "order": "DESC", "dimension": null}],
+                  "limit": 50,
+                  "tolerance": 100,
+                  "comment": ""
+                }
+              ]
+            }
         """,
     )
     fun `serializes edge schema to JSON`(
@@ -177,5 +294,34 @@ class EdgeSchemaSerializationTest {
         expected: String,
     ) {
         assertEquals(expected, prettyWriter.writeValueAsString(schema))
+    }
+
+    @Test
+    fun `cache without tolerance deserializes to limit times 2`() {
+        val json =
+            """
+            {
+              "cache": "created_at_desc",
+              "fields": [{"field": "version", "order": "DESC"}],
+              "limit": 50
+            }
+            """.trimIndent()
+
+        assertEquals(100, objectMapper.readValue<Cache>(json).tolerance)
+    }
+
+    @Test
+    fun `cache with explicit tolerance keeps its value on deserialization`() {
+        val json =
+            """
+            {
+              "cache": "created_at_desc",
+              "fields": [{"field": "version", "order": "DESC"}],
+              "limit": 50,
+              "tolerance": 30
+            }
+            """.trimIndent()
+
+        assertEquals(30, objectMapper.readValue<Cache>(json).tolerance)
     }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -7,9 +7,10 @@ import com.kakao.actionbase.test.json.PrettyObjectWriter
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+import org.junit.jupiter.api.Test
+
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.jupiter.api.Test
 
 class EdgeSchemaSerializationTest {
     val prettyWriter = PrettyObjectWriter.DEFAULT

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -38,6 +38,7 @@ import com.kakao.actionbase.v2.engine.entity.ServiceEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 class V3MetadataConverterTest {
     private val tenant = "test-tenant"
@@ -401,6 +402,69 @@ class V3MetadataConverterTest {
             assertThat(schema.caches[0].fields).hasSize(1)
             assertThat(schema.caches[0].fields[0].field).isEqualTo("score")
             assertThat(schema.caches[0].fields[0].order).isEqualTo(V3Order.DESC)
+        }
+
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - database: mydb
+              table: mytable
+              cacheName: cache1
+              cacheLimit: 50
+              cacheTolerance: 30
+            """,
+        )
+        fun `LabelEntity cache tolerance is preserved when converting to TableDescriptor Edge`(
+            database: String,
+            table: String,
+            cacheName: String,
+            cacheLimit: Int,
+            cacheTolerance: Int,
+        ) {
+            val edgeSchema =
+                EdgeSchema(
+                    VertexField(VertexType.STRING, "source"),
+                    VertexField(VertexType.STRING, "target"),
+                    listOf(
+                        com.kakao.actionbase.v2.core.types
+                            .Field("score", DataType.INT, true, "score field"),
+                    ),
+                )
+            val v2Entity =
+                LabelEntity(
+                    active = true,
+                    name = EntityName(database, table),
+                    desc = "test table",
+                    type = LabelType.INDEXED,
+                    schema = edgeSchema,
+                    dirType = V2DirectionType.OUT,
+                    storage = "datastore://test_namespace/test_table",
+                    indices = emptyList(),
+                    groups = emptyList(),
+                    caches =
+                        listOf(
+                            Cache(
+                                cache = cacheName,
+                                fields = listOf(CacheField("score", V3Order.DESC)),
+                                limit = cacheLimit,
+                                tolerance = cacheTolerance,
+                            ),
+                        ),
+                    event = false,
+                    readOnly = false,
+                    mode = V2MutationMode.SYNC,
+                )
+
+            val v3Descriptor = v2Entity.toV3TableDescriptor(tenant) as TableDescriptor.Edge
+            val schema = v3Descriptor.schema
+            assertThat(schema.caches).hasSize(1)
+            assertThat(schema.caches[0].tolerance).isEqualTo(cacheTolerance)
+        }
+
+        @Test
+        fun `Cache tolerance defaults to limit times 2 when not set`() {
+            val cache = Cache(cache = "c", fields = emptyList(), limit = 50)
+            assertThat(cache.tolerance).isEqualTo(100)
         }
 
         @ObjectSourceParameterizedTest


### PR DESCRIPTION
## Summary

Adds a `tolerance` field to cache metadata, bounding the margin of concurrent delete/update operations absorbed during cache prune (on top of `limit`).

When absent, `tolerance` defaults to `limit * 2` so older metadata deserializes with a concrete value. An explicit value is kept as-is; an explicit `null` is rejected.

Follows up on #322.

## Changes

- Add `tolerance: Int` to `Cache`, defaulting to `limit * 2`, validated as `> 0`
- Add deserialization and V2 ↔ V3 conversion tests

## How to Test
`./gradlew :core:test :server:test`

## AI Assistance

- [x] This PR was written largely with AI assistance
 - Tool / model: Claude Code (Opus 4.8)

