### PR TITLE
Fix missing type casting in AGG group qualifier encoding

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -3,6 +3,7 @@ package com.kakao.actionbase.core.metadata.common
 import com.kakao.actionbase.core.state.AbstractSchema
 import com.kakao.actionbase.core.state.Schema
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
@@ -19,6 +20,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 )
 sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
+
+    @get:JsonIgnore
+    val propertiesByName: Map<String, StructField> by lazy { properties.associateBy { it.name } }
 
     @JsonTypeName("edge")
     data class Edge(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -333,7 +333,15 @@ class V2BackedTableBinding(
                 require(predicate is WherePredicate.Eq) {
                     "only `Eq` predicate is allowed for the first ${firstPairs.size} group fields, but got $predicate."
                 }
-                field.bucketOrGet(predicate.value, ceil = false)
+                if (field.bucket == null) {
+                    descriptor.schema.properties
+                        .find { it.name == field.name }
+                        ?.type
+                        ?.cast(predicate.value)
+                        ?: predicate.value
+                } else {
+                    field.bucketOrGet(predicate.value, ceil = false)
+                }
             }
 
         val (from, to) = encodeAggRanges(eqValues, lastField, lastPredicate)
@@ -462,14 +470,27 @@ class V2BackedTableBinding(
                 EdgeGroupRecord.Qualifier(groupValues = values + additionalValues.toList()),
             )
 
+        fun bucketOrCast(
+            value: Any,
+            ceil: Boolean,
+        ): Any =
+            if (lastField.bucket == null) {
+                descriptor.schema.properties
+                    .find { it.name == lastField.name }
+                    ?.type
+                    ?.cast(value) ?: value
+            } else {
+                lastField.bucketOrGet(value, ceil)
+            }
+
         return when (lastPredicate) {
             is WherePredicate.Eq -> {
-                val parsed = lastField.bucketOrGet(lastPredicate.value, ceil = false)
+                val parsed = bucketOrCast(lastPredicate.value, ceil = false)
                 encode(parsed).let { it to it }
             }
             is WherePredicate.Between -> {
-                val from = encode(lastField.bucketOrGet(lastPredicate.from, ceil = false))
-                val to = encode(lastField.bucketOrGet(lastPredicate.to, ceil = true))
+                val from = encode(bucketOrCast(lastPredicate.from, ceil = false))
+                val to = encode(bucketOrCast(lastPredicate.to, ceil = true))
                 from to to
             }
             else -> throw IllegalArgumentException(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -334,8 +334,7 @@ class V2BackedTableBinding(
                     "only `Eq` predicate is allowed for the first ${firstPairs.size} group fields, but got $predicate."
                 }
                 if (field.bucket == null) {
-                    descriptor.schema.properties
-                        .find { it.name == field.name }
+                    descriptor.schema.propertiesByName[field.name]
                         ?.type
                         ?.cast(predicate.value)
                         ?: predicate.value
@@ -475,8 +474,7 @@ class V2BackedTableBinding(
             ceil: Boolean,
         ): Any =
             if (lastField.bucket == null) {
-                descriptor.schema.properties
-                    .find { it.name == lastField.name }
+                descriptor.schema.propertiesByName[lastField.name]
                     ?.type
                     ?.cast(value) ?: value
             } else {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
@@ -1,0 +1,450 @@
+package com.kakao.actionbase.v2.engine.v3
+
+import com.kakao.actionbase.core.metadata.common.DirectionType as V3DirectionType
+
+import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
+import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.core.metadata.common.Bucket
+import com.kakao.actionbase.core.metadata.common.Group
+import com.kakao.actionbase.core.metadata.common.GroupType
+import com.kakao.actionbase.engine.service.MutationService
+import com.kakao.actionbase.engine.service.QueryService
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
+import com.kakao.actionbase.v2.engine.test.GraphFixtures
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import reactor.kotlin.test.test
+
+class EdgeAggQuerySpec :
+    StringSpec({
+        lateinit var graph: Graph
+        lateinit var mutationService: MutationService
+        lateinit var queryService: QueryService
+
+        beforeTest {
+            graph = GraphFixtures.create()
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
+        }
+
+        afterTest {
+            graph.close()
+        }
+
+        /**
+         * Mutation:
+         * | source | target | createdAt |
+         * |--------|--------|-----------|
+         * | 1000   | 2000   | 100       |
+         * | 1000   | 2001   | 100       |
+         * | 1000   | 2002   | 200       |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT)
+         * |       row key        | qualifier (Long) | value |
+         * |----------------------|------------------|-------|
+         * | hash|1000|T|-5|OUT|G | createdAt=100    |     2 |
+         * | hash|1000|T|-5|OUT|G | createdAt=200    |     1 |
+         *
+         * Before #227: predicate "100"/"200" encoded as String → count=0.
+         */
+        "INSERT → agg Eq on Long field returns matching count" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_long_eq"
+            val groupName = "by_created_at"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "agg long eq test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields = listOf(Group.Field("createdAt")),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "na", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "na", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "na", "createdAt": 200}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { response ->
+                    EdgeMutationResponse.from(response).results.size shouldBe 3
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "createdAt:eq:100")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 2L
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "createdAt:eq:200")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 1L
+                }.verifyComplete()
+        }
+
+        /**
+         * Mutation:
+         * | source | target | createdAt |
+         * |--------|--------|-----------|
+         * | 1000   | 2000   | 50        |
+         * | 1000   | 2001   | 100       |
+         * | 1000   | 2002   | 150       |
+         * | 1000   | 2003   | 250       |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT)
+         * |       row key        | qualifier (Long) | value |
+         * |----------------------|------------------|-------|
+         * | hash|1000|T|-5|OUT|G | createdAt=50     |     1 |
+         * | hash|1000|T|-5|OUT|G | createdAt=100    |     1 |
+         * | hash|1000|T|-5|OUT|G | createdAt=150    |     1 |
+         * | hash|1000|T|-5|OUT|G | createdAt=250    |     1 |
+         *
+         * Range [100, 200] matches 100 and 150 → sum=2.
+         */
+        "INSERT → agg Between on Long field returns count in range" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_long_bt"
+            val groupName = "by_created_at"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "agg long bt test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields = listOf(Group.Field("createdAt")),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "na", "createdAt": 50}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "na", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "na", "createdAt": 150}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2003", "properties": {"permission": "na", "createdAt": 250}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { response ->
+                    EdgeMutationResponse.from(response).results.size shouldBe 4
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "createdAt:bt:100,200")
+                .test()
+                .assertNext { payload ->
+                    payload.groups.sumOf { it.value } shouldBe 2L
+                }.verifyComplete()
+        }
+
+        /**
+         * Regression guard: String fields already worked before #227.
+         *
+         * Mutation:
+         * | source | target | permission |
+         * |--------|--------|------------|
+         * | 1000   | 2000   | me         |
+         * | 1000   | 2001   | me         |
+         * | 1000   | 2002   | others     |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT)
+         * |       row key        | qualifier (String) | value |
+         * |----------------------|--------------------|-------|
+         * | hash|1000|T|-5|OUT|G | permission=me      |     2 |
+         * | hash|1000|T|-5|OUT|G | permission=others  |     1 |
+         */
+        "INSERT → agg Eq on String field returns matching count" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_string_eq"
+            val groupName = "by_permission"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "agg string eq test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields = listOf(Group.Field("permission")),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "me", "createdAt": 1}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "me", "createdAt": 2}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "others", "createdAt": 3}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { response ->
+                    EdgeMutationResponse.from(response).results.size shouldBe 3
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "permission:eq:me")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 2L
+                }.verifyComplete()
+        }
+
+        /**
+         * Multi-field group: leading Long field must be cast, trailing String field
+         * flows through as-is. `eqValues` (the leading-fields cast in agg()) was the
+         * second copy of the buggy pattern before #227.
+         *
+         * Mutation:
+         * | source | target | createdAt | permission |
+         * |--------|--------|-----------|------------|
+         * | 1000   | 2000   | 100       | me         |
+         * | 1000   | 2001   | 100       | me         |
+         * | 1000   | 2002   | 100       | others     |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT)
+         * |       row key        | qualifier                     | value |
+         * |----------------------|-------------------------------|-------|
+         * | hash|1000|T|-5|OUT|G | Long(100), String("me")       |     2 |
+         * | hash|1000|T|-5|OUT|G | Long(100), String("others")   |     1 |
+         */
+        "INSERT → agg with leading Long field and trailing String field" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_multi_field"
+            val groupName = "by_created_at_and_permission"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "agg multi-field test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields = listOf(Group.Field("createdAt"), Group.Field("permission")),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "me", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "me", "createdAt": 100}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "others", "createdAt": 100}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { response ->
+                    EdgeMutationResponse.from(response).results.size shouldBe 3
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "createdAt:eq:100;permission:eq:me")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 2L
+                }.verifyComplete()
+        }
+
+        /**
+         * Bucketed field: `bucketOrGet` normalises the value on both paths, so no
+         * schema-type cast is applied even though the underlying property is Long.
+         * The query key is the bucket's `name`, not the property name.
+         *
+         * Mutation (createdAt is epoch millis, bucketed to yyyy-MM-dd UTC):
+         * | source | target | createdAt (ms)       | → bucket day |
+         * |--------|--------|----------------------|--------------|
+         * | 1000   | 2000   | 1704067200000 (2024-01-01) | 2024-01-01 |
+         * | 1000   | 2001   | 1704153600000 (2024-01-02) | 2024-01-02 |
+         * | 1000   | 2002   | 1704240000000 (2024-01-03) | 2024-01-03 |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT)
+         * |       row key        | qualifier            | value |
+         * |----------------------|----------------------|-------|
+         * | hash|1000|T|-5|OUT|G | String("2024-01-01") |     1 |
+         * | hash|1000|T|-5|OUT|G | String("2024-01-02") |     1 |
+         * | hash|1000|T|-5|OUT|G | String("2024-01-03") |     1 |
+         */
+        "INSERT → agg on Date-bucketed field returns matching count" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_bucketed"
+            val groupName = "by_day"
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "agg bucketed test",
+                    type = LabelType.INDEXED,
+                    schema = GraphFixtures.sampleSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    indices = GraphFixtures.sampleIndices,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields =
+                                    listOf(
+                                        Group.Field(
+                                            name = "createdAt",
+                                            bucket =
+                                                Bucket.Date(
+                                                    name = "day",
+                                                    unit = Bucket.ValueUnit.MILLISECOND,
+                                                    timezone = "UTC",
+                                                    format = "yyyy-MM-dd",
+                                                ),
+                                        ),
+                                    ),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<EdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2000", "properties": {"permission": "na", "createdAt": 1704067200000}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2001", "properties": {"permission": "na", "createdAt": 1704153600000}}},
+                        {"type": "INSERT", "edge": {"version": 1, "source": "1000", "target": "2002", "properties": {"permission": "na", "createdAt": 1704240000000}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { response ->
+                    EdgeMutationResponse.from(response).results.size shouldBe 3
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "day:eq:2024-01-02")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 1L
+                }.verifyComplete()
+        }
+    }) {
+    companion object {
+        val mapper = jacksonObjectMapper()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes AGG queries returning `count=0` on group fields whose property type is not `String`. The write path encoded the qualifier with the native type (e.g. `Long 1L` → `encodeInt64`), but the read path passed the predicate value through as a `String`, so qualifier bytes never matched.

The fix casts bucketless predicate values to the schema property type before qualifier encoding, on both the leading-fields path (`eqValues`) and the trailing-field path (`encodeAggRanges`). Bucketed fields are unchanged — the bucket already normalises the value.

Closes #227

## Changes

- Cast group predicate values to the schema property type when the field is bucketless (`V2BackedTableBinding.agg` / `encodeAggRanges`).
- Add integration spec `EdgeAggQuerySpec` covering Long Eq, Long Between, String Eq, multi-field, and Date-bucketed group queries.
- Add interactive e2e script `bin/e2e_agg_group_predicate_cast.sh` for manual verification against a running server.

## How to Test

- `./gradlew :engine:test --tests 'com.kakao.actionbase.v2.engine.v3.EdgeAggQuerySpec'` — 5/5 pass; without the fix Long Eq / Long Between / multi-field fail with `count=0`.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Sonnet 4.6 / Opus 4.7, 1M context)
