### PR TITLE
Add migrate CLI command with datastore:// storage rewrite (Phase 2, #347)

### DIFF
--- a/cli/internal/client/actionbase_client.go
+++ b/cli/internal/client/actionbase_client.go
@@ -111,6 +111,12 @@ func (a *ActionbaseClient) Mutate(
 	)
 }
 
+// PostRaw POSTs an arbitrary body to a path and returns the HTTP status code.
+// Used by migrate apply to replay a plan without knowing each entry's type.
+func (a *ActionbaseClient) PostRaw(path string, body any) int {
+	return PostForStatus(a.client, path, body)
+}
+
 func (a *ActionbaseClient) GetHost() string {
 	return a.client.baseUrl
 }

--- a/cli/internal/client/actionbase_client.go
+++ b/cli/internal/client/actionbase_client.go
@@ -111,10 +111,11 @@ func (a *ActionbaseClient) Mutate(
 	)
 }
 
-// PostRaw POSTs an arbitrary body to a path and returns the HTTP status code.
-// Used by migrate apply to replay a plan without knowing each entry's type.
-func (a *ActionbaseClient) PostRaw(path string, body any) int {
-	return PostForStatus(a.client, path, body)
+// PostRaw POSTs an arbitrary body to a path and returns the HTTP status code
+// and raw response body. Used by migrate apply to replay a plan without
+// knowing each entry's type.
+func (a *ActionbaseClient) PostRaw(path string, body any) (int, string) {
+	return PostForResult(a.client, path, body)
 }
 
 func (a *ActionbaseClient) GetHost() string {

--- a/cli/internal/client/http_client.go
+++ b/cli/internal/client/http_client.go
@@ -91,19 +91,20 @@ func Post[T any, R any](c *HTTPClient, uri string, requestBody T) *Response[R] {
 	return call[R](c, request, requestBodyJson)
 }
 
-// PostForStatus POSTs a JSON body and returns only the HTTP status code,
-// without parsing the response body. Returns -1 on transport failure. Used by
-// replay-style flows (e.g. migrate apply) that key solely on status.
-func PostForStatus(c *HTTPClient, uri string, requestBody any) int {
+// PostForResult POSTs a JSON body and returns the HTTP status code and the
+// raw response body without parsing it. Returns -1 on transport failure. Used
+// by replay-style flows (e.g. migrate apply) that key on the status plus the
+// server's error message.
+func PostForResult(c *HTTPClient, uri string, requestBody any) (int, string) {
 	url := fmt.Sprintf("%s%s", c.baseUrl, uri)
 	requestBodyJson, err := json.Marshal(requestBody)
 	if err != nil {
-		return -1
+		return -1, ""
 	}
 
 	request, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBodyJson))
 	if err != nil {
-		return -1
+		return -1, ""
 	}
 
 	request.Header.Set("Content-Type", "application/json")
@@ -117,14 +118,16 @@ func PostForStatus(c *HTTPClient, uri string, requestBody any) int {
 
 	response, err := c.client.Do(request)
 	if err != nil {
-		return -1
+		return -1, ""
 	}
 	defer func() { _ = response.Body.Close() }()
 
+	responseBody, _ := io.ReadAll(response.Body)
+
 	if c.context.IsDebugEnabled {
-		slog.Debug(fmt.Sprintf("← %s", response.Status))
+		slog.Debug(fmt.Sprintf("← %s %s", response.Status, util.Truncate(string(responseBody), 60)))
 	}
-	return response.StatusCode
+	return response.StatusCode, string(responseBody)
 }
 
 func call[T any](c *HTTPClient, request *http.Request, requestBody []byte) *Response[T] {

--- a/cli/internal/client/http_client.go
+++ b/cli/internal/client/http_client.go
@@ -91,6 +91,42 @@ func Post[T any, R any](c *HTTPClient, uri string, requestBody T) *Response[R] {
 	return call[R](c, request, requestBodyJson)
 }
 
+// PostForStatus POSTs a JSON body and returns only the HTTP status code,
+// without parsing the response body. Returns -1 on transport failure. Used by
+// replay-style flows (e.g. migrate apply) that key solely on status.
+func PostForStatus(c *HTTPClient, uri string, requestBody any) int {
+	url := fmt.Sprintf("%s%s", c.baseUrl, uri)
+	requestBodyJson, err := json.Marshal(requestBody)
+	if err != nil {
+		return -1
+	}
+
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBodyJson))
+	if err != nil {
+		return -1
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	if c.authKey != nil {
+		request.Header.Set("Authorization", *c.authKey)
+	}
+
+	if c.context.IsDebugEnabled {
+		slog.Debug(fmt.Sprintf("→ %s %s %s", request.Method, request.URL.RequestURI(), util.Truncate(string(requestBodyJson), 60)))
+	}
+
+	response, err := c.client.Do(request)
+	if err != nil {
+		return -1
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if c.context.IsDebugEnabled {
+		slog.Debug(fmt.Sprintf("← %s", response.Status))
+	}
+	return response.StatusCode
+}
+
 func call[T any](c *HTTPClient, request *http.Request, requestBody []byte) *Response[T] {
 	if c.context.IsDebugEnabled {
 		if requestBody == nil {

--- a/cli/internal/client/model/metastore.go
+++ b/cli/internal/client/model/metastore.go
@@ -34,6 +34,7 @@ type TableEntity struct {
 	Storage  string  `json:"storage"`
 	Indices  []Index `json:"indices"`
 	Groups   []Group `json:"groups"`
+	Caches   []any   `json:"caches"`
 	Event    bool    `json:"event"`
 	ReadOnly bool    `json:"readOnly"`
 	Mode     string  `json:"mode"`

--- a/cli/internal/command/command_type.go
+++ b/cli/internal/command/command_type.go
@@ -80,6 +80,11 @@ var (
 		name:    "doctor",
 		command: "doctor <names>",
 	}
+
+	TypeMigrate = Type{
+		name:    "migrate",
+		command: "migrate <plan [-o <file>]|apply [-i <file>]>",
+	}
 )
 
 func (t Type) GetName() string {

--- a/cli/internal/command/migrate.go
+++ b/cli/internal/command/migrate.go
@@ -1,0 +1,231 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kakao/actionbase/internal/client"
+	clientModel "github.com/kakao/actionbase/internal/client/model"
+	"github.com/kakao/actionbase/internal/command/model"
+	"github.com/kakao/actionbase/internal/util"
+)
+
+const (
+	defaultPlanFile    = "migration-run.json"
+	datastoreURIPrefix = "datastore://"
+	jdbcNamespace      = "__jdbc__"
+	localNamespace     = "__local__"
+)
+
+// migrationEntry is one POST the apply phase will replay. It mirrors the JSON
+// shape of the previous dev/migration-run.py plan: a path, a request body, and
+// a human-readable label for progress output.
+type migrationEntry struct {
+	Path  string         `json:"path"`
+	Body  map[string]any `json:"body"`
+	Label string         `json:"label"`
+}
+
+type Migrate struct {
+	client *client.ActionbaseClient
+}
+
+func NewMigrate(c *client.ActionbaseClient) *Migrate {
+	return &Migrate{client: c}
+}
+
+func (m *Migrate) Execute(args []string) *model.Response {
+	if len(args) < 1 {
+		return model.Fail(fmt.Sprintf("Usage: %s", m.GetType().GetCommand()))
+	}
+	parser := util.ParseArgs(args[1:])
+	switch args[0] {
+	case "plan":
+		out := defaultPlanFile
+		if v, ok := parser.Get("o"); ok {
+			out = v
+		}
+		return m.plan(out)
+	case "apply":
+		in := defaultPlanFile
+		if v, ok := parser.Get("i"); ok {
+			in = v
+		}
+		return m.apply(in)
+	default:
+		return model.Fail(fmt.Sprintf("Usage: %s", m.GetType().GetCommand()))
+	}
+}
+
+// plan reads all operational metadata and writes a migration plan to disk.
+// Storage entities are not re-created (the v2 Storage model is being removed);
+// instead each label's storage reference is rewritten to a datastore:// URI so
+// the plan stays valid against the new metadata API.
+func (m *Migrate) plan(outputPath string) *model.Response {
+	dbs := m.client.GetDatabases()
+	if dbs.IsError() {
+		return model.Fail("Failed to fetch databases")
+	}
+
+	// Read storages first: label storage references are stored as storage names,
+	// and we need each storage's conf to resolve the datastore:// URI.
+	storageURIByName := map[string]string{}
+	if resp := m.client.GetStorages(); !resp.IsError() {
+		for _, s := range resp.Body.Content {
+			storageURIByName[s.Name] = storageToDatastoreURI(s)
+		}
+	}
+
+	var plan []migrationEntry
+	add := func(path string, body map[string]any, label string) {
+		plan = append(plan, migrationEntry{Path: path, Body: body, Label: label})
+	}
+
+	databases, tables, aliases := 0, 0, 0
+	for _, db := range dbs.Body.Content {
+		if isSystem(db.Name) {
+			continue
+		}
+		databases++
+		add(fmt.Sprintf("/graph/v2/service/%s", db.Name),
+			map[string]any{"desc": db.Desc},
+			fmt.Sprintf("service/%s", db.Name))
+
+		if resp := m.client.GetTables(db.Name); !resp.IsError() {
+			for _, t := range resp.Body.Content {
+				if isSystem(t.Name) {
+					continue
+				}
+				short := shortName(t.Name)
+				detail := m.client.GetTable(db.Name, short)
+				if detail.IsError() {
+					return model.Fail(fmt.Sprintf("Failed to fetch table %s.%s", db.Name, short))
+				}
+				tables++
+				add(fmt.Sprintf("/graph/v2/service/%s/label/%s", db.Name, short),
+					tableBody(*detail.Body, storageURIByName),
+					fmt.Sprintf("label/%s/%s", db.Name, short))
+			}
+		}
+
+		if resp := m.client.GetAliases(db.Name); !resp.IsError() {
+			for _, a := range resp.Body.Content {
+				if isSystem(a.Name) {
+					continue
+				}
+				short := shortName(a.Name)
+				aliases++
+				add(fmt.Sprintf("/graph/v2/service/%s/alias/%s", db.Name, short),
+					map[string]any{"desc": a.Desc, "target": a.Target},
+					fmt.Sprintf("alias/%s/%s", db.Name, short))
+			}
+		}
+	}
+
+	data, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return model.Fail(fmt.Sprintf("Failed to encode plan: %v", err))
+	}
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return model.Fail(fmt.Sprintf("Failed to write %s: %v", outputPath, err))
+	}
+
+	return model.SuccessWithResult(fmt.Sprintf(
+		"Wrote %s (%d entries: %d database(s), %d table(s), %d alias(es)). Review it, then run: migrate apply -i %s",
+		outputPath, len(plan), databases, tables, aliases, outputPath))
+}
+
+// apply replays each entry in the plan. Existing entries (409) are skipped so
+// the run is idempotent.
+func (m *Migrate) apply(inputPath string) *model.Response {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return model.Fail(fmt.Sprintf("Failed to read %s: %v", inputPath, err))
+	}
+	var plan []migrationEntry
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return model.Fail(fmt.Sprintf("Failed to parse %s: %v", inputPath, err))
+	}
+
+	ok, skip, fail := 0, 0, 0
+	for _, e := range plan {
+		status := m.client.PostRaw(e.Path, e.Body)
+		switch {
+		case status == 409:
+			util.Print("[SKIP] %s (already exists)\n", e.Label)
+			skip++
+		case status >= 200 && status < 300:
+			util.Print("[OK]   %s\n", e.Label)
+			ok++
+		default:
+			util.Print("[FAIL] %s (HTTP %d)\n", e.Label, status)
+			fail++
+		}
+	}
+
+	summary := fmt.Sprintf("done: ok=%d skip=%d fail=%d", ok, skip, fail)
+	if fail > 0 {
+		return model.Fail(summary)
+	}
+	return model.SuccessWithResult(summary)
+}
+
+// tableBody builds the label create body, rewriting the storage reference to a
+// datastore:// URI resolved from the storage-name→URI map.
+func tableBody(t clientModel.TableEntity, storageURIByName map[string]string) map[string]any {
+	storage := t.Storage
+	if resolved, ok := storageURIByName[storage]; ok {
+		storage = resolved
+	}
+	return map[string]any{
+		"desc":     t.Desc,
+		"type":     t.Type,
+		"schema":   t.Schema,
+		"dirType":  t.DirType,
+		"storage":  storage,
+		"indices":  t.Indices,
+		"groups":   t.Groups,
+		"event":    t.Event,
+		"readOnly": t.ReadOnly,
+		"mode":     t.Mode,
+	}
+}
+
+// storageToDatastoreURI maps a legacy storage entity to its datastore:// URI.
+func storageToDatastoreURI(s clientModel.StorageEntity) string {
+	switch s.Type {
+	case "HBASE":
+		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, confString(s.Conf, "namespace"), confString(s.Conf, "tableName"))
+	case "JDBC":
+		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, jdbcNamespace, s.Name)
+	case "LOCAL":
+		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, localNamespace, s.Name)
+	default:
+		return s.Name
+	}
+}
+
+func confString(conf map[string]any, key string) string {
+	if v, ok := conf[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// isSystem reports bootstrap seeds that must not be migrated: the sys service
+// and any origin-prefixed entity. Mirrors the original migration script rule.
+func isSystem(name string) bool {
+	return name == "sys" || strings.HasPrefix(name, "origin")
+}
+
+func (m *Migrate) GetDescription() string {
+	return "Migrate metadata: plan reads all metadata to a file, apply replays it"
+}
+
+func (m *Migrate) GetType() Type {
+	return TypeMigrate
+}

--- a/cli/internal/command/migrate.go
+++ b/cli/internal/command/migrate.go
@@ -15,8 +15,6 @@ import (
 const (
 	defaultPlanFile    = "migration-run.json"
 	datastoreURIPrefix = "datastore://"
-	jdbcNamespace      = "__jdbc__"
-	localNamespace     = "__local__"
 )
 
 // migrationEntry is one POST the apply phase will replay. It mirrors the JSON
@@ -70,11 +68,18 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 	}
 
 	// Read storages first: label storage references are stored as storage names,
-	// and we need each storage's conf to resolve the datastore:// URI.
+	// and we need each storage's conf to resolve the datastore:// URI. Storages
+	// without a datastore:// equivalent keep their error so the plan can fail
+	// with the reason if a label actually references one.
 	storageURIByName := map[string]string{}
+	storageErrByName := map[string]error{}
 	if resp := m.client.GetStorages(); !resp.IsError() {
 		for _, s := range resp.Body.Content {
-			storageURIByName[s.Name] = storageToDatastoreURI(s)
+			if uri, err := storageToDatastoreURI(s); err != nil {
+				storageErrByName[s.Name] = err
+			} else {
+				storageURIByName[s.Name] = uri
+			}
 		}
 	}
 
@@ -103,9 +108,13 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 				if detail.IsError() {
 					return model.Fail(fmt.Sprintf("Failed to fetch table %s.%s", db.Name, short))
 				}
+				body, err := tableBody(*detail.Body, storageURIByName, storageErrByName)
+				if err != nil {
+					return model.Fail(fmt.Sprintf("Cannot plan label %s.%s: %v", db.Name, short, err))
+				}
 				tables++
 				add(fmt.Sprintf("/graph/v2/service/%s/label/%s", db.Name, short),
-					tableBody(*detail.Body, storageURIByName),
+					body,
 					fmt.Sprintf("label/%s/%s", db.Name, short))
 			}
 		}
