### PR TITLE
Block v2 Storage creation

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
@@ -1,13 +1,11 @@
 package com.kakao.actionbase.server.api.graph.v2.storage
 
-import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.entity.StorageEntity
 import com.kakao.actionbase.v2.engine.service.ddl.DdlPage
 import com.kakao.actionbase.v2.engine.service.ddl.DdlStatus
-import com.kakao.actionbase.v2.engine.service.ddl.StorageCreateRequest
 import com.kakao.actionbase.v2.engine.service.ddl.StorageUpdateRequest
 
 import org.springframework.data.domain.Pageable
@@ -15,7 +13,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -24,6 +21,9 @@ import org.springframework.web.bind.annotation.RestController
 
 import reactor.core.publisher.Mono
 
+// Storage creation is removed as part of the v2 Storage removal (#398): new
+// labels reference storage via datastore:// URIs, so no new Storage is minted.
+// Read and update of existing storages stay available.
 @RestController
 class StorageController(
     val graph: Graph,
@@ -44,17 +44,6 @@ class StorageController(
         @RequestHeader headers: HttpHeaders,
         pageable: Pageable = Pageable.unpaged(),
     ): Mono<ResponseEntity<DdlPage<StorageEntity>>> = graph.storageDdl.getAll(EntityName.origin).mapToResponseEntity()
-
-    @Suppress("UnusedParameter")
-    @PostMapping("/graph/v2/storage/{storage}")
-    fun create(
-        @RequestHeader headers: HttpHeaders,
-        @PathVariable storage: String,
-        @RequestBody request: StorageCreateRequest,
-    ): Mono<ResponseEntity<DdlStatus<StorageEntity>>> {
-        val name = EntityName.fromOrigin(NameValidator.validate(storage, "storage"))
-        return graph.storageDdl.create(name, request).mapToResponseEntity()
-    }
 
     @Suppress("UnusedParameter")
     @PutMapping("/graph/v2/storage/{storage}")

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -205,7 +205,6 @@ class ReadOnlyRequestFilterTest {
                 "POST /graph/v2/service/{service}/label/{label}/edge/purge",
                 "POST /graph/v2/service/{service}/label/{label}/edge/sync",
                 "POST /graph/v2/service/{service}/query/{query}",
-                "POST /graph/v2/storage/{storage}",
                 "PUT /graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}",
                 "PUT /graph/v2/edge",
                 "PUT /graph/v2/service/{service}",


### PR DESCRIPTION
## Summary

Block v2 `Storage` **creation**. `POST /graph/v2/storage/{storage}` is removed, so no new `Storage` can be minted; new labels reference storage via `datastore://<namespace>/<table>` URIs. Read and update of existing storages stay available. Phase 1 of removing `Storage` (#398). Breaking change for clients that create storages.

Closes #398

## Why create-only is enough

`getStorage` already resolves both `datastore://` URIs and legacy storage names:

```kotlin
fun getStorage(uri: String): StorageEntity? =
    when {
        uri.startsWith("datastore://") -> StorageEntity.empty.copy(type = DATASTORE)  // new labels
        else -> storages[EntityName.fromOrigin(uri)]                                  // existing labels
    }
```

So blocking creation is sufficient: new labels can only carry `datastore://` URIs (first branch), and existing labels keep resolving via the `storages` map (second branch). The read path is unchanged — hence this PR is 2 files, and `:server:test` stays green.

Deleting the whole `Storage` type now would be larger and riskier: it removes the `storages` source the second branch depends on, forcing a rewrite of the read path and the in-use guard in the same change. Deferring avoids that coupling.

## Changes

- Remove `Storage` creation (`StorageController` POST).
- Keep read (`GET`), update (`PUT`), the `Storage` type, and `getStorage` as-is — creation is simply unreachable now.

## Follow-up (separate PR)

Once `doctor` confirms no active label references a non-`datastore://` storage, the type, its DDL, and the `getStorage` legacy branch are provably dead and can be deleted mechanically.

## How to Test

- `POST /graph/v2/storage/...` → no longer routable.
- Existing labels still materialize; a label with a `datastore://` storage works.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Opus 4.8
