### PR TITLE
Validate edge schema before bulk encoding

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -63,6 +63,9 @@ public class BulkEdgeEncoder {
     int labelId = label.getId();
     Active active = bulkLoadEdge.isActive() ? Active.ACTIVE : Active.INACTIVE;
     Edge castedEdge = bulkLoadEdge.ensureType(label.getSchema());
+    if (bulkLoadEdge.isActive()) {
+      bulkLoadEdge.validateAgainstSchema(label.getSchema());
+    }
 
     List<TypedKeyFieldValue<T>> edges = new ArrayList<>();
 

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -64,7 +64,7 @@ public class BulkEdgeEncoder {
     Active active = bulkLoadEdge.isActive() ? Active.ACTIVE : Active.INACTIVE;
     Edge castedEdge = bulkLoadEdge.ensureType(label.getSchema());
     if (bulkLoadEdge.isActive()) {
-      bulkLoadEdge.validateAgainstSchema(label.getSchema());
+      bulkLoadEdge.validate(label.getSchema());
     }
 
     List<TypedKeyFieldValue<T>> edges = new ArrayList<>();

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/Edge.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/Edge.java
@@ -60,6 +60,44 @@ public class Edge {
     return props;
   }
 
+  public void validateAgainstSchema(EdgeSchema schema) {
+    for (Field field : schema.getFields()) {
+      String name = field.getName();
+      boolean present = props.containsKey(name);
+      Object raw = present ? props.get(name) : null;
+
+      if (raw != null) {
+        Object casted = field.getType().cast(raw);
+        if (casted == null) {
+          throw new IllegalArgumentException(
+              "Schema validation failed: field '"
+                  + name
+                  + "' value ["
+                  + raw
+                  + "] cannot be cast to "
+                  + field.getType()
+                  + " (type mismatch) "
+                  + identityForError());
+        }
+        continue;
+      }
+
+      if (!field.isNullable()) {
+        throw new IllegalArgumentException(
+            "Schema validation failed: required field '"
+                + name
+                + "' is "
+                + (present ? "null" : "missing")
+                + " "
+                + identityForError());
+      }
+    }
+  }
+
+  private String identityForError() {
+    return "(src=" + src + ", tgt=" + tgt + ", ts=" + ts + ")";
+  }
+
   public Edge ensureType(EdgeSchema schema) {
     Object castedSrc = schema.getSrc().getDataType().castNotNull(src);
     Object castedTgt = schema.getTgt().getDataType().castNotNull(tgt);

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/Edge.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/edge/Edge.java
@@ -60,15 +60,14 @@ public class Edge {
     return props;
   }
 
-  public void validateAgainstSchema(EdgeSchema schema) {
+  public void validate(EdgeSchema schema) {
     for (Field field : schema.getFields()) {
       String name = field.getName();
       boolean present = props.containsKey(name);
       Object raw = present ? props.get(name) : null;
 
       if (raw != null) {
-        Object casted = field.getType().cast(raw);
-        if (casted == null) {
+        if (field.getType().cast(raw) == null) {
           throw new IllegalArgumentException(
               "Schema validation failed: field '"
                   + name
@@ -79,10 +78,7 @@ public class Edge {
                   + " (type mismatch) "
                   + identityForError());
         }
-        continue;
-      }
-
-      if (!field.isNullable()) {
+      } else if (!field.isNullable()) {
         throw new IllegalArgumentException(
             "Schema validation failed: required field '"
                 + name

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -437,6 +437,44 @@ public class BulkEdgeEncoderTests {
     return a.length - b.length;
   }
 
+  @Test
+  void shouldRejectBulkEncodeWhenRequiredFieldIsNull() throws JsonProcessingException {
+    LabelDTO label = objectMapper.readValue(labelJsonString, LabelDTO.class);
+    LabelDTO newLabel =
+        label.copy("gift.like_product_v1_20240402_132500", "gift.like_product_v1_20240402_132500");
+
+    String invalidEdgeJson = edgeJsonString.replace("\"created_at\":1", "\"created_at\":null");
+    BulkLoadEdge edge = objectMapper.readValue(invalidEdgeJson, BulkLoadEdge.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel));
+    assertTrue(ex.getMessage().contains("created_at"), ex.getMessage());
+  }
+
+  @Test
+  void shouldRejectBulkEncodeWhenRequiredFieldIsMissing() throws JsonProcessingException {
+    LabelDTO label = objectMapper.readValue(labelJsonString, LabelDTO.class);
+    LabelDTO newLabel =
+        label.copy("gift.like_product_v1_20240402_132500", "gift.like_product_v1_20240402_132500");
+
+    String invalidEdgeJson = edgeJsonString.replace("\"created_at\":1, ", "");
+    BulkLoadEdge edge = objectMapper.readValue(invalidEdgeJson, BulkLoadEdge.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel));
+    assertTrue(ex.getMessage().contains("created_at"), ex.getMessage());
+  }
+
   // VERTEX label: active edge → State only (1 hash row). No index, no counter.
   @Test
   void testVertexActiveEdgeProducesStateOnly() throws JsonProcessingException {

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
@@ -52,8 +52,7 @@ public class EdgeValidationTest {
     props.put("rank", 1);
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(
-            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
   }
@@ -64,8 +63,7 @@ public class EdgeValidationTest {
     props.put("score", null);
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(
-            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("null"), ex.getMessage());
   }
@@ -76,8 +74,7 @@ public class EdgeValidationTest {
     props.put("score", "not-a-long");
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(
-            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
   }
@@ -90,8 +87,7 @@ public class EdgeValidationTest {
     props.put("rank", "not-an-int");
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(
-            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
     assertTrue(ex.getMessage().contains("rank"), ex.getMessage());
     assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
   }

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
@@ -25,7 +25,7 @@ public class EdgeValidationTest {
     Map<String, Object> props = new HashMap<>();
     props.put("score", 42L);
     Edge edge = new Edge(1L, 1L, "tgt", props);
-    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+    assertDoesNotThrow(() -> edge.validate(SCHEMA));
   }
 
   @Test
@@ -34,7 +34,7 @@ public class EdgeValidationTest {
     props.put("score", 42L);
     // "rank" not present — nullable, so OK
     Edge edge = new Edge(1L, 1L, "tgt", props);
-    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+    assertDoesNotThrow(() -> edge.validate(SCHEMA));
   }
 
   @Test
@@ -43,7 +43,7 @@ public class EdgeValidationTest {
     props.put("score", 42L);
     props.put("rank", null);
     Edge edge = new Edge(1L, 1L, "tgt", props);
-    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+    assertDoesNotThrow(() -> edge.validate(SCHEMA));
   }
 
   @Test
@@ -52,7 +52,7 @@ public class EdgeValidationTest {
     props.put("rank", 1);
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validate(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
   }
@@ -63,7 +63,7 @@ public class EdgeValidationTest {
     props.put("score", null);
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validate(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("null"), ex.getMessage());
   }
@@ -74,7 +74,7 @@ public class EdgeValidationTest {
     props.put("score", "not-a-long");
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validate(SCHEMA));
     assertTrue(ex.getMessage().contains("score"), ex.getMessage());
     assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
   }
@@ -87,7 +87,7 @@ public class EdgeValidationTest {
     props.put("rank", "not-an-int");
     Edge edge = new Edge(1L, 1L, "tgt", props);
     IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+        assertThrows(IllegalArgumentException.class, () -> edge.validate(SCHEMA));
     assertTrue(ex.getMessage().contains("rank"), ex.getMessage());
     assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
   }

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/edge/EdgeValidationTest.java
@@ -1,0 +1,98 @@
+package com.kakao.actionbase.v2.core.edge;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.kakao.actionbase.v2.core.types.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class EdgeValidationTest {
+
+  private static final EdgeSchema SCHEMA =
+      new EdgeSchema(
+          new VertexField(VertexType.LONG),
+          new VertexField(VertexType.STRING),
+          Arrays.asList(
+              new Field("score", DataType.LONG, false), // required
+              new Field("rank", DataType.INT, true))); // nullable
+
+  @Test
+  void shouldPassWhenAllRequiredFieldsPresent() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", 42L);
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+  }
+
+  @Test
+  void shouldPassWhenNullableFieldIsMissing() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", 42L);
+    // "rank" not present — nullable, so OK
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+  }
+
+  @Test
+  void shouldPassWhenNullableFieldIsNull() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", 42L);
+    props.put("rank", null);
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    assertDoesNotThrow(() -> edge.validateAgainstSchema(SCHEMA));
+  }
+
+  @Test
+  void shouldRejectWhenRequiredFieldIsMissing() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("rank", 1);
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+    assertTrue(ex.getMessage().contains("score"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
+  }
+
+  @Test
+  void shouldRejectWhenRequiredFieldIsNull() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", null);
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+    assertTrue(ex.getMessage().contains("score"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("null"), ex.getMessage());
+  }
+
+  @Test
+  void shouldRejectWhenRequiredFieldHasTypeMismatch() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", "not-a-long");
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+    assertTrue(ex.getMessage().contains("score"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
+  }
+
+  @Test
+  void shouldRejectWhenNullableFieldHasTypeMismatch() {
+    // "rank" is nullable but has a non-castable value — silent null coercion must be rejected
+    Map<String, Object> props = new HashMap<>();
+    props.put("score", 42L);
+    props.put("rank", "not-an-int");
+    Edge edge = new Edge(1L, 1L, "tgt", props);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> edge.validateAgainstSchema(SCHEMA));
+    assertTrue(ex.getMessage().contains("rank"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("type mismatch"), ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary

Add schema validation in `codec-java` before bulk encoding. Edges that violate the schema are now rejected with a descriptive error instead of being silently written as invalid active data.

Closes #377

## Changes

- **`Edge.validate(EdgeSchema)`** (new method): iterates all declared schema fields and rejects:
  - required (`nullable=false`) fields that are missing or null
  - any field with a non-null value that cannot be cast to its declared type (prevents the silent `null` coercion in `DataType.cast()`)
- **`BulkEdgeEncoder.bulkEncodeAll`**: calls `validate` for active edges immediately after `ensureType` and before any byte encoding. Inactive (tombstone) edges skip validation since property values are irrelevant for key-based deletion.
- **`EdgeValidationTest`** (new): unit tests covering required-missing, required-null, required-type-mismatch, nullable-type-mismatch, and happy-path cases.
- **`BulkEdgeEncoderTests`**: two integration tests verifying the bulk path rejects required-null and required-missing edges end-to-end.

## How to Test

```
./gradlew :codec-java:test
```

All existing tests continue to pass (no regression). New tests cover the failure cases from #377.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code / claude-opus-4-8