### PR TITLE
Fix AGG on MULTI_EDGE _source/_target group fields

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -22,7 +22,7 @@ sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
 
     @get:JsonIgnore
-    val propertiesByName: Map<String, StructField> by lazy { properties.associateBy { it.name } }
+    open val propertiesByName: Map<String, StructField> by lazy { properties.associateBy { it.name } }
 
     @JsonTypeName("edge")
     data class Edge(
@@ -47,7 +47,16 @@ sealed class ModelSchema : AbstractSchema {
         val groups: List<Group> = emptyList(),
         val caches: List<Cache> = emptyList(),
     ) : ModelSchema(),
-        AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false))
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false)) {
+        @get:JsonIgnore
+        override val propertiesByName: Map<String, StructField> by lazy {
+            properties.associateBy { it.name } +
+                mapOf(
+                    "_source" to StructField(name = "_source", type = source.type, comment = source.comment, nullable = false),
+                    "_target" to StructField(name = "_target", type = target.type, comment = target.comment, nullable = false),
+                )
+        }
+    }
 
     @JsonTypeName("vertex")
     data class Vertex(

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -22,7 +22,7 @@ sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
 
     @get:JsonIgnore
-    open val propertiesByName: Map<String, StructField> by lazy { properties.associateBy { it.name } }
+    val propertiesByName: Map<String, StructField> by lazy { properties.associateBy { it.name } }
 
     @JsonTypeName("edge")
     data class Edge(
@@ -47,16 +47,7 @@ sealed class ModelSchema : AbstractSchema {
         val groups: List<Group> = emptyList(),
         val caches: List<Cache> = emptyList(),
     ) : ModelSchema(),
-        AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false)) {
-        @get:JsonIgnore
-        override val propertiesByName: Map<String, StructField> by lazy {
-            properties.associateBy { it.name } +
-                mapOf(
-                    "_source" to StructField(name = "_source", type = source.type, comment = source.comment, nullable = false),
-                    "_target" to StructField(name = "_target", type = target.type, comment = target.comment, nullable = false),
-                )
-        }
-    }
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable } + listOf("_source" to false, "_target" to false))
 
     @JsonTypeName("vertex")
     data class Vertex(

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -334,8 +334,7 @@ class V2BackedTableBinding(
                     "only `Eq` predicate is allowed for the first ${firstPairs.size} group fields, but got $predicate."
                 }
                 if (field.bucket == null) {
-                    descriptor.schema.propertiesByName[field.name]
-                        ?.type
+                    descriptor.schema.fieldType(field.name)
                         ?.cast(predicate.value)
                         ?: predicate.value
                 } else {
@@ -474,9 +473,7 @@ class V2BackedTableBinding(
             ceil: Boolean,
         ): Any =
             if (lastField.bucket == null) {
-                descriptor.schema.propertiesByName[lastField.name]
-                    ?.type
-                    ?.cast(value) ?: value
+                descriptor.schema.fieldType(lastField.name)?.cast(value) ?: value
             } else {
                 lastField.bucketOrGet(value, ceil)
             }
@@ -594,6 +591,18 @@ class V2BackedTableBinding(
             when (this) {
                 Direction.OUT -> com.kakao.actionbase.core.metadata.common.Direction.OUT
                 Direction.IN -> com.kakao.actionbase.core.metadata.common.Direction.IN
+            }
+
+        /**
+         * Resolves the primitive type of a field addressable by [name] in this schema.
+         * Covers user-declared properties for all schemas, plus MULTI_EDGE's promoted
+         * `_source` / `_target` keys which are not part of [ModelSchema.propertiesByName].
+         */
+        internal fun ModelSchema.fieldType(name: String): PrimitiveType? =
+            when {
+                this is ModelSchema.MultiEdge && name == "_source" -> source.type
+                this is ModelSchema.MultiEdge && name == "_target" -> target.type
+                else -> propertiesByName[name]?.type
             }
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -594,11 +594,6 @@ class V2BackedTableBinding(
                 Direction.IN -> com.kakao.actionbase.core.metadata.common.Direction.IN
             }
 
-        /**
-         * Resolves the primitive type of a field addressable by [name] in this schema.
-         * Covers user-declared properties for all schemas, plus MULTI_EDGE's promoted
-         * `_source` / `_target` keys which are not part of [ModelSchema.propertiesByName].
-         */
         internal fun ModelSchema.fieldType(name: String): PrimitiveType? =
             when {
                 this is ModelSchema.MultiEdge && name == "_source" -> source.type

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -334,7 +334,8 @@ class V2BackedTableBinding(
                     "only `Eq` predicate is allowed for the first ${firstPairs.size} group fields, but got $predicate."
                 }
                 if (field.bucket == null) {
-                    descriptor.schema.fieldType(field.name)
+                    descriptor.schema
+                        .fieldType(field.name)
                         ?.cast(predicate.value)
                         ?: predicate.value
                 } else {

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.core.metadata.common.DirectionType as V3DirectionTyp
 
 import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
 import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.core.edge.payload.MultiEdgeBulkMutationRequest
 import com.kakao.actionbase.core.metadata.common.Bucket
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.GroupType
@@ -12,6 +13,11 @@ import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.core.metadata.DirectionType
 import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.core.types.DataType
+import com.kakao.actionbase.v2.core.types.EdgeSchema
+import com.kakao.actionbase.v2.core.types.Field
+import com.kakao.actionbase.v2.core.types.VertexField
+import com.kakao.actionbase.v2.core.types.VertexType
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
@@ -437,6 +443,100 @@ class EdgeAggQuerySpec :
 
             queryService
                 .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "day:eq:2024-01-02")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 1L
+                }.verifyComplete()
+        }
+
+        /**
+         * MultiEdge lets a single (source, target) pair repeat, so `_target` is a useful
+         * group dimension. Writes encode `_target` as Long (from the schema target type);
+         * reads must cast the ranges predicate the same way to match, otherwise
+         * the qualifier bytes mismatch and the GET returns nothing.
+         *
+         * Mutation:
+         * | id | source | target |
+         * |----|--------|--------|
+         * | 1  | 1000   | 2000   |
+         * | 2  | 1000   | 2000   |
+         * | 3  | 1000   | 2001   |
+         *
+         * EdgeGroup (source=1000, OUT, GroupType.COUNT, fields=[_target])
+         * |       row key        | qualifier (Long) | value |
+         * |----------------------|------------------|-------|
+         * | hash|1000|T|-5|OUT|G | _target=2000     |     2 |
+         * | hash|1000|T|-5|OUT|G | _target=2001     |     1 |
+         */
+        "INSERT MultiEdge → agg on `_target` group returns per-target count" {
+            val database = GraphFixtures.serviceName
+            val table = "agg_multi_edge_target"
+            val groupName = "by_target"
+
+            val multiEdgeSchema =
+                EdgeSchema(
+                    VertexField(VertexType.LONG),
+                    VertexField(VertexType.LONG),
+                    listOf(
+                        Field("_id", DataType.LONG, false),
+                    ),
+                )
+
+            val createRequest =
+                LabelCreateRequest(
+                    desc = "multi edge target agg test",
+                    type = LabelType.MULTI_EDGE,
+                    schema = multiEdgeSchema,
+                    dirType = DirectionType.BOTH,
+                    storage = GraphFixtures.datastoreStorage,
+                    readOnly = true,
+                    groups =
+                        listOf(
+                            Group(
+                                group = groupName,
+                                type = GroupType.COUNT,
+                                fields = listOf(Group.Field("_target")),
+                                directionType = V3DirectionType.OUT,
+                            ),
+                        ),
+                )
+
+            graph.labelDdl
+                .create(EntityName(database, table), createRequest)
+                .test()
+                .assertNext { it.status.name shouldBe "CREATED" }
+                .verifyComplete()
+
+            val insertRequest =
+                mapper.readValue<MultiEdgeBulkMutationRequest>(
+                    """
+                    {
+                      "mutations": [
+                        {"type": "INSERT", "edge": {"version": 1, "id": 1, "source": 1000, "target": 2000, "properties": {}}},
+                        {"type": "INSERT", "edge": {"version": 1, "id": 2, "source": 1000, "target": 2000, "properties": {}}},
+                        {"type": "INSERT", "edge": {"version": 1, "id": 3, "source": 1000, "target": 2001, "properties": {}}}
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+            mutationService
+                .mutate(database, table, insertRequest.mutations)
+                .test()
+                .assertNext { }
+                .verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "_target:eq:2000")
+                .test()
+                .assertNext { payload ->
+                    payload.count shouldBe 1
+                    payload.groups[0].value shouldBe 2L
+                }.verifyComplete()
+
+            queryService
+                .agg(database, table, groupName, listOf("1000"), Direction.OUT, ranges = "_target:eq:2001")
                 .test()
                 .assertNext { payload ->
                     payload.count shouldBe 1

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/EdgeAggQuerySpec.kt
@@ -451,10 +451,11 @@ class EdgeAggQuerySpec :
         }
 
         /**
-         * MultiEdge lets a single (source, target) pair repeat, so `_target` is a useful
-         * group dimension. Writes encode `_target` as Long (from the schema target type);
-         * reads must cast the ranges predicate the same way to match, otherwise
-         * the qualifier bytes mismatch and the GET returns nothing.
+         * MULTI_EDGE promotes the top-level source/target fields into the persistence
+         * layer under `_source` / `_target`. Grouping on those keys is a common top-k
+         * pattern (per-entity ranking by target). The write path already stores them as
+         * the top-level primitive type; the read path must cast predicates the same way,
+         * otherwise the qualifier bytes mismatch and the GET returns no records.
          *
          * Mutation:
          * | id | source | target |


### PR DESCRIPTION
## Summary

Follow-up to #388. AGG on MULTI_EDGE group fields _source / _target returned empty: the cast site looked them up in propertiesByName, but those are persistence-layer keys not exposed on the domain view. Predicates fell back to String while writes stored Long, so qualifier bytes never matched.

Resolve _source / _target to MultiEdge.source.type / target.type at the cast site. ModelSchema is untouched.

Closes #394

## Changes

- Add ModelSchema.fieldType(name) helper in V2BackedTableBinding covering the promoted keys.
- Route both AGG cast sites (agg, bucketOrCast) through it.
- Add a MULTI_EDGE + _target group case to EdgeAggQuerySpec.

## How to Test
`./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.EdgeAggQuerySpec"`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.7)

