### PR TITLE
Add BulkLoadVertex to codec-java

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.v2.core.code;
 
 import com.kakao.actionbase.v2.core.edge.BulkLoadEdge;
+import com.kakao.actionbase.v2.core.edge.BulkLoadVertex;
 import com.kakao.actionbase.v2.core.edge.Edge;
 import com.kakao.actionbase.v2.core.metadata.Active;
 import com.kakao.actionbase.v2.core.metadata.Direction;
@@ -34,6 +35,24 @@ public class BulkEdgeEncoder {
 
   static final String SOURCE_FIELD_ON_STATE = "_source";
   static final String TARGET_FIELD_ON_STATE = "_target";
+
+  /**
+   * Encode a Vertex bulk-load row.
+   *
+   * <p>Lowers {@link BulkLoadVertex} into a {@link BulkLoadEdge} ({@code src=id,
+   * tgt=VERTEX_MARKER}) and dispatches through {@link #bulkEncodeAll(EdgeEncoder, BulkLoadEdge,
+   * LabelDTO)}. The label type is asserted up-front so callers cannot mistakenly write vertex
+   * payloads into a non-vertex table — that would silently corrupt the edge keyspace with a row at
+   * {@code target="-"}.
+   */
+  public static <T> List<TypedKeyFieldValue<T>> bulkEncodeVertex(
+      EdgeEncoder<T> encoder, BulkLoadVertex bulkLoadVertex, LabelDTO label) {
+    if (label.getType() != LabelType.VERTEX) {
+      throw new IllegalArgumentException(
+          "bulkEncodeVertex requires a VERTEX label, got " + label.getType());
+    }
+    return bulkEncodeAll(encoder, bulkLoadVertex.toBulkLoadEdge(), label);
+  }
 
   public static <T> List<TypedKeyFieldValue<T>> bulkEncodeAll(
       EdgeEncoder<T> encoder, BulkLoadEdge bulkLoadEdge, LabelDTO label) {

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/BulkLoadVertex.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/BulkLoadVertex.java
@@ -1,0 +1,111 @@
+package com.kakao.actionbase.v2.core.edge;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Bulk-load input for a Vertex row.
+ *
+ * <p>Mirrors {@link BulkLoadEdge} but exposes the vertex contract — a single {@code id} and
+ * properties — instead of leaking the {@code (src, tgt="-")} encoding. {@code BulkEdgeEncoder}
+ * converts this into a {@code BulkLoadEdge} with {@code src=id, tgt=VERTEX_MARKER} before
+ * delegating to the shared encoding pipeline.
+ *
+ * <p>JSON shape:
+ *
+ * <pre>{"active": true, "ts": 1, "id": "user1", "props": {...}}</pre>
+ */
+public class BulkLoadVertex {
+
+  /**
+   * Reserved value used as the encoded {@code target} of a vertex row. Mirrors {@code
+   * com.kakao.actionbase.core.Constants.VERTEX_MARKER} from the Kotlin core module — kept in sync
+   * because codec-java is Java 8 and cannot depend on core.
+   */
+  public static final String VERTEX_MARKER = "-";
+
+  @JsonProperty(required = true)
+  final boolean active;
+
+  @JsonProperty(required = true)
+  final long ts;
+
+  @JsonProperty(required = true)
+  final Object id;
+
+  @JsonProperty final Map<String, Object> props;
+
+  @JsonCreator
+  public BulkLoadVertex(
+      @JsonProperty(value = "active", required = true) boolean active,
+      @JsonProperty(value = "ts", required = true) long ts,
+      @JsonProperty(value = "id", required = true) Object id,
+      @JsonProperty(value = "props") Map<String, Object> props) {
+    Objects.requireNonNull(id, "vertex id must not be null");
+    if (VERTEX_MARKER.equals(id.toString())) {
+      throw new IllegalArgumentException(
+          "Vertex id cannot be '" + VERTEX_MARKER + "' (reserved marker)");
+    }
+    this.active = active;
+    this.ts = ts;
+    this.id = id;
+    // Match BulkLoadEdge / Edge: props is never null on the instance, so callers don't NPE on
+    // getProps() before the value reaches the encoder.
+    this.props = props != null ? props : Collections.emptyMap();
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public long getTs() {
+    return ts;
+  }
+
+  public Object getId() {
+    return id;
+  }
+
+  public Map<String, Object> getProps() {
+    return props;
+  }
+
+  /**
+   * Lower this vertex into the shared {@link BulkLoadEdge} representation: {@code src=id,
+   * tgt=VERTEX_MARKER}. The encoder pipeline keys all vertex behaviour off the LabelType, so the
+   * concrete edge object is just a vehicle for the property map.
+   */
+  public BulkLoadEdge toBulkLoadEdge() {
+    return new BulkLoadEdge(active, ts, id, VERTEX_MARKER, props);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof BulkLoadVertex)) return false;
+    BulkLoadVertex that = (BulkLoadVertex) o;
+    return active == that.active && ts == that.ts && id.equals(that.id) && props.equals(that.props);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(active, ts, id, props);
+  }
+
+  @Override
+  public String toString() {
+    return "BulkLoadVertex(active="
+        + active
+        + ", ts="
+        + ts
+        + ", id="
+        + id
+        + ", props="
+        + props
+        + ')';
+  }
+}

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -3,6 +3,7 @@ package com.kakao.actionbase.v2.core.code;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.kakao.actionbase.v2.core.edge.BulkLoadEdge;
+import com.kakao.actionbase.v2.core.edge.BulkLoadVertex;
 import com.kakao.actionbase.v2.core.edge.Edge;
 import com.kakao.actionbase.v2.core.metadata.Direction;
 import com.kakao.actionbase.v2.core.metadata.EncodedEdgeType;
@@ -463,6 +464,105 @@ public class BulkEdgeEncoderTests {
     // Vertex: State only — 1 hash row, no index, no counter
     assertEquals(1, encodedEdges.size());
     assertEquals(EncodedEdgeType.HASH_EDGE_TYPE, encodedEdges.get(0).getEncodedEdgeType());
+  }
+
+  // bulkEncodeVertex: lowers (id, props) into BulkLoadEdge(src=id, tgt="-") and produces
+  // exactly the same single hash row as the legacy entry point — no index, no counter.
+  @Test
+  void testBulkEncodeVertexActiveProducesStateOnly() throws JsonProcessingException {
+    String vertexLabelJson =
+        labelJsonString
+            .replace("\"type\":\"INDEXED\"", "\"type\":\"VERTEX\"")
+            .replace("\"dirType\":\"BOTH\"", "\"dirType\":\"OUT\"")
+            .replace(
+                "\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}]",
+                "\"indices\":[]")
+            .replace(
+                ",\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+                "");
+    LabelDTO label = objectMapper.readValue(vertexLabelJson, LabelDTO.class);
+    LabelDTO newLabel = label.copy("vertex_table_20240101", "vertex_table_20240101");
+
+    String vertexJson =
+        "{\"active\":true,\"ts\":1,\"id\":123,\"props\":{\"created_at\":1,\"permission\":\"public\",\"memo\":\"hi\"}}";
+    BulkLoadVertex vertex = objectMapper.readValue(vertexJson, BulkLoadVertex.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeVertex(encoder, vertex, newLabel);
+
+    assertEquals(1, encodedEdges.size());
+    assertEquals(EncodedEdgeType.HASH_EDGE_TYPE, encodedEdges.get(0).getEncodedEdgeType());
+
+    // Decoded row carries src=id and tgt=VERTEX_MARKER — the on-wire vertex shape.
+    DecodedEdge decoded =
+        DecodedEdge.from(KeyFieldValue.from(encodedEdges.get(0)), Collections.emptyMap());
+    assertEquals(123L, decoded.getSrc());
+    assertEquals(BulkLoadVertex.VERTEX_MARKER, decoded.getTgt());
+  }
+
+  // bulkEncodeVertex on an inactive vertex emits a single hash tombstone — same as the legacy
+  // path, but without the caller having to know about VERTEX_MARKER.
+  @Test
+  void testBulkEncodeVertexInactiveProducesHashTombstoneOnly() throws JsonProcessingException {
+    String vertexLabelJson =
+        labelJsonString
+            .replace("\"type\":\"INDEXED\"", "\"type\":\"VERTEX\"")
+            .replace("\"dirType\":\"BOTH\"", "\"dirType\":\"OUT\"")
+            .replace(
+                "\"indices\":[{\"id\":0,\"name\":\"created_at_desc\",\"fields\":[{\"name\":\"created_at\",\"order\":\"DESC\"}]}]",
+                "\"indices\":[]")
+            .replace(
+                ",\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+                "");
+    LabelDTO label = objectMapper.readValue(vertexLabelJson, LabelDTO.class);
+    LabelDTO newLabel = label.copy("vertex_table_20240101", "vertex_table_20240101");
+
+    String vertexJson = "{\"active\":false,\"ts\":1,\"id\":123,\"props\":{\"created_at\":1}}";
+    BulkLoadVertex vertex = objectMapper.readValue(vertexJson, BulkLoadVertex.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeVertex(encoder, vertex, newLabel);
+
+    assertEquals(1, encodedEdges.size());
+    assertEquals(EncodedEdgeType.HASH_EDGE_TYPE, encodedEdges.get(0).getEncodedEdgeType());
+
+    // The tombstone row must still carry the on-wire vertex shape (src=id, tgt="-").
+    DecodedEdge decoded =
+        DecodedEdge.from(KeyFieldValue.from(encodedEdges.get(0)), Collections.emptyMap());
+    assertEquals(123L, decoded.getSrc());
+    assertEquals(BulkLoadVertex.VERTEX_MARKER, decoded.getTgt());
+  }
+
+  // bulkEncodeVertex must reject non-VERTEX labels; otherwise a vertex payload would silently
+  // be written into an edge table at target="-".
+  @Test
+  void testBulkEncodeVertexRejectsNonVertexLabel() throws JsonProcessingException {
+    LabelDTO indexedLabel = objectMapper.readValue(labelJsonString, LabelDTO.class);
+    BulkLoadVertex vertex = new BulkLoadVertex(true, 1L, 123L, Collections.emptyMap());
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> BulkEdgeEncoder.bulkEncodeVertex(encoder, vertex, indexedLabel));
+    assertTrue(ex.getMessage().contains("VERTEX"));
+  }
+
+  // The reserved marker "-" must never become a vertex id — the encoded row would be
+  // indistinguishable from a tombstone-shaped key.
+  @Test
+  void testBulkLoadVertexRejectsReservedMarkerId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BulkLoadVertex(true, 1L, BulkLoadVertex.VERTEX_MARKER, Collections.emptyMap()));
   }
 
   // VERTEX label: inactive edge → 1 hash tombstone only.


### PR DESCRIPTION
## Summary

Add `BulkLoadVertex` and `BulkEdgeEncoder.bulkEncodeVertex` so external bulk-load jobs (Spark/MR) can encode vertex rows without knowing the `(src, tgt="-")` encoding. Follow-up to #373; surfaced while wiring Spark vertex bulk-load.

## Changes

- `codec-java`: add `BulkLoadVertex` (`{active, ts, id, props}`) — lowers to `BulkLoadEdge(src=id, tgt=VERTEX_MARKER)` for the shared pipeline.
- `codec-java`: add `BulkEdgeEncoder.bulkEncodeVertex` — asserts `LabelType.VERTEX` and rejects `id == "-"`, blocking latent corruption (`tgt="-"` rows landing in edge tables) that would otherwise survive decode.

## How to Test

```bash
./gradlew :codec-java:test :codec-java:spotlessCheck
```

New tests: round-trip decode for active vertex (`src=id, tgt="-"`), inactive tombstone with the same shape, non-vertex label rejection, reserved-marker id rejection.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (claude-opus-4-7)