### PR TITLE
Add MultiEdge count API backed by agg group

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
@@ -19,6 +19,7 @@ object EdgeMutationBuilder {
     const val MULTI_EDGE_ID_FIELD_NAME = "id"
     const val MULTI_EDGE_SOURCE_FIELD_NAME = "_source"
     const val MULTI_EDGE_TARGET_FIELD_NAME = "_target"
+    const val MULTI_EDGE_COUNT_GROUP_NAME = "_count"
 
     val MULTI_EDGE_ID_CODE = XXHash32Wrapper.default.stringHash(MULTI_EDGE_ID_FIELD_NAME)
     val MULTI_EDGE_SOURCE_CODE = XXHash32Wrapper.default.stringHash(MULTI_EDGE_SOURCE_FIELD_NAME)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/DataFrameMultiEdgeAggCountPayload.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/DataFrameMultiEdgeAggCountPayload.kt
@@ -1,0 +1,7 @@
+package com.kakao.actionbase.core.edge.payload
+
+data class DataFrameMultiEdgeAggCountPayload(
+    val counts: List<MultiEdgeAggCountPayload>,
+    val count: Int,
+    val context: Map<String, Any?>,
+)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeAggCountPayload.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeAggCountPayload.kt
@@ -1,0 +1,10 @@
+package com.kakao.actionbase.core.edge.payload
+
+import com.kakao.actionbase.core.metadata.common.Direction
+
+data class MultiEdgeAggCountPayload(
+    val start: Any,
+    val direction: Direction,
+    val count: Long,
+    val context: Map<String, Any?>,
+)

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -2,11 +2,14 @@ package com.kakao.actionbase.engine.service
 
 import com.kakao.actionbase.core.Constants.VERTEX_MARKER
 import com.kakao.actionbase.core.edge.EdgeField
+import com.kakao.actionbase.core.edge.mutation.EdgeMutationBuilder
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeAggPayload
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgeCountPayload
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
+import com.kakao.actionbase.core.edge.payload.DataFrameMultiEdgeAggCountPayload
 import com.kakao.actionbase.core.edge.payload.EdgeCountPayload
 import com.kakao.actionbase.core.edge.payload.EdgePayload
+import com.kakao.actionbase.core.edge.payload.MultiEdgeAggCountPayload
 import com.kakao.actionbase.engine.QueryEngine
 import com.kakao.actionbase.engine.query.ActionbaseQuery
 import com.kakao.actionbase.engine.query.ActionbaseQueryExecutor
@@ -170,6 +173,45 @@ class QueryService(
         features: List<String> = emptyList(),
         ttl: Long? = null,
     ): Mono<DataFrameEdgeAggPayload> = engine.getTableBinding(database, table).agg(group, start, direction, ranges, filters, features, ttl)
+
+    fun multiEdgeCount(
+        database: String,
+        table: String,
+        group: String,
+        start: List<Any>,
+        direction: Direction,
+        target: String,
+        ranges: String? = null,
+        ttl: Long? = null,
+    ): Mono<DataFrameMultiEdgeAggCountPayload> {
+        val groupField =
+            if (direction == Direction.OUT) EdgeMutationBuilder.MULTI_EDGE_TARGET_FIELD_NAME else EdgeMutationBuilder.MULTI_EDGE_SOURCE_FIELD_NAME
+
+        return agg(
+            database,
+            table,
+            group,
+            start,
+            direction,
+            ranges = listOfNotNull("$groupField:eq:$target", ranges).joinToString(";"),
+            ttl = ttl,
+        ).map { payload ->
+            val counts =
+                payload.groups.map { item ->
+                    MultiEdgeAggCountPayload(
+                        start = item.start,
+                        direction = item.direction,
+                        count = item.value,
+                        context = item.context,
+                    )
+                }
+            DataFrameMultiEdgeAggCountPayload(
+                counts = counts,
+                count = counts.size,
+                context = payload.context,
+            )
+        }
+    }
 
     fun query(request: ActionbaseQuery): Mono<Map<String, DataFrame>> = queryExecutor.query(request)
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/QueryService.kt
@@ -177,7 +177,7 @@ class QueryService(
     fun multiEdgeCount(
         database: String,
         table: String,
-        group: String,
+        group: String = EdgeMutationBuilder.MULTI_EDGE_COUNT_GROUP_NAME,
         start: List<Any>,
         direction: Direction,
         target: String,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeQueryController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v3
 
+import com.kakao.actionbase.core.edge.mutation.EdgeMutationBuilder
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.edge.payload.DataFrameMultiEdgeAggCountPayload
 import com.kakao.actionbase.engine.service.QueryService
@@ -52,7 +53,7 @@ class MultiEdgeQueryController(
     fun count(
         @PathVariable database: String,
         @PathVariable table: String,
-        @RequestParam group: String,
+        @RequestParam group: String = EdgeMutationBuilder.MULTI_EDGE_COUNT_GROUP_NAME,
         @RequestParam start: List<String>,
         @RequestParam target: String,
         @RequestParam direction: Direction,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeQueryController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeQueryController.kt
@@ -1,9 +1,11 @@
 package com.kakao.actionbase.server.api.graph.v3
 
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
+import com.kakao.actionbase.core.edge.payload.DataFrameMultiEdgeAggCountPayload
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.server.payload.MultiEdgeIdsRequest
 import com.kakao.actionbase.server.util.mapToResponseEntity
+import com.kakao.actionbase.v2.core.metadata.Direction
 
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -39,5 +41,25 @@ class MultiEdgeQueryController(
     ): Mono<ResponseEntity<DataFrameEdgePayload>> =
         queryService
             .gets(database, table, request.ids, request.filters, request.features)
+            .mapToResponseEntity()
+
+    /**
+     * Returns the count of multi-edges for each (source, target) pair.
+     * Internally delegates to the agg API using the group defined in the table schema.
+     * The counter field (_target for OUT, _source for IN) is automatically prepended to ranges.
+     */
+    @GetMapping("/graph/v3/databases/{database}/tables/{table}/multi-edges/count")
+    fun count(
+        @PathVariable database: String,
+        @PathVariable table: String,
+        @RequestParam group: String,
+        @RequestParam start: List<String>,
+        @RequestParam target: String,
+        @RequestParam direction: Direction,
+        @RequestParam ranges: String? = null,
+        @RequestParam ttl: Long? = null,
+    ): Mono<ResponseEntity<DataFrameMultiEdgeAggCountPayload>> =
+        queryService
+            .multiEdgeCount(database, table, group, start, direction, target, ranges, ttl)
             .mapToResponseEntity()
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeCountE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MultiEdgeCountE2ETest.kt
@@ -1,0 +1,146 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MultiEdgeCountE2ETest : E2ETestBase() {
+    private val db = "count-test-db"
+    private val table = "count-multi-edge"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "agg count test db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$table",
+                  "schema": {
+                    "type": "MULTI_EDGE",
+                    "id": {"type": "string", "comment": "id"},
+                    "source": {"type": "string", "comment": "src"},
+                    "target": {"type": "string", "comment": "tgt"},
+                    "properties": [
+                      {"name": "paidAt", "type": "long", "comment": "paid at"}
+                    ],
+                    "direction": "BOTH",
+                    "indexes": [],
+                    "groups": [
+                      {
+                        "group": "_count",
+                        "type": "COUNT",
+                        "fields": [{"name": "_target"}],
+                        "directionType": "OUT",
+                        "ttl": 9223372036854775807
+                      },
+                      {
+                        "group": "day",
+                        "type": "COUNT",
+                        "fields": [
+                          {"name": "_target"},
+                          {
+                            "name": "paidAt",
+                            "bucket": {
+                              "type": "date",
+                              "name": "time",
+                              "unit": "MILLISECOND",
+                              "timezone": "+09:00",
+                              "format": "yyyyMMdd"
+                            }
+                          }
+                        ],
+                        "directionType": "OUT",
+                        "ttl": 31536000000
+                      }
+                    ]
+                  },
+                  "storage": "datastore://test_namespace/agg_count_multi_edge",
+                  "mode": "SYNC",
+                  "comment": "multi edge for agg count test"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        // INSERT: id=e1, source=userA, target=postB, paidAt=1718380800000 (2024-06-15 KST)
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/multi-edges")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 1, "id": "e1", "source": "userA", "target": "postB", "properties": {"paidAt": 1718380800000}}},
+                    {"type": "INSERT", "edge": {"version": 2, "id": "e2", "source": "userA", "target": "postB", "properties": {"paidAt": 1718380800000}}},
+                    {"type": "INSERT", "edge": {"version": 3, "id": "e3", "source": "userA", "target": "postC", "properties": {"paidAt": 1718380800000}}}
+                  ]
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `count returns total count by (source, target)`() {
+        client
+            .get()
+            .uri { builder ->
+                builder
+                    .path("/graph/v3/databases/$db/tables/$table/multi-edges/count")
+                    .queryParam("group", "_count")
+                    .queryParam("start", "userA")
+                    .queryParam("target", "postB")
+                    .queryParam("direction", "OUT")
+                    .build()
+            }.exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.counts[0].start")
+            .isEqualTo("userA")
+            .jsonPath("$.counts[0].count")
+            .isEqualTo(2)
+    }
+
+    @Test
+    fun `count returns count by (source, target) within time range`() {
+        client
+            .get()
+            .uri { builder ->
+                builder
+                    .path("/graph/v3/databases/$db/tables/$table/multi-edges/count")
+                    .queryParam("group", "day")
+                    .queryParam("start", "userA")
+                    .queryParam("target", "postB")
+                    .queryParam("direction", "OUT")
+                    .queryParam("ranges", "time:bt:20240601,20240630")
+                    .build()
+            }.exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.counts[0].start")
+            .isEqualTo("userA")
+            .jsonPath("$.counts[0].count")
+            .isEqualTo(2)
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -173,6 +173,7 @@ class ReadOnlyRequestFilterTest {
                 "GET /graph/v3/databases/{database}/tables/{table}/edges/counts",
                 "GET /graph/v3/databases/{database}/tables/{table}/edges/get",
                 "GET /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}",
+                "GET /graph/v3/databases/{database}/tables/{table}/multi-edges/count",
                 "GET /graph/v3/databases/{database}/tables/{table}/multi-edges/ids",
                 "GET /graph/v3/databases/{database}/tables/{table}/vertices/get",
                 "GET /graph/v3/datastore",


### PR DESCRIPTION
## Summary

Adds a `/multi-edges/count` endpoint that returns the count of multi-edges for a given (source, target) pair, backed by the existing agg group mechanism.

The counter field (_target for OUT, _source for IN) is automatically prepended to ranges, so callers only need to provide start, target, and direction. Additional ranges (e.g. time bucket) can be appended for period-based counts.

Requires the table schema to declare a COUNT group with _target (or _source) as the leading field.

### Endpoint
```
/graph/v3/databases/{database}/tables/{table}/multi-edges/count\
?start={start}&target={target}&direction={direction}&group={group}&ranges={ranges}
```
Response
```json
{
  "counts": [
    {
      "start": "userA",
      "direction": "OUT",
      "count": 2,
      "context": {}
    }
  ],
  "count": 1,
  "context": {}
}
```

1. total count (group defaults to `_count`)
```bash
curl -X GET "http://localhost:8080/graph/v3/databases/{database}/tables/{table}/multi-edges/count\
?start=userA&target=postB&direction=OUT"
```
2. period-based count
```bash
curl -X GET "http://localhost:8080/graph/v3/databases/{database}/tables/{table}/multi-edges/count\
?start=userA&target=postB&direction=OUT&group=day&ranges=time:bt:20240601,20240630"
```

## Changes

- QueryService.multiEdgeCount: builds fullRanges from target + optional ranges and delegates to agg
- MultiEdgeQueryController: exposes GET /multi-edges/count
- MultiEdgeAggCountPayload, DataFrameMultiEdgeAggCountPayload: response payload types
- MultiEdgeCountE2ETest: E2E tests for total count and period-based count
- EdgeMutationBuilder: add MULTI_EDGE_COUNT_GROUP_NAME constant as the default group name for (source, target) count

## How to Test

```bash
./gradlew :server:test --tests "com.kakao.actionbase.server.api.graph.v3.MultiEdgeCountE2ETest"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Sonnet 4.6 (claude.ai/code)