@@ -151,16 +160,16 @@ func (m *Migrate) apply(inputPath string) *model.Response {
 
 	ok, skip, fail := 0, 0, 0
 	for _, e := range plan {
-		status := m.client.PostRaw(e.Path, e.Body)
+		status, body := m.client.PostRaw(e.Path, e.Body)
 		switch {
-		case status == 409:
+		case isAlreadyExists(status, body):
 			util.Print("[SKIP] %s (already exists)\n", e.Label)
 			skip++
 		case status >= 200 && status < 300:
 			util.Print("[OK]   %s\n", e.Label)
 			ok++
 		default:
-			util.Print("[FAIL] %s (HTTP %d)\n", e.Label, status)
+			util.Print("[FAIL] %s (HTTP %d: %s)\n", e.Label, status, util.Truncate(body, 120))
 			fail++
 		}
 	}
@@ -172,12 +181,33 @@ func (m *Migrate) apply(inputPath string) *model.Response {
 	return model.SuccessWithResult(summary)
 }
 
-// tableBody builds the label create body, rewriting the storage reference to a
-// datastore:// URI resolved from the storage-name→URI map.
-func tableBody(t clientModel.TableEntity, storageURIByName map[string]string) map[string]any {
+// isAlreadyExists reports a duplicate-create rejection. The v2 DDL path never
+// returns 409: `failOnExist` duplicates surface as 400 with an "already
+// exists" message, so apply matches on the message to stay idempotent.
+func isAlreadyExists(status int, body string) bool {
+	return status == 409 || (status == 400 && strings.Contains(body, "already exists"))
+}
+
+// tableBody builds the label create body, rewriting a legacy storage-name
+// reference to its datastore:// URI. A reference that cannot be resolved to a
+// URI fails the plan: replaying it would create a label the server cannot
+// route once the legacy Storage entities are gone.
+func tableBody(t clientModel.TableEntity, uriByName map[string]string, errByName map[string]error) (map[string]any, error) {
 	storage := t.Storage
-	if resolved, ok := storageURIByName[storage]; ok {
-		storage = resolved
+	switch {
+	case strings.HasPrefix(storage, datastoreURIPrefix):
+		// already a URI; keep as is
+	case uriByName[storage] != "":
+		storage = uriByName[storage]
+	case errByName[storage] != nil:
+		return nil, fmt.Errorf("storage %q: %w", t.Storage, errByName[storage])
+	default:
+		return nil, fmt.Errorf("storage %q not found; cannot resolve a datastore:// URI", t.Storage)
+	}
+
+	caches := t.Caches
+	if caches == nil {
+		caches = []any{}
 	}
 	return map[string]any{
 		"desc":     t.Desc,
@@ -187,24 +217,27 @@ func tableBody(t clientModel.TableEntity, storageURIByName map[string]string) ma
 		"storage":  storage,
 		"indices":  t.Indices,
 		"groups":   t.Groups,
+		"caches":   caches,
 		"event":    t.Event,
 		"readOnly": t.ReadOnly,
 		"mode":     t.Mode,
-	}
+	}, nil
 }
 
-// storageToDatastoreURI maps a legacy storage entity to its datastore:// URI.
-func storageToDatastoreURI(s clientModel.StorageEntity) string {
-	switch s.Type {
-	case "HBASE":
-		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, confString(s.Conf, "namespace"), confString(s.Conf, "tableName"))
-	case "JDBC":
-		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, jdbcNamespace, s.Name)
-	case "LOCAL":
-		return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, localNamespace, s.Name)
-	default:
-		return s.Name
+// storageToDatastoreURI maps a legacy HBASE storage entity to its datastore://
+// URI. The engine resolves every datastore:// URI except the reserved
+// __sys__ metastore as an HBase namespace/table, so non-HBASE storages have
+// no URI to mint — they return an error instead.
+func storageToDatastoreURI(s clientModel.StorageEntity) (string, error) {
+	if s.Type != "HBASE" {
+		return "", fmt.Errorf("storage type %s has no datastore:// equivalent", s.Type)
 	}
+	namespace := confString(s.Conf, "namespace")
+	tableName := confString(s.Conf, "tableName")
+	if namespace == "" || tableName == "" {
+		return "", fmt.Errorf("HBASE storage %q conf is missing namespace/tableName", s.Name)
+	}
+	return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, namespace, tableName), nil
 }
 
 func confString(conf map[string]any, key string) string {

--- a/cli/internal/command/migrate_test.go
+++ b/cli/internal/command/migrate_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"testing"
 
 	clientModel "github.com/kakao/actionbase/internal/client/model"
@@ -11,6 +12,7 @@ func TestStorageToDatastoreURI(t *testing.T) {
 		name     string
 		storage  clientModel.StorageEntity
 		expected string
+		wantErr  bool
 	}{
 		{
 			name: "HBASE uses namespace and tableName from conf",
@@ -22,35 +24,128 @@ func TestStorageToDatastoreURI(t *testing.T) {
 			expected: "datastore://kc_graph/edges",
 		},
 		{
-			name:     "JDBC maps to __jdbc__ sentinel namespace",
-			storage:  clientModel.StorageEntity{Name: "metastore", Type: "JDBC", Conf: map[string]any{}},
-			expected: "datastore://__jdbc__/metastore",
+			name:    "JDBC has no datastore equivalent",
+			storage: clientModel.StorageEntity{Name: "metastore", Type: "JDBC", Conf: map[string]any{}},
+			wantErr: true,
 		},
 		{
-			name:     "LOCAL maps to __local__ sentinel namespace",
-			storage:  clientModel.StorageEntity{Name: "local_backed_metastore", Type: "LOCAL", Conf: map[string]any{}},
-			expected: "datastore://__local__/local_backed_metastore",
+			name:    "LOCAL has no datastore equivalent",
+			storage: clientModel.StorageEntity{Name: "local_backed_metastore", Type: "LOCAL", Conf: map[string]any{}},
+			wantErr: true,
 		},
 		{
-			name:     "unknown type falls back to the storage name unchanged",
-			storage:  clientModel.StorageEntity{Name: "weird", Type: "NIL", Conf: map[string]any{}},
-			expected: "weird",
+			name:    "unknown type has no datastore equivalent",
+			storage: clientModel.StorageEntity{Name: "weird", Type: "NIL", Conf: map[string]any{}},
+			wantErr: true,
 		},
 		{
-			name: "HBASE with missing conf keys yields empty segments",
+			name: "HBASE with missing conf keys is rejected",
 			storage: clientModel.StorageEntity{
 				Name: "broken",
 				Type: "HBASE",
 				Conf: map[string]any{},
 			},
-			expected: "datastore:///",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := storageToDatastoreURI(tt.storage); got != tt.expected {
+			got, err := storageToDatastoreURI(tt.storage)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("storageToDatastoreURI(%+v) = %q, want error", tt.storage, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("storageToDatastoreURI(%+v) unexpected error: %v", tt.storage, err)
+				return
+			}
+			if got != tt.expected {
 				t.Errorf("storageToDatastoreURI(%+v) = %q, want %q", tt.storage, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTableBody(t *testing.T) {
+	uriByName := map[string]string{"default_hbase_storage": "datastore://kc_graph/edges"}
+	errByName := map[string]error{"metastore": errors.New("storage type JDBC has no datastore:// equivalent")}
+
+	t.Run("legacy storage name is rewritten to its URI", func(t *testing.T) {
+		body, err := tableBody(clientModel.TableEntity{Storage: "default_hbase_storage"}, uriByName, errByName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if body["storage"] != "datastore://kc_graph/edges" {
+			t.Errorf("storage = %q, want datastore://kc_graph/edges", body["storage"])
+		}
+	})
+
+	t.Run("datastore URI passes through unchanged", func(t *testing.T) {
+		body, err := tableBody(clientModel.TableEntity{Storage: "datastore://ns/tbl"}, uriByName, errByName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if body["storage"] != "datastore://ns/tbl" {
+			t.Errorf("storage = %q, want datastore://ns/tbl", body["storage"])
+		}
+	})
+
+	t.Run("unconvertible storage fails with its reason", func(t *testing.T) {
+		if _, err := tableBody(clientModel.TableEntity{Storage: "metastore"}, uriByName, errByName); err == nil {
+			t.Error("want error for unconvertible storage, got nil")
+		}
+	})
+
+	t.Run("unknown storage name fails", func(t *testing.T) {
+		if _, err := tableBody(clientModel.TableEntity{Storage: "ghost"}, uriByName, errByName); err == nil {
+			t.Error("want error for unknown storage, got nil")
+		}
+	})
+
+	t.Run("caches are carried over, nil becomes empty list", func(t *testing.T) {
+		withCaches, err := tableBody(clientModel.TableEntity{
+			Storage: "datastore://ns/tbl",
+			Caches:  []any{map[string]any{"type": "recent"}},
+		}, uriByName, errByName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if caches, ok := withCaches["caches"].([]any); !ok || len(caches) != 1 {
+			t.Errorf("caches = %v, want the original single entry", withCaches["caches"])
+		}
+
+		withoutCaches, err := tableBody(clientModel.TableEntity{Storage: "datastore://ns/tbl"}, uriByName, errByName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if caches, ok := withoutCaches["caches"].([]any); !ok || len(caches) != 0 {
+			t.Errorf("caches = %v, want empty list", withoutCaches["caches"])
+		}
+	})
+}
+
+func TestIsAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		expected bool
+	}{
+		{"v2 DDL duplicate: 400 with already-exists message", 400, `{"status":400,"message":"edge already exists"}`, true},
+		{"precondition duplicate: 400 with name-already-exists message", 400, `{"message":"label name already exists : svc.tbl"}`, true},
+		{"plain conflict status", 409, "", true},
+		{"validation failure is not a duplicate", 400, `{"message":"desc is required"}`, false},
+		{"server error is not a duplicate", 500, "edge already exists", false},
+		{"success is not a duplicate", 201, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAlreadyExists(tt.status, tt.body); got != tt.expected {
+				t.Errorf("isAlreadyExists(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.expected)
 			}
 		})
 	}

--- a/cli/internal/command/migrate_test.go
+++ b/cli/internal/command/migrate_test.go
@@ -1,0 +1,78 @@
+package command
+
+import (
+	"testing"
+
+	clientModel "github.com/kakao/actionbase/internal/client/model"
+)
+
+func TestStorageToDatastoreURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		storage  clientModel.StorageEntity
+		expected string
+	}{
+		{
+			name: "HBASE uses namespace and tableName from conf",
+			storage: clientModel.StorageEntity{
+				Name: "default_hbase_storage",
+				Type: "HBASE",
+				Conf: map[string]any{"namespace": "kc_graph", "tableName": "edges"},
+			},
+			expected: "datastore://kc_graph/edges",
+		},
+		{
+			name:     "JDBC maps to __jdbc__ sentinel namespace",
+			storage:  clientModel.StorageEntity{Name: "metastore", Type: "JDBC", Conf: map[string]any{}},
+			expected: "datastore://__jdbc__/metastore",
+		},
+		{
+			name:     "LOCAL maps to __local__ sentinel namespace",
+			storage:  clientModel.StorageEntity{Name: "local_backed_metastore", Type: "LOCAL", Conf: map[string]any{}},
+			expected: "datastore://__local__/local_backed_metastore",
+		},
+		{
+			name:     "unknown type falls back to the storage name unchanged",
+			storage:  clientModel.StorageEntity{Name: "weird", Type: "NIL", Conf: map[string]any{}},
+			expected: "weird",
+		},
+		{
+			name: "HBASE with missing conf keys yields empty segments",
+			storage: clientModel.StorageEntity{
+				Name: "broken",
+				Type: "HBASE",
+				Conf: map[string]any{},
+			},
+			expected: "datastore:///",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storageToDatastoreURI(tt.storage); got != tt.expected {
+				t.Errorf("storageToDatastoreURI(%+v) = %q, want %q", tt.storage, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsSystem(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"bare sys", "sys", true},
+		{"origin-prefixed seed", "origin_default", true},
+		{"operational database", "myservice", false},
+		{"operational qualified label", "myservice.follows", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSystem(tt.input); got != tt.expected {
+				t.Errorf("isSystem(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/cli/internal/runner/actionbase_runner.go
+++ b/cli/internal/runner/actionbase_runner.go
@@ -73,6 +73,7 @@ func NewActionbaseCommandLineRunner(version, host string, authKey *string, curre
 	runner.RegisterCommand(command.TypeDebug.GetName(), command.NewDebug(runner))
 	runner.RegisterCommand(command.TypeGuide.GetName(), command.NewGuide(runner, actionbaseClient))
 	runner.RegisterCommand(command.TypeDoctor.GetName(), command.NewDoctor(actionbaseClient))
+	runner.RegisterCommand(command.TypeMigrate.GetName(), command.NewMigrate(actionbaseClient))
 
 	return runner
 }


### PR DESCRIPTION
## Summary

Adds a native `migrate` CLI command to seed metadata into HBase for Phase 2 of #347, replacing the earlier `dev/*.py` prototype scripts (never merged). Each label's storage reference is rewritten to a `datastore://` URI during migration, so the seeded metadata is valid against the new storage model (#398).

**Once migration completes, MySQL is effectively dead.** Every key exists in HBase, so the overlay (#390) always returns the HBase value and never falls through to MySQL. No code change needed — MySQL just stops being read. That's the gate for Phase 3.

I rebuilt the branch on current main: it previously stacked on #390's overlay commits, which have since been squash-merged. Re-verifying against main surfaced three contract drifts, fixed here: duplicates surface as `400` (not `409`), only HBASE storages have a `datastore://` equivalent, and label `caches` were dropped from the replay body.

Related: #347, #390, #398

## Changes

- `cli/internal/command/migrate.go` — new command, two phases:
  - `migrate plan [-o <file>]` reads databases/tables/aliases (sys/origin skipped) and writes a `{path, body, label}` plan
  - `migrate apply [-i <file>]` replays each entry; duplicates are skipped so re-runs are idempotent
- Duplicate detection matches the server's actual contract: the v2 DDL path maps `failOnExist` duplicates to `400` with an "already exists" message (`AbstractLabel` → `ExceptionController`) — there is no `409`. A plain `409` is still treated as a skip.
- Storage rewrite is HBASE-only: `HBASE → datastore://<namespace>/<table>`. The engine resolves every `datastore://` URI except the reserved `__sys__` metastore as an HBase namespace/table, so minting sentinel URIs for JDBC/LOCAL would create labels the server can't route. `migrate plan` fails fast, with the reason, if a label references a non-HBASE storage. References that are already `datastore://` URIs pass through unchanged.
- Label `caches` are carried into the replay body (previously dropped silently).
- `client.PostRaw` / `http.PostForResult` — POST returning status + raw body, so apply can key on the error message; failures print the server response
- `command_type.go`, `actionbase_runner.go` — register the command
- Unit tests for the storage→URI conversion, the `tableBody` rewrite paths, duplicate matching, and the sys/origin filter

## How to Test

```
cd cli && go test ./...
ACT_HOST=https://ab.example.com ACT_API_KEY=<key> actionbase -e "migrate plan"
# review migration-run.json, then
ACT_HOST=https://ab.example.com ACT_API_KEY=<key> actionbase -e "migrate apply"
```

`migrate apply` exits non-zero if any entry fails.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Opus 4.8, Claude Fable 5
