### PR TITLE
Fix MultiEdge group counter inconsistency on _source change

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -104,10 +104,12 @@ class V2BackedTableBinding(
         val beforeRecord = EdgeStateRecord.of(source, target, beforeClean, label.entity.id)
         val afterRecord = EdgeStateRecord.of(source, target, afterClean, label.entity.id)
 
-        val isMultiEdgeSourceChanged = descriptor.schema is ModelSchema.MultiEdge &&
-            beforeClean.active && afterClean.active &&
-            beforeClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value !=
-            afterClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value
+        val isMultiEdgeSourceChanged =
+            descriptor.schema is ModelSchema.MultiEdge &&
+                beforeClean.active &&
+                afterClean.active &&
+                beforeClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value !=
+                afterClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value
 
         return if (isMultiEdgeSourceChanged) {
             val inactiveClean = afterClean.copy(active = false)
@@ -116,7 +118,8 @@ class V2BackedTableBinding(
             val deleteRecords = buildMutationRecords(before = beforeRecord, after = inactiveRecord)
             val createRecords = buildMutationRecords(before = inactiveRecord, after = afterRecord)
 
-            label.handleDeferredRequests(buildHBaseMutations(deleteRecords), storageOpCollector)
+            label
+                .handleDeferredRequests(buildHBaseMutations(deleteRecords), storageOpCollector)
                 .then(label.handleDeferredRequests(buildHBaseMutations(createRecords), null))
                 .thenReturn(MutationRecordsSummary("UPDATED", 0L, beforeClean, afterClean))
         } else {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -9,6 +9,7 @@ import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.mapper.EdgeGroupRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mutation.EdgeMutationBuilder
+import com.kakao.actionbase.core.edge.mutation.EdgeMutationBuilder.MULTI_EDGE_SOURCE_FIELD_NAME
 import com.kakao.actionbase.core.edge.mutation.EdgeMutationRecords
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
 import com.kakao.actionbase.core.edge.payload.EdgeAggPayload
@@ -102,10 +103,29 @@ class V2BackedTableBinding(
         val afterClean = after.specialStateValueToNull()
         val beforeRecord = EdgeStateRecord.of(source, target, beforeClean, label.entity.id)
         val afterRecord = EdgeStateRecord.of(source, target, afterClean, label.entity.id)
-        val records = buildMutationRecords(beforeRecord, afterRecord)
-        return label
-            .handleDeferredRequests(buildHBaseMutations(records), storageOpCollector)
-            .thenReturn(MutationRecordsSummary(records.status, records.acc, beforeClean, afterClean))
+
+        val isMultiEdgeSourceChanged = descriptor.schema is ModelSchema.MultiEdge &&
+            beforeClean.active && afterClean.active &&
+            beforeClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value !=
+            afterClean.properties[MULTI_EDGE_SOURCE_FIELD_NAME]?.value
+
+        return if (isMultiEdgeSourceChanged) {
+            val inactiveClean = afterClean.copy(active = false)
+            val inactiveRecord = EdgeStateRecord.of(source, target, state = inactiveClean, label.entity.id)
+
+            val deleteRecords = buildMutationRecords(before = beforeRecord, after = inactiveRecord)
+            val createRecords = buildMutationRecords(before = inactiveRecord, after = afterRecord)
+
+            label.handleDeferredRequests(buildHBaseMutations(deleteRecords), storageOpCollector)
+                .then(label.handleDeferredRequests(buildHBaseMutations(createRecords), null))
+                .thenReturn(MutationRecordsSummary("UPDATED", 0L, beforeClean, afterClean))
+        } else {
+            val records = buildMutationRecords(beforeRecord, afterRecord)
+
+            label
+                .handleDeferredRequests(buildHBaseMutations(records), storageOpCollector)
+                .thenReturn(MutationRecordsSummary(records.status, records.acc, beforeClean, afterClean))
+        }
     }
 
     override fun handleMutationError(error: Throwable) {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
@@ -82,6 +82,16 @@ class MultiEdgeSpec :
                   "desc": "recently paid first"
                 }
               ],
+              "groups": [
+                {
+                  "group": "by_target",
+                  "type": "COUNT",
+                  "fields": [
+                    { "name": "_target" }
+                  ],
+                  "directionType": "OUT"
+                }
+              ],
               "event": false,
               "readOnly": true,
               "mode": "SYNC"
@@ -772,6 +782,145 @@ class MultiEdgeSpec :
                     result.edges[0].properties["_id"] shouldBe 300001L
                     result.edges[0].properties["paidAt"] shouldBe 2000L
                 }.verifyComplete()
+        }
+
+        "agg group counter is correct when _source changes on UPDATE" {
+            // separate label with STRING src/tgt for agg qualifier type compatibility
+            val aggLabelName = EntityName(GraphFixtures.serviceName, "agg_test_label")
+            val aggLabelDefinition = """
+            {
+              "desc": "agg test",
+              "type": "MULTI_EDGE",
+              "schema": {
+                "src": { "type": "STRING", "desc": "source" },
+                "tgt": { "type": "STRING", "desc": "target" },
+                "fields": [
+                  { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
+                  { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
+                  { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
+                ]
+              },
+              "dirType": "BOTH",
+              "storage": "${GraphFixtures.hbaseStorage}",
+              "groups": [
+                { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
+              ],
+              "event": false,
+              "readOnly": true,
+              "mode": "SYNC"
+            }
+            """.trimIndent()
+            graph.labelDdl.create(aggLabelName, mapper.readValue<LabelCreateRequest>(aggLabelDefinition)).block()
+            val aggTable = aggLabelName.nameNotNull
+
+            // INSERT: id="e1", source="userA", target="postB"
+            mutationService
+                .mutate(
+                    database, aggTable,
+                    mapper.readValue<MultiEdgeBulkMutationRequest>(
+                        """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e1","source":"userA","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
+                    ).mutations,
+                ).test()
+                .assertNext { it.first().status shouldBe "CREATED" }
+                .verifyComplete()
+
+            // agg: source="userA", target="postB" → count=1
+            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+                .test()
+                .assertNext { it.groups.first().value shouldBe 1L }
+                .verifyComplete()
+
+            // UPDATE id="e1": source="userA"→"userC" (_source changes)
+            mutationService
+                .mutate(
+                    database, aggTable,
+                    mapper.readValue<MultiEdgeBulkMutationRequest>(
+                        """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e1","source":"userC","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
+                    ).mutations,
+                ).test()
+                .assertNext { it.first().status shouldBe "UPDATED" }
+                .verifyComplete()
+
+            // old source="userA", target="postB" → count=0
+            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+                .test()
+                .assertNext { it.groups.firstOrNull()?.value ?: 0L shouldBe 0L }
+                .verifyComplete()
+
+            // new source="userC", target="postB" → count=1
+            queryService.agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postB")
+                .test()
+                .assertNext { it.groups.first().value shouldBe 1L }
+                .verifyComplete()
+        }
+
+        "agg group counter is correct when both _source and _target change on UPDATE" {
+            val aggLabelName = EntityName(GraphFixtures.serviceName, "agg_test_label_2")
+            val aggLabelDefinition = """
+            {
+              "desc": "agg test 2",
+              "type": "MULTI_EDGE",
+              "schema": {
+                "src": { "type": "STRING", "desc": "source" },
+                "tgt": { "type": "STRING", "desc": "target" },
+                "fields": [
+                  { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
+                  { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
+                  { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
+                ]
+              },
+              "dirType": "BOTH",
+              "storage": "${GraphFixtures.hbaseStorage}",
+              "groups": [
+                { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
+              ],
+              "event": false,
+              "readOnly": true,
+              "mode": "SYNC"
+            }
+            """.trimIndent()
+            graph.labelDdl.create(aggLabelName, mapper.readValue<LabelCreateRequest>(aggLabelDefinition)).block()
+            val aggTable = aggLabelName.nameNotNull
+
+            // INSERT: id="e2", source="userA", target="postB"
+            mutationService
+                .mutate(
+                    database, aggTable,
+                    mapper.readValue<MultiEdgeBulkMutationRequest>(
+                        """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e2","source":"userA","target":"postB","properties":{"paidAt":1,"productId":200}}}]}""",
+                    ).mutations,
+                ).test()
+                .assertNext { it.first().status shouldBe "CREATED" }
+                .verifyComplete()
+
+            // agg: source="userA", target="postB" → count=1
+            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+                .test()
+                .assertNext { it.groups.first().value shouldBe 1L }
+                .verifyComplete()
+
+            // UPDATE id="e2": source="userA"→"userC", target="postB"→"postD"
+            mutationService
+                .mutate(
+                    database, aggTable,
+                    mapper.readValue<MultiEdgeBulkMutationRequest>(
+                        """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e2","source":"userC","target":"postD","properties":{"paidAt":1,"productId":200}}}]}""",
+                    ).mutations,
+                ).test()
+                .assertNext { it.first().status shouldBe "UPDATED" }
+                .verifyComplete()
+
+            // old source="userA", target="postB" → count=0
+            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+                .test()
+                .assertNext { it.groups.firstOrNull()?.value ?: 0L shouldBe 0L }
+                .verifyComplete()
+
+            // new source="userC", target="postD" → count=1
+            queryService.agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postD")
+                .test()
+                .assertNext { it.groups.first().value shouldBe 1L }
+                .verifyComplete()
         }
 
         "ids query should not return deleted edges" {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/MultiEdgeSpec.kt
@@ -787,45 +787,49 @@ class MultiEdgeSpec :
         "agg group counter is correct when _source changes on UPDATE" {
             // separate label with STRING src/tgt for agg qualifier type compatibility
             val aggLabelName = EntityName(GraphFixtures.serviceName, "agg_test_label")
-            val aggLabelDefinition = """
-            {
-              "desc": "agg test",
-              "type": "MULTI_EDGE",
-              "schema": {
-                "src": { "type": "STRING", "desc": "source" },
-                "tgt": { "type": "STRING", "desc": "target" },
-                "fields": [
-                  { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
-                  { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
-                  { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
-                ]
-              },
-              "dirType": "BOTH",
-              "storage": "${GraphFixtures.hbaseStorage}",
-              "groups": [
-                { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
-              ],
-              "event": false,
-              "readOnly": true,
-              "mode": "SYNC"
-            }
-            """.trimIndent()
+            val aggLabelDefinition =
+                """
+                {
+                  "desc": "agg test",
+                  "type": "MULTI_EDGE",
+                  "schema": {
+                    "src": { "type": "STRING", "desc": "source" },
+                    "tgt": { "type": "STRING", "desc": "target" },
+                    "fields": [
+                      { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
+                      { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
+                      { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
+                    ]
+                  },
+                  "dirType": "BOTH",
+                  "storage": "${GraphFixtures.hbaseStorage}",
+                  "groups": [
+                    { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
+                  ],
+                  "event": false,
+                  "readOnly": true,
+                  "mode": "SYNC"
+                }
+                """.trimIndent()
             graph.labelDdl.create(aggLabelName, mapper.readValue<LabelCreateRequest>(aggLabelDefinition)).block()
             val aggTable = aggLabelName.nameNotNull
 
             // INSERT: id="e1", source="userA", target="postB"
             mutationService
                 .mutate(
-                    database, aggTable,
-                    mapper.readValue<MultiEdgeBulkMutationRequest>(
-                        """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e1","source":"userA","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
-                    ).mutations,
+                    database,
+                    aggTable,
+                    mapper
+                        .readValue<MultiEdgeBulkMutationRequest>(
+                            """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e1","source":"userA","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
+                        ).mutations,
                 ).test()
                 .assertNext { it.first().status shouldBe "CREATED" }
                 .verifyComplete()
 
             // agg: source="userA", target="postB" → count=1
-            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
                 .test()
                 .assertNext { it.groups.first().value shouldBe 1L }
                 .verifyComplete()
@@ -833,22 +837,26 @@ class MultiEdgeSpec :
             // UPDATE id="e1": source="userA"→"userC" (_source changes)
             mutationService
                 .mutate(
-                    database, aggTable,
-                    mapper.readValue<MultiEdgeBulkMutationRequest>(
-                        """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e1","source":"userC","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
-                    ).mutations,
+                    database,
+                    aggTable,
+                    mapper
+                        .readValue<MultiEdgeBulkMutationRequest>(
+                            """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e1","source":"userC","target":"postB","properties":{"paidAt":1,"productId":100}}}]}""",
+                        ).mutations,
                 ).test()
                 .assertNext { it.first().status shouldBe "UPDATED" }
                 .verifyComplete()
 
             // old source="userA", target="postB" → count=0
-            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
                 .test()
                 .assertNext { it.groups.firstOrNull()?.value ?: 0L shouldBe 0L }
                 .verifyComplete()
 
             // new source="userC", target="postB" → count=1
-            queryService.agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postB")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postB")
                 .test()
                 .assertNext { it.groups.first().value shouldBe 1L }
                 .verifyComplete()
@@ -856,45 +864,49 @@ class MultiEdgeSpec :
 
         "agg group counter is correct when both _source and _target change on UPDATE" {
             val aggLabelName = EntityName(GraphFixtures.serviceName, "agg_test_label_2")
-            val aggLabelDefinition = """
-            {
-              "desc": "agg test 2",
-              "type": "MULTI_EDGE",
-              "schema": {
-                "src": { "type": "STRING", "desc": "source" },
-                "tgt": { "type": "STRING", "desc": "target" },
-                "fields": [
-                  { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
-                  { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
-                  { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
-                ]
-              },
-              "dirType": "BOTH",
-              "storage": "${GraphFixtures.hbaseStorage}",
-              "groups": [
-                { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
-              ],
-              "event": false,
-              "readOnly": true,
-              "mode": "SYNC"
-            }
-            """.trimIndent()
+            val aggLabelDefinition =
+                """
+                {
+                  "desc": "agg test 2",
+                  "type": "MULTI_EDGE",
+                  "schema": {
+                    "src": { "type": "STRING", "desc": "source" },
+                    "tgt": { "type": "STRING", "desc": "target" },
+                    "fields": [
+                      { "name": "_id", "type": "STRING", "nullable": false, "desc": "id" },
+                      { "name": "paidAt", "type": "LONG", "nullable": false, "desc": "paidAt" },
+                      { "name": "productId", "type": "LONG", "nullable": false, "desc": "productId" }
+                    ]
+                  },
+                  "dirType": "BOTH",
+                  "storage": "${GraphFixtures.hbaseStorage}",
+                  "groups": [
+                    { "group": "by_target", "type": "COUNT", "fields": [{ "name": "_target" }], "directionType": "OUT" }
+                  ],
+                  "event": false,
+                  "readOnly": true,
+                  "mode": "SYNC"
+                }
+                """.trimIndent()
             graph.labelDdl.create(aggLabelName, mapper.readValue<LabelCreateRequest>(aggLabelDefinition)).block()
             val aggTable = aggLabelName.nameNotNull
 
             // INSERT: id="e2", source="userA", target="postB"
             mutationService
                 .mutate(
-                    database, aggTable,
-                    mapper.readValue<MultiEdgeBulkMutationRequest>(
-                        """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e2","source":"userA","target":"postB","properties":{"paidAt":1,"productId":200}}}]}""",
-                    ).mutations,
+                    database,
+                    aggTable,
+                    mapper
+                        .readValue<MultiEdgeBulkMutationRequest>(
+                            """{"mutations":[{"type":"INSERT","edge":{"version":1,"id":"e2","source":"userA","target":"postB","properties":{"paidAt":1,"productId":200}}}]}""",
+                        ).mutations,
                 ).test()
                 .assertNext { it.first().status shouldBe "CREATED" }
                 .verifyComplete()
 
             // agg: source="userA", target="postB" → count=1
-            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
                 .test()
                 .assertNext { it.groups.first().value shouldBe 1L }
                 .verifyComplete()
@@ -902,22 +914,26 @@ class MultiEdgeSpec :
             // UPDATE id="e2": source="userA"→"userC", target="postB"→"postD"
             mutationService
                 .mutate(
-                    database, aggTable,
-                    mapper.readValue<MultiEdgeBulkMutationRequest>(
-                        """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e2","source":"userC","target":"postD","properties":{"paidAt":1,"productId":200}}}]}""",
-                    ).mutations,
+                    database,
+                    aggTable,
+                    mapper
+                        .readValue<MultiEdgeBulkMutationRequest>(
+                            """{"mutations":[{"type":"UPDATE","edge":{"version":2,"id":"e2","source":"userC","target":"postD","properties":{"paidAt":1,"productId":200}}}]}""",
+                        ).mutations,
                 ).test()
                 .assertNext { it.first().status shouldBe "UPDATED" }
                 .verifyComplete()
 
             // old source="userA", target="postB" → count=0
-            queryService.agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userA"), Direction.OUT, "_target:eq:postB")
                 .test()
                 .assertNext { it.groups.firstOrNull()?.value ?: 0L shouldBe 0L }
                 .verifyComplete()
 
             // new source="userC", target="postD" → count=1
-            queryService.agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postD")
+            queryService
+                .agg(database, aggTable, "by_target", listOf("userC"), Direction.OUT, "_target:eq:postD")
                 .test()
                 .assertNext { it.groups.first().value shouldBe 1L }
                 .verifyComplete()


### PR DESCRIPTION
## Summary

When a MultiEdge record's `_source` is updated, the old implementation submitted a decrement on the old source row and an increment on the new source row in a single batchAll call. Since HBase does not guarantee atomicity across rows, a partial failure could corrupt group counters with no safe retry path — replaying the same UPDATE would double-decrement the old source.

This PR fixes this by splitting the UPDATE into two sequential batches in V2BackedTableBinding.write:
1. Phase 1 (DELETE): persists an intermediate state (_source=<new>, active=false) and cleans up old source records
2. Phase 2 (CREATE): persists _source=<new>, active=true and populates new source records
  
The intermediate state written in phase 1 is the key to safe retries — if phase 2 fails and the client retries, read() picks up _source=<new>, active=false and re-enters only the CREATED path, preventing double-decrement on the old source counter.


## Changes

- V2BackedTableBinding.write: detect _source change on a MultiEdge UPDATE and execute DELETE + CREATE as two sequential handleDeferredRequests calls instead of one  

## How to Test
  - `./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.edge.MultiEdgeSpec"`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model:  Claude Sonnet 4.6 (claude.ai/code)

