### PR TITLE
Enforce lowercase alphanumeric/underscore naming across all metadata APIs

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -40,7 +40,6 @@ object Constants {
     object Name {
         const val PATTERN = "^[a-z][a-z0-9_]{0,63}$"
         const val MESSAGE = "name must start with a lowercase letter and contain only lowercase alphanumeric characters or underscores (max 64 chars)"
-        const val MAX_LENGTH = 64
 
         const val STORAGE_URI_PATTERN = "^datastore://[a-z][a-z0-9_]*/[a-z][a-z0-9_]*$"
         const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> where each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table)"

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -41,6 +41,9 @@ object Constants {
         const val PATTERN = "^[a-z][a-z0-9_]{0,63}$"
         const val MESSAGE = "name must start with a lowercase letter and contain only lowercase alphanumeric characters or underscores (max 64 chars)"
 
+        const val COMMENT_MAX_LENGTH = 1000
+        const val COMMENT_SIZE_MESSAGE = "comment must be at most $COMMENT_MAX_LENGTH characters"
+
         const val STORAGE_URI_PATTERN = "^datastore://[a-z][a-z0-9_]*/[a-z][a-z0-9_]*$"
         const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> where each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table)"
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -33,6 +33,16 @@ object Constants {
         const val BYTE_TRUE: Byte = 1
     }
 
+    /**
+     * Naming policy for all Actionbase metadata entities (database, table, alias, service, label, storage).
+     * Rationale: URL path safety + HBase naming constraints both require lowercase alphanumeric and underscore only.
+     */
+    object Name {
+        const val PATTERN = "^[a-z][a-z0-9_]{0,63}$"
+        const val MESSAGE = "name must start with a lowercase letter and contain only lowercase alphanumeric characters or underscores (max 64 chars)"
+        const val MAX_LENGTH = 64
+    }
+
     object Group {
         const val DEFAULT_TTL = 8 * 24 * 60 * 60 * 1000L // 8 days in milliseconds (691,200,000)
 

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -41,6 +41,9 @@ object Constants {
         const val PATTERN = "^[a-z][a-z0-9_]{0,63}$"
         const val MESSAGE = "name must start with a lowercase letter and contain only lowercase alphanumeric characters or underscores (max 64 chars)"
         const val MAX_LENGTH = 64
+
+        const val STORAGE_URI_PATTERN = "^datastore://[a-z0-9_]+/[a-z0-9_]+$"
+        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> using lowercase alphanumeric/underscore only (e.g., datastore://my_namespace/my_table)"
     }
 
     object Group {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -42,8 +42,8 @@ object Constants {
         const val MESSAGE = "name must start with a lowercase letter and contain only lowercase alphanumeric characters or underscores (max 64 chars)"
         const val MAX_LENGTH = 64
 
-        const val STORAGE_URI_PATTERN = "^datastore://[a-z0-9_]+/[a-z0-9_]+$"
-        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> using lowercase alphanumeric/underscore only (e.g., datastore://my_namespace/my_table)"
+        const val STORAGE_URI_PATTERN = "^datastore://[a-z][a-z0-9_]*/[a-z][a-z0-9_]*$"
+        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> where each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table)"
     }
 
     object Group {

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
@@ -1,5 +1,7 @@
 package com.kakao.actionbase.engine.storage
 
+import com.kakao.actionbase.core.Constants
+
 /**
  * Utility for parsing datastore URIs.
  *
@@ -8,6 +10,7 @@ package com.kakao.actionbase.engine.storage
 object DatastoreUri {
     private const val PREFIX = "datastore://"
     private val SAFE_NAME_PATTERN = Regex("^[a-z0-9_]+$")
+    val URI_PATTERN = Regex(Constants.Name.STORAGE_URI_PATTERN)
 
     /**
      * Parses a datastore URI and returns namespace and table name.

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
@@ -1,7 +1,5 @@
 package com.kakao.actionbase.engine.storage
 
-import com.kakao.actionbase.core.Constants
-
 /**
  * Utility for parsing datastore URIs.
  *
@@ -10,7 +8,6 @@ import com.kakao.actionbase.core.Constants
 object DatastoreUri {
     private const val PREFIX = "datastore://"
     private val SAFE_NAME_PATTERN = Regex("^[a-z0-9_]+$")
-    val URI_PATTERN = Regex(Constants.Name.STORAGE_URI_PATTERN)
 
     /**
      * Parses a datastore URI and returns namespace and table name.

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceAliasController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceAliasController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.service
 
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.AliasEntity
@@ -58,7 +59,7 @@ class ServiceAliasController(
         @PathVariable alias: String,
         @Valid @RequestBody request: AliasCreateRequest,
     ): Mono<ResponseEntity<DdlStatus<AliasEntity>>> {
-        val name = EntityName(service, alias)
+        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(alias, "alias"))
         return graph.aliasDdl
             .create(name, request)
             .map {
@@ -72,7 +73,7 @@ class ServiceAliasController(
         @PathVariable alias: String,
         @RequestBody request: AliasUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<AliasEntity>>> {
-        val name = EntityName(service, alias)
+        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(alias, "alias"))
         return graph.aliasDdl
             .update(name, request)
             .map {

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceAliasController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceAliasController.kt
@@ -73,7 +73,7 @@ class ServiceAliasController(
         @PathVariable alias: String,
         @RequestBody request: AliasUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<AliasEntity>>> {
-        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(alias, "alias"))
+        val name = EntityName(service, alias)
         return graph.aliasDdl
             .update(name, request)
             .map {

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceController.kt
@@ -49,7 +49,7 @@ class ServiceController(
         @PathVariable service: String,
         @RequestBody request: ServiceUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<ServiceEntity>>> {
-        val name = EntityName.fromOrigin(NameValidator.validate(service, "service"))
+        val name = EntityName.fromOrigin(service)
         return graph.serviceDdl.update(name, request).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.service
 
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -39,7 +40,7 @@ class ServiceController(
         @PathVariable service: String,
         @RequestBody request: ServiceCreateRequest,
     ): Mono<ResponseEntity<DdlStatus<ServiceEntity>>> {
-        val name = EntityName.fromOrigin(service)
+        val name = EntityName.fromOrigin(NameValidator.validate(service, "service"))
         return graph.serviceDdl.create(name, request).mapToResponseEntity()
     }
 
@@ -48,7 +49,7 @@ class ServiceController(
         @PathVariable service: String,
         @RequestBody request: ServiceUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<ServiceEntity>>> {
-        val name = EntityName.fromOrigin(service)
+        val name = EntityName.fromOrigin(NameValidator.validate(service, "service"))
         return graph.serviceDdl.update(name, request).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceLabelController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceLabelController.kt
@@ -60,7 +60,7 @@ class ServiceLabelController(
         @RequestBody request: LabelUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<LabelEntity>>> {
         getLogger().warn("update request: $request")
-        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(label, "label"))
+        val name = EntityName(service, label)
         return graph.labelDdl.update(name, request).mapToResponseEntity()
     }
 
@@ -71,7 +71,7 @@ class ServiceLabelController(
         @Valid @RequestBody request: LabelCopyRequest,
     ): Mono<ResponseEntity<DdlStatus<LabelEntity>>> {
         val from = EntityName(service, label)
-        val to = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(request.target, "target"))
+        val to = EntityName(service, NameValidator.validate(request.target, "target"))
         return graph.labelDdl.copy(from, to, mapOf("storage" to request.storage)).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceLabelController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/service/ServiceLabelController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.service
 
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -48,7 +49,7 @@ class ServiceLabelController(
         @PathVariable label: String,
         @Valid @RequestBody request: LabelCreateRequest,
     ): Mono<ResponseEntity<DdlStatus<LabelEntity>>> {
-        val name = EntityName(service, label)
+        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(label, "label"))
         return graph.labelDdl.create(name, request).mapToResponseEntity()
     }
 
@@ -59,7 +60,7 @@ class ServiceLabelController(
         @RequestBody request: LabelUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<LabelEntity>>> {
         getLogger().warn("update request: $request")
-        val name = EntityName(service, label)
+        val name = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(label, "label"))
         return graph.labelDdl.update(name, request).mapToResponseEntity()
     }
 
@@ -70,7 +71,7 @@ class ServiceLabelController(
         @Valid @RequestBody request: LabelCopyRequest,
     ): Mono<ResponseEntity<DdlStatus<LabelEntity>>> {
         val from = EntityName(service, label)
-        val to = EntityName(service, request.target)
+        val to = EntityName(NameValidator.validate(service, "service"), NameValidator.validate(request.target, "target"))
         return graph.labelDdl.copy(from, to, mapOf("storage" to request.storage)).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v2.storage
 
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.server.util.mapToResponseEntity
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -51,7 +52,7 @@ class StorageController(
         @PathVariable storage: String,
         @RequestBody request: StorageCreateRequest,
     ): Mono<ResponseEntity<DdlStatus<StorageEntity>>> {
-        val name = EntityName.fromOrigin(storage)
+        val name = EntityName.fromOrigin(NameValidator.validate(storage, "storage"))
         return graph.storageDdl.create(name, request).mapToResponseEntity()
     }
 
@@ -63,7 +64,7 @@ class StorageController(
         @RequestParam(required = false) sync: Boolean = false,
         @RequestBody request: StorageUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<StorageEntity>>> {
-        val name = EntityName.fromOrigin(storage)
+        val name = EntityName.fromOrigin(NameValidator.validate(storage, "storage"))
         return graph.storageDdl.update(name, request).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/storage/StorageController.kt
@@ -64,7 +64,7 @@ class StorageController(
         @RequestParam(required = false) sync: Boolean = false,
         @RequestBody request: StorageUpdateRequest,
     ): Mono<ResponseEntity<DdlStatus<StorageEntity>>> {
-        val name = EntityName.fromOrigin(NameValidator.validate(storage, "storage"))
+        val name = EntityName.fromOrigin(storage)
         return graph.storageDdl.update(name, request).mapToResponseEntity()
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
@@ -1,10 +1,10 @@
 package com.kakao.actionbase.server.api.graph.v3.datastore.hbase
 
-import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseAdmin
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableInfo
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableSchema
 import com.kakao.actionbase.server.configuration.ConditionalOnHBaseDatastore
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.entity.StorageEntity

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.api.graph.v3.datastore.hbase
 
+import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseAdmin
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableInfo
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableSchema
@@ -61,6 +62,7 @@ class DatastoreHBaseService(
         request: HBaseTableCreateRequest?,
     ): Mono<Void> =
         withValidatedTableName(optionalFullQualifierTableName) { tableName ->
+            NameValidator.validate(tableName.qualifierAsString, "table")
             val schema = request?.toHBaseTableSchema() ?: HBaseTableSchema.DEFAULT
             hBaseAdmin.createTable(tableName.namespaceAsString, tableName.qualifierAsString, schema)
         }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasController.kt
@@ -29,7 +29,7 @@ class AliasController(
         @RequestParam(required = false, defaultValue = "ACTIVE") status: MetadataStatus,
     ): Mono<ResponseEntity<List<AliasDescriptor>>> =
         v3CompatService
-            .getAliases(V3NameValidator.validateDatabase(database), status)
+            .getAliases(database, status)
             .map { ResponseEntity.ok(it) }
 
     @GetMapping("/graph/v3/databases/{database}/aliases/{alias}")
@@ -38,7 +38,7 @@ class AliasController(
         @PathVariable alias: String,
     ): Mono<ResponseEntity<AliasDescriptor>> =
         v3CompatService
-            .getAlias(V3NameValidator.validateDatabase(database), V3NameValidator.validateAlias(alias))
+            .getAlias(database, alias)
             .map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
 
@@ -62,8 +62,8 @@ class AliasController(
     ): Mono<ResponseEntity<AliasDescriptor>> =
         v3CompatService
             .updateAlias(
-                V3NameValidator.validateDatabase(database),
-                V3NameValidator.validateAlias(alias),
+                database,
+                alias,
                 request,
             ).map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
@@ -74,6 +74,6 @@ class AliasController(
         @PathVariable alias: String,
     ): Mono<ResponseEntity<Void>> =
         v3CompatService
-            .deleteAlias(V3NameValidator.validateDatabase(database), V3NameValidator.validateAlias(alias))
+            .deleteAlias(database, alias)
             .then(Mono.just(ResponseEntity.noContent().build<Void>()))
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
@@ -1,21 +1,16 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
+import com.kakao.actionbase.core.Constants
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class AliasCreateRequest(
     @field:NotBlank(message = "alias is required")
-    @field:Pattern(
-        regexp = "^[a-z][a-z0-9_]{0,63}$",
-        message = "alias must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
-    )
+    @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val alias: String,
     @field:NotBlank(message = "table is required")
-    @field:Pattern(
-        regexp = "^[a-z][a-z0-9_]{0,63}$",
-        message = "table must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
-    )
+    @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val table: String,
     @field:Size(max = 1000, message = "comment must be at most 1000 characters")
     val comment: String,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
@@ -7,14 +7,14 @@ import jakarta.validation.constraints.Size
 data class AliasCreateRequest(
     @field:NotBlank(message = "alias is required")
     @field:Pattern(
-        regexp = "^[a-zA-Z][a-zA-Z0-9_-]{0,63}$",
-        message = "alias must start with a letter, contain only alphanumeric/underscore/hyphen, max 64 chars",
+        regexp = "^[a-z][a-z0-9_]{0,63}$",
+        message = "alias must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
     )
     val alias: String,
     @field:NotBlank(message = "table is required")
     @field:Pattern(
-        regexp = "^[a-zA-Z][a-zA-Z0-9_-]{0,63}$",
-        message = "table must start with a letter, contain only alphanumeric/underscore/hyphen, max 64 chars",
+        regexp = "^[a-z][a-z0-9_]{0,63}$",
+        message = "table must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
     )
     val table: String,
     @field:Size(max = 1000, message = "comment must be at most 1000 characters")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasCreateRequest.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
 import com.kakao.actionbase.core.Constants
+
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
@@ -12,6 +13,6 @@ data class AliasCreateRequest(
     @field:NotBlank(message = "table is required")
     @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val table: String,
-    @field:Size(max = 1000, message = "comment must be at most 1000 characters")
+    @field:Size(max = Constants.Name.COMMENT_MAX_LENGTH, message = Constants.Name.COMMENT_SIZE_MESSAGE)
     val comment: String,
 )

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasUpdateRequest.kt
@@ -1,14 +1,12 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
+import com.kakao.actionbase.core.Constants
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class AliasUpdateRequest(
     val active: Boolean? = null,
-    @field:Pattern(
-        regexp = "^[a-zA-Z][a-zA-Z0-9_-]{0,63}$",
-        message = "table must start with a letter, contain only alphanumeric/underscore/hyphen, max 64 chars",
-    )
+    @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val table: String? = null,
     @field:Size(max = 1000, message = "comment must be at most 1000 characters")
     val comment: String? = null,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasUpdateRequest.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
 import com.kakao.actionbase.core.Constants
+
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
@@ -8,6 +9,6 @@ data class AliasUpdateRequest(
     val active: Boolean? = null,
     @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val table: String? = null,
-    @field:Size(max = 1000, message = "comment must be at most 1000 characters")
+    @field:Size(max = Constants.Name.COMMENT_MAX_LENGTH, message = Constants.Name.COMMENT_SIZE_MESSAGE)
     val comment: String? = null,
 )

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseController.kt
@@ -38,7 +38,7 @@ class DatabaseController(
         @PathVariable database: String,
     ): Mono<ResponseEntity<DatabaseDescriptor>> =
         v3CompatService
-            .getDatabase(V3NameValidator.validateDatabase(database))
+            .getDatabase(database)
             .map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
 
@@ -56,7 +56,7 @@ class DatabaseController(
         @Valid @RequestBody request: DatabaseUpdateRequest,
     ): Mono<ResponseEntity<DatabaseDescriptor>> =
         v3CompatService
-            .updateDatabase(V3NameValidator.validateDatabase(database), request)
+            .updateDatabase(database, request)
             .map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
 
@@ -65,6 +65,6 @@ class DatabaseController(
         @PathVariable database: String,
     ): Mono<ResponseEntity<Void>> =
         v3CompatService
-            .deleteDatabase(V3NameValidator.validateDatabase(database))
+            .deleteDatabase(database)
             .then(Mono.just(ResponseEntity.noContent().build<Void>()))
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableController.kt
@@ -29,7 +29,7 @@ class TableController(
         @RequestParam(required = false, defaultValue = "ACTIVE") status: MetadataStatus,
     ): Mono<ResponseEntity<List<TableDescriptor<*>>>> =
         v3CompatService
-            .getTables(V3NameValidator.validateDatabase(database), status)
+            .getTables(database, status)
             .map { ResponseEntity.ok(it) }
 
     @GetMapping("/graph/v3/databases/{database}/tables/{table}")
@@ -38,7 +38,7 @@ class TableController(
         @PathVariable table: String,
     ): Mono<ResponseEntity<TableDescriptor<*>>> =
         v3CompatService
-            .getTable(V3NameValidator.validateDatabase(database), V3NameValidator.validateTable(table))
+            .getTable(database, table)
             .map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
 
@@ -62,8 +62,8 @@ class TableController(
     ): Mono<ResponseEntity<TableDescriptor<*>>> =
         v3CompatService
             .updateTable(
-                V3NameValidator.validateDatabase(database),
-                V3NameValidator.validateTable(table),
+                database,
+                table,
                 request,
             ).map { ResponseEntity.ok(it) }
             .defaultIfEmpty(ResponseEntity.notFound().build())
@@ -74,6 +74,6 @@ class TableController(
         @PathVariable table: String,
     ): Mono<ResponseEntity<Void>> =
         v3CompatService
-            .deleteTable(V3NameValidator.validateDatabase(database), V3NameValidator.validateTable(table))
+            .deleteTable(database, table)
             .then(Mono.just(ResponseEntity.noContent().build<Void>()))
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -30,10 +30,7 @@ data class TableCreateRequest(
     @field:Valid
     val schema: ModelSchema,
     @field:NotBlank(message = "storage is required")
-    @field:Pattern(
-        regexp = "^datastore://[a-z0-9_]+/[a-z0-9_]+$",
-        message = "storage must be in format datastore://<namespace>/<table> using lowercase alphanumeric/underscore only (e.g., datastore://my_namespace/my_table)",
-    )
+    @field:Pattern(regexp = Constants.Name.STORAGE_URI_PATTERN, message = Constants.Name.STORAGE_URI_MESSAGE)
     val storage: String,
     val mode: MutationMode = MutationMode.SYNC,
     @field:Size(max = 1000, message = "comment must be at most 1000 characters")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.v2.core.code.Index as V2Index
 import com.kakao.actionbase.v2.core.metadata.DirectionType as V2DirectionType
 import com.kakao.actionbase.v2.core.types.Field as V2Field
 
+import com.kakao.actionbase.core.Constants
 import com.kakao.actionbase.core.Constants.VERTEX_TARGET_COMMENT
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.metadata.common.MutationMode
@@ -23,18 +24,15 @@ import jakarta.validation.constraints.Size
 
 data class TableCreateRequest(
     @field:NotBlank(message = "table is required")
-    @field:Pattern(
-        regexp = "^[a-z][a-z0-9_]{0,63}$",
-        message = "table must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
-    )
+    @field:Pattern(regexp = Constants.Name.PATTERN, message = Constants.Name.MESSAGE)
     val table: String,
     @field:NotNull(message = "schema is required")
     @field:Valid
     val schema: ModelSchema,
     @field:NotBlank(message = "storage is required")
     @field:Pattern(
-        regexp = "^datastore://[a-z_]+/[a-zA-Z0-9_]+$",
-        message = "storage must be in format datastore://<namespace>/<table> (e.g., datastore://my_namespace/my_table)",
+        regexp = "^datastore://[a-z0-9_]+/[a-z0-9_]+$",
+        message = "storage must be in format datastore://<namespace>/<table> using lowercase alphanumeric/underscore only (e.g., datastore://my_namespace/my_table)",
     )
     val storage: String,
     val mode: MutationMode = MutationMode.SYNC,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -33,7 +33,7 @@ data class TableCreateRequest(
     @field:Pattern(regexp = Constants.Name.STORAGE_URI_PATTERN, message = Constants.Name.STORAGE_URI_MESSAGE)
     val storage: String,
     val mode: MutationMode = MutationMode.SYNC,
-    @field:Size(max = 1000, message = "comment must be at most 1000 characters")
+    @field:Size(max = Constants.Name.COMMENT_MAX_LENGTH, message = Constants.Name.COMMENT_SIZE_MESSAGE)
     val comment: String,
 ) {
     fun toV2EdgeSchema(): EdgeSchema =

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -24,8 +24,8 @@ import jakarta.validation.constraints.Size
 data class TableCreateRequest(
     @field:NotBlank(message = "table is required")
     @field:Pattern(
-        regexp = "^[a-zA-Z][a-zA-Z0-9_-]{0,63}$",
-        message = "table must start with a letter, contain only alphanumeric/underscore/hyphen, max 64 chars",
+        regexp = "^[a-z][a-z0-9_]{0,63}$",
+        message = "table must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
     )
     val table: String,
     @field:NotNull(message = "schema is required")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -3,6 +3,7 @@ package com.kakao.actionbase.server.api.graph.v3.metadata
 import com.kakao.actionbase.v2.core.code.Index as V2Index
 import com.kakao.actionbase.v2.core.types.Field as V2Field
 
+import com.kakao.actionbase.core.Constants
 import com.kakao.actionbase.core.metadata.common.Cache
 import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.ModelSchema
@@ -21,7 +22,7 @@ data class TableUpdateRequest(
     @field:Valid
     val schema: ModelSchema? = null,
     val mode: MutationMode? = null,
-    @field:Size(max = 1000, message = "comment must be at most 1000 characters")
+    @field:Size(max = Constants.Name.COMMENT_MAX_LENGTH, message = Constants.Name.COMMENT_SIZE_MESSAGE)
     val comment: String? = null,
 ) {
     fun toV2EdgeSchema(): EdgeSchema? =

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
@@ -1,28 +1,10 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
-import com.kakao.actionbase.core.Constants
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
+import com.kakao.actionbase.server.util.NameValidator
 
 object V3NameValidator {
-    private val NAME_PATTERN = Regex(Constants.Name.PATTERN)
-
-    fun validate(
-        name: String,
-        fieldName: String,
-    ): String {
-        if (!name.matches(NAME_PATTERN)) {
-            throw ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                "Invalid $fieldName: ${Constants.Name.MESSAGE}",
-            )
-        }
-        return name
-    }
-
-    fun validateDatabase(name: String): String = validate(name, "database")
-
-    fun validateTable(name: String): String = validate(name, "table")
-
-    fun validateAlias(name: String): String = validate(name, "alias")
+    fun validate(name: String, fieldName: String): String = NameValidator.validate(name, fieldName)
+    fun validateDatabase(name: String): String = NameValidator.validate(name, "database")
+    fun validateTable(name: String): String = NameValidator.validate(name, "table")
+    fun validateAlias(name: String): String = NameValidator.validate(name, "alias")
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
@@ -5,11 +5,11 @@ import org.springframework.web.server.ResponseStatusException
 
 /**
  * Validates names for V3 Metadata API to prevent injection attacks.
- * Names must start with a letter and contain only alphanumeric characters,
- * underscores, or hyphens. Maximum length is 64 characters.
+ * Names must start with a lowercase letter and contain only lowercase alphanumeric
+ * characters or underscores. Maximum length is 64 characters.
  */
 object V3NameValidator {
-    private val NAME_PATTERN = Regex("^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
+    private val NAME_PATTERN = Regex("^[a-z][a-z0-9_]{0,63}$")
 
     /**
      * Validates a name and returns it if valid.
@@ -22,7 +22,7 @@ object V3NameValidator {
         if (!name.matches(NAME_PATTERN)) {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "Invalid $fieldName: must start with a letter, contain only alphanumeric/underscore/hyphen, max 64 chars",
+                "Invalid $fieldName: must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
             )
         }
         return name

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
@@ -3,8 +3,14 @@ package com.kakao.actionbase.server.api.graph.v3.metadata
 import com.kakao.actionbase.server.util.NameValidator
 
 object V3NameValidator {
-    fun validate(name: String, fieldName: String): String = NameValidator.validate(name, fieldName)
+    fun validate(
+        name: String,
+        fieldName: String,
+    ): String = NameValidator.validate(name, fieldName)
+
     fun validateDatabase(name: String): String = NameValidator.validate(name, "database")
+
     fun validateTable(name: String): String = NameValidator.validate(name, "table")
+
     fun validateAlias(name: String): String = NameValidator.validate(name, "alias")
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidator.kt
@@ -1,20 +1,12 @@
 package com.kakao.actionbase.server.api.graph.v3.metadata
 
+import com.kakao.actionbase.core.Constants
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-/**
- * Validates names for V3 Metadata API to prevent injection attacks.
- * Names must start with a lowercase letter and contain only lowercase alphanumeric
- * characters or underscores. Maximum length is 64 characters.
- */
 object V3NameValidator {
-    private val NAME_PATTERN = Regex("^[a-z][a-z0-9_]{0,63}$")
+    private val NAME_PATTERN = Regex(Constants.Name.PATTERN)
 
-    /**
-     * Validates a name and returns it if valid.
-     * @throws ResponseStatusException with 400 Bad Request if invalid
-     */
     fun validate(
         name: String,
         fieldName: String,
@@ -22,7 +14,7 @@ object V3NameValidator {
         if (!name.matches(NAME_PATTERN)) {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "Invalid $fieldName: must start with a lowercase letter, contain only lowercase alphanumeric/underscore, max 64 chars",
+                "Invalid $fieldName: ${Constants.Name.MESSAGE}",
             )
         }
         return name

--- a/server/src/main/kotlin/com/kakao/actionbase/server/util/NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/util/NameValidator.kt
@@ -1,0 +1,22 @@
+package com.kakao.actionbase.server.util
+
+import com.kakao.actionbase.core.Constants
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+object NameValidator {
+    private val NAME_PATTERN = Regex(Constants.Name.PATTERN)
+
+    fun validate(
+        name: String,
+        fieldName: String,
+    ): String {
+        if (!name.matches(NAME_PATTERN)) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Invalid $fieldName: ${Constants.Name.MESSAGE}",
+            )
+        }
+        return name
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/util/NameValidator.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/util/NameValidator.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.util
 
 import com.kakao.actionbase.core.Constants
+
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/edge/V2EdgeStorageOpsSpec.kt
@@ -10,8 +10,8 @@ import org.springframework.http.MediaType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class V2EdgeStorageOpsSpec : E2ETestBase() {
-    private val service = "v2-storage-ops-svc"
-    private val label = "v2-storage-ops-label"
+    private val service = "v2_storage_ops_svc"
+    private val label = "v2_storage_ops_label"
     private val name = "$service.$label"
 
     @BeforeAll

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ActionbaseQueryE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ActionbaseQueryE2ETest.kt
@@ -21,8 +21,8 @@ import org.springframework.http.MediaType
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ActionbaseQueryE2ETest : E2ETestBase() {
-    private val db1 = "multihop-db1"
-    private val db2 = "multihop-db2"
+    private val db1 = "multihop_db1"
+    private val db2 = "multihop_db2"
     private val hop1Table = "follows"
     private val hop2Table = "wishlist"
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeAggCountSentinelE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeAggCountSentinelE2ETest.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EdgeAggCountSentinelE2ETest : E2ETestBase() {
-    private val db = "test-agg-count-db"
+    private val db = "test_agg_count_db"
     private val table = "follows"
     private val objectMapper = jacksonObjectMapper()
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeCacheQueryE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeCacheQueryE2ETest.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 class EdgeCacheQueryE2ETest : E2ETestBase() {
     private val objectMapper = jacksonObjectMapper()
 
-    private val db = "test-db"
+    private val db = "test_db"
     private val edgeTable = "wishlist"
     private val multiEdgeTable = "orders"
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationForceSyncTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationForceSyncTest.kt
@@ -11,9 +11,9 @@ import org.springframework.test.context.TestPropertySource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = ["kc.graph.system-mutation-mode=ASYNC"])
 class EdgeMutationForceSyncTest : E2ETestBase() {
-    private val db = "force-sync-test-db"
-    private val table = "force-sync-edge"
-    private val multiEdgeTable = "force-sync-multi-edge"
+    private val db = "force_sync_test_db"
+    private val table = "force_sync_edge"
+    private val multiEdgeTable = "force_sync_multi_edge"
 
     @BeforeAll
     fun setup() {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationStorageOpsSpec.kt
@@ -10,9 +10,9 @@ import org.springframework.http.MediaType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EdgeMutationStorageOpsSpec : E2ETestBase() {
-    private val db = "storage-ops-db"
-    private val edgeTable = "storage-ops-edge"
-    private val multiEdgeTable = "storage-ops-multi"
+    private val db = "storage_ops_db"
+    private val edgeTable = "storage_ops_edge"
+    private val multiEdgeTable = "storage_ops_multi"
 
     @BeforeAll
     fun setup() {
@@ -87,7 +87,7 @@ class EdgeMutationStorageOpsSpec : E2ETestBase() {
     @ObjectSource(
         cases = """
         - name: edge without header omits storage_ops
-          table: storage-ops-edge
+          table: storage_ops_edge
           path: edges
           header: null
           body: |
@@ -95,15 +95,15 @@ class EdgeMutationStorageOpsSpec : E2ETestBase() {
           storageOpsExists: false
 
         - name: edge with header exposes storage_ops
-          table: storage-ops-edge
+          table: storage_ops_edge
           path: edges
           header: "true"
           body: |
             {"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "x", "target": "y", "properties": {"score": 2}}}]}
           storageOpsExists: true
 
-        - name: multi-edge with header exposes storage_ops
-          table: storage-ops-multi
+        - name: multi_edge with header exposes storage_ops
+          table: storage_ops_multi
           path: multi-edges
           header: "true"
           body: |

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationValidationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationValidationTest.kt
@@ -14,9 +14,9 @@ import org.springframework.test.web.reactive.server.StatusAssertions
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EdgeMutationValidationTest : E2ETestBase() {
-    private val db = "validation-test-db"
-    private val syncTable = "validation-sync-edge"
-    private val asyncTable = "validation-async-edge"
+    private val db = "validation_test_db"
+    private val syncTable = "validation_sync_edge"
+    private val asyncTable = "validation_async_edge"
 
     // Schema: "required" (long, non-nullable), "optional" (string, nullable)
     private fun tableDdl(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/MutationContextOptInE2ETest.kt
@@ -143,7 +143,7 @@ class MutationContextOptInE2ETest : E2ETestBase() {
             .header(INCLUDE_MUTATION_CONTEXT, "false")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
-                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-false", "target": "t-false", "properties": {}}}]}""",
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s_false", "target": "t_false", "properties": {}}}]}""",
             ).exchange()
             .expectStatus()
             .isOk
@@ -160,7 +160,7 @@ class MutationContextOptInE2ETest : E2ETestBase() {
             .header(INCLUDE_MUTATION_CONTEXT, "true")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
-                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s-async", "target": "t-async", "properties": {}}}]}""",
+                """{"mutations": [{"type": "INSERT", "edge": {"version": 1, "source": "s_async", "target": "t_async", "properties": {}}}]}""",
             ).exchange()
             .expectStatus()
             .isOk
@@ -193,7 +193,7 @@ class MutationContextOptInE2ETest : E2ETestBase() {
             .uri("/graph/v2/edge")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
-                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-a", "tgt": "t-v2-a", "props": {}}]}""",
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s_v2_a", "tgt": "t_v2_a", "props": {}}]}""",
             ).exchange()
             .expectStatus()
             .isOk
@@ -210,7 +210,7 @@ class MutationContextOptInE2ETest : E2ETestBase() {
             .header(INCLUDE_MUTATION_CONTEXT, "true")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
-                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s-v2-b", "tgt": "t-v2-b", "props": {}}]}""",
+                """{"label": "$db.$edgeTable", "edges": [{"ts": 1, "src": "s_v2_b", "tgt": "t_v2_b", "props": {}}]}""",
             ).exchange()
             .expectStatus()
             .isOk

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/VertexIntegrationTest.kt
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VertexIntegrationTest : E2ETestBase() {
-    private val db = "vertex-db"
+    private val db = "vertex_db"
     private val vertexTable = "users"
     private val longIdTable = "users_long"
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -12,8 +12,8 @@ import org.springframework.http.MediaType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AliasControllerTest : E2ETestBase() {
-    private val db = "v3-alias-test-db"
-    private val table = "v3-alias-target-table"
+    private val db = "v3_alias_test_db"
+    private val table = "v3_alias_target_table"
     private val baseUri = "/graph/v3/databases/$db/aliases"
 
     @BeforeAll
@@ -60,21 +60,21 @@ class AliasControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-alias-basic
+            - name: v3_alias_basic
               create: |
-                {"alias": "v3-alias-basic", "table": "v3-alias-target-table", "comment": "test alias"}
+                {"alias": "v3_alias_basic", "table": "v3_alias_target_table", "comment": "test alias"}
               expected: |
-                {"alias": "v3-alias-basic", "table": "v3-alias-target-table", "comment": "test alias", "active": true}
-            - name: v3-alias-empty
+                {"alias": "v3_alias_basic", "table": "v3_alias_target_table", "comment": "test alias", "active": true}
+            - name: v3_alias_empty
               create: |
-                {"alias": "v3-alias-empty", "table": "v3-alias-target-table", "comment": ""}
+                {"alias": "v3_alias_empty", "table": "v3_alias_target_table", "comment": ""}
               expected: |
-                {"alias": "v3-alias-empty", "table": "v3-alias-target-table", "comment": "", "active": true}
-            - name: v3-alias-special
+                {"alias": "v3_alias_empty", "table": "v3_alias_target_table", "comment": "", "active": true}
+            - name: v3_alias_special
               create: |
-                {"alias": "v3-alias-special", "table": "v3-alias-target-table", "comment": "alias @#"}
+                {"alias": "v3_alias_special", "table": "v3_alias_target_table", "comment": "alias @#"}
               expected: |
-                {"alias": "v3-alias-special", "table": "v3-alias-target-table", "comment": "alias @#", "active": true}
+                {"alias": "v3_alias_special", "table": "v3_alias_target_table", "comment": "alias @#", "active": true}
             """,
         )
         fun `create alias`(
@@ -106,27 +106,27 @@ class AliasControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-alias-upd-basic
+            - name: v3_alias_upd_basic
               create: |
-                {"alias": "v3-alias-upd-basic", "table": "v3-alias-target-table", "comment": "test alias"}
+                {"alias": "v3_alias_upd_basic", "table": "v3_alias_target_table", "comment": "test alias"}
               update: |
                 {"comment": "updated comment"}
               expected: |
-                {"alias": "v3-alias-upd-basic", "comment": "updated comment", "active": true}
-            - name: v3-alias-upd-empty
+                {"alias": "v3_alias_upd_basic", "comment": "updated comment", "active": true}
+            - name: v3_alias_upd_empty
               create: |
-                {"alias": "v3-alias-upd-empty", "table": "v3-alias-target-table", "comment": ""}
+                {"alias": "v3_alias_upd_empty", "table": "v3_alias_target_table", "comment": ""}
               update: |
                 {"comment": "updated empty"}
               expected: |
-                {"alias": "v3-alias-upd-empty", "comment": "updated empty", "active": true}
-            - name: v3-alias-upd-special
+                {"alias": "v3_alias_upd_empty", "comment": "updated empty", "active": true}
+            - name: v3_alias_upd_special
               create: |
-                {"alias": "v3-alias-upd-special", "table": "v3-alias-target-table", "comment": "alias @#"}
+                {"alias": "v3_alias_upd_special", "table": "v3_alias_target_table", "comment": "alias @#"}
               update: |
                 {"comment": "updated special"}
               expected: |
-                {"alias": "v3-alias-upd-special", "comment": "updated special", "active": true}
+                {"alias": "v3_alias_upd_special", "comment": "updated special", "active": true}
             """,
         )
         fun `update alias`(
@@ -164,21 +164,21 @@ class AliasControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-alias-deact-basic
+            - name: v3_alias_deact_basic
               create: |
-                {"alias": "v3-alias-deact-basic", "table": "v3-alias-target-table", "comment": "test alias"}
+                {"alias": "v3_alias_deact_basic", "table": "v3_alias_target_table", "comment": "test alias"}
               expected: |
-                {"alias": "v3-alias-deact-basic", "active": false}
-            - name: v3-alias-deact-empty
+                {"alias": "v3_alias_deact_basic", "active": false}
+            - name: v3_alias_deact_empty
               create: |
-                {"alias": "v3-alias-deact-empty", "table": "v3-alias-target-table", "comment": ""}
+                {"alias": "v3_alias_deact_empty", "table": "v3_alias_target_table", "comment": ""}
               expected: |
-                {"alias": "v3-alias-deact-empty", "active": false}
-            - name: v3-alias-deact-special
+                {"alias": "v3_alias_deact_empty", "active": false}
+            - name: v3_alias_deact_special
               create: |
-                {"alias": "v3-alias-deact-special", "table": "v3-alias-target-table", "comment": "alias @#"}
+                {"alias": "v3_alias_deact_special", "table": "v3_alias_target_table", "comment": "alias @#"}
               expected: |
-                {"alias": "v3-alias-deact-special", "active": false}
+                {"alias": "v3_alias_deact_special", "active": false}
             """,
         )
         fun `deactivate alias`(
@@ -218,16 +218,16 @@ class AliasControllerTest : E2ETestBase() {
                 {"active": true}
             """,
             cases = """
-            - name: v3-alias-react-basic
+            - name: v3_alias_react_basic
               create: |
-                {"alias": "v3-alias-react-basic", "table": "v3-alias-target-table", "comment": "test alias"}
+                {"alias": "v3_alias_react_basic", "table": "v3_alias_target_table", "comment": "test alias"}
               expected: |
-                {"alias": "v3-alias-react-basic", "active": true}
-            - name: v3-alias-react-empty
+                {"alias": "v3_alias_react_basic", "active": true}
+            - name: v3_alias_react_empty
               create: |
-                {"alias": "v3-alias-react-empty", "table": "v3-alias-target-table", "comment": ""}
+                {"alias": "v3_alias_react_empty", "table": "v3_alias_target_table", "comment": ""}
               expected: |
-                {"alias": "v3-alias-react-empty", "active": true}
+                {"alias": "v3_alias_react_empty", "active": true}
             """,
         )
         fun `reactivate alias`(
@@ -275,15 +275,15 @@ class AliasControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-alias-del-basic
+            - name: v3_alias_del_basic
               create: |
-                {"alias": "v3-alias-del-basic", "table": "v3-alias-target-table", "comment": "test alias"}
-            - name: v3-alias-del-empty
+                {"alias": "v3_alias_del_basic", "table": "v3_alias_target_table", "comment": "test alias"}
+            - name: v3_alias_del_empty
               create: |
-                {"alias": "v3-alias-del-empty", "table": "v3-alias-target-table", "comment": ""}
-            - name: v3-alias-del-special
+                {"alias": "v3_alias_del_empty", "table": "v3_alias_target_table", "comment": ""}
+            - name: v3_alias_del_special
               create: |
-                {"alias": "v3-alias-del-special", "table": "v3-alias-target-table", "comment": "alias @#"}
+                {"alias": "v3_alias_del_special", "table": "v3_alias_target_table", "comment": "alias @#"}
             """,
         )
         fun `delete alias`(
@@ -322,7 +322,7 @@ class AliasControllerTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class StatusFilterTest {
-        private val aliasName = "v3-alias-status-filter"
+        private val aliasName = "v3_alias_status_filter"
 
         @BeforeAll
         fun setup() {
@@ -424,7 +424,7 @@ class AliasControllerTest : E2ETestBase() {
         fun `get non-existent alias returns 404`() {
             client
                 .get()
-                .uri("$baseUri/non-existent")
+                .uri("$baseUri/non_existent")
                 .exchange()
                 .expectStatus()
                 .isNotFound
@@ -434,7 +434,7 @@ class AliasControllerTest : E2ETestBase() {
         fun `invalid alias name returns 400`() {
             client
                 .get()
-                .uri("$baseUri/123-invalid")
+                .uri("$baseUri/123invalid")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -433,8 +433,10 @@ class AliasControllerTest : E2ETestBase() {
         @Test
         fun `invalid alias name returns 400`() {
             client
-                .get()
-                .uri("$baseUri/123invalid")
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"alias": "123invalid", "table": "valid_table", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest
@@ -443,8 +445,10 @@ class AliasControllerTest : E2ETestBase() {
         @Test
         fun `alias name with dot returns 400`() {
             client
-                .get()
-                .uri("$baseUri/alias.injection")
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"alias": "alias.injection", "table": "valid_table", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -465,5 +465,29 @@ class AliasControllerTest : E2ETestBase() {
                 .expectStatus()
                 .isBadRequest
         }
+
+        @Test
+        fun `update alias with hyphenated table name returns 400`() {
+            client
+                .put()
+                .uri("$baseUri/valid_alias")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"table": "my-table"}""")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
+        fun `update alias with uppercase table name returns 400`() {
+            client
+                .put()
+                .uri("$baseUri/valid_alias")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"table": "MyTable"}""")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/AliasControllerTest.kt
@@ -443,6 +443,18 @@ class AliasControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `alias name with hyphen returns 400`() {
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"alias": "my-alias", "table": "valid_table", "comment": ""}""")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `alias name with dot returns 400`() {
             client
                 .post()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -394,6 +394,18 @@ class DatabaseControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `database name with hyphen returns 400`() {
+            client
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"database": "my-db", "comment": ""}""")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `database name with dot returns 400`() {
             client
                 .post()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -18,21 +18,21 @@ class DatabaseControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-db-basic
+            - name: v3_db_basic
               create: |
-                {"database": "v3-db-basic", "comment": "test db"}
+                {"database": "v3_db_basic", "comment": "test db"}
               expected: |
-                {"database": "v3-db-basic", "comment": "test db", "active": true}
-            - name: v3-db-empty-comment
+                {"database": "v3_db_basic", "comment": "test db", "active": true}
+            - name: v3_db_empty_comment
               create: |
-                {"database": "v3-db-empty-comment", "comment": ""}
+                {"database": "v3_db_empty_comment", "comment": ""}
               expected: |
-                {"database": "v3-db-empty-comment", "comment": "", "active": true}
-            - name: v3-db-special
+                {"database": "v3_db_empty_comment", "comment": "", "active": true}
+            - name: v3_db_special
               create: |
-                {"database": "v3-db-special", "comment": "test @#$%"}
+                {"database": "v3_db_special", "comment": "test @#$%"}
               expected: |
-                {"database": "v3-db-special", "comment": "test @#$%", "active": true}
+                {"database": "v3_db_special", "comment": "test @#$%", "active": true}
             """,
         )
         fun `create database`(
@@ -64,27 +64,27 @@ class DatabaseControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-db-upd-basic
+            - name: v3_db_upd_basic
               create: |
-                {"database": "v3-db-upd-basic", "comment": "test db"}
+                {"database": "v3_db_upd_basic", "comment": "test db"}
               update: |
                 {"comment": "updated comment"}
               expected: |
-                {"database": "v3-db-upd-basic", "comment": "updated comment", "active": true}
-            - name: v3-db-upd-empty
+                {"database": "v3_db_upd_basic", "comment": "updated comment", "active": true}
+            - name: v3_db_upd_empty
               create: |
-                {"database": "v3-db-upd-empty", "comment": ""}
+                {"database": "v3_db_upd_empty", "comment": ""}
               update: |
                 {"comment": "updated empty"}
               expected: |
-                {"database": "v3-db-upd-empty", "comment": "updated empty", "active": true}
-            - name: v3-db-upd-special
+                {"database": "v3_db_upd_empty", "comment": "updated empty", "active": true}
+            - name: v3_db_upd_special
               create: |
-                {"database": "v3-db-upd-special", "comment": "test @#$%"}
+                {"database": "v3_db_upd_special", "comment": "test @#$%"}
               update: |
                 {"comment": "updated special"}
               expected: |
-                {"database": "v3-db-upd-special", "comment": "updated special", "active": true}
+                {"database": "v3_db_upd_special", "comment": "updated special", "active": true}
             """,
         )
         fun `update database`(
@@ -122,16 +122,16 @@ class DatabaseControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-db-deact-basic
+            - name: v3_db_deact_basic
               create: |
-                {"database": "v3-db-deact-basic", "comment": "test db"}
+                {"database": "v3_db_deact_basic", "comment": "test db"}
               expected: |
-                {"database": "v3-db-deact-basic", "active": false}
-            - name: v3-db-deact-empty
+                {"database": "v3_db_deact_basic", "active": false}
+            - name: v3_db_deact_empty
               create: |
-                {"database": "v3-db-deact-empty", "comment": ""}
+                {"database": "v3_db_deact_empty", "comment": ""}
               expected: |
-                {"database": "v3-db-deact-empty", "active": false}
+                {"database": "v3_db_deact_empty", "active": false}
             """,
         )
         fun `deactivate database`(
@@ -171,16 +171,16 @@ class DatabaseControllerTest : E2ETestBase() {
                 {"active": true}
             """,
             cases = """
-            - name: v3-db-react-basic
+            - name: v3_db_react_basic
               create: |
-                {"database": "v3-db-react-basic", "comment": "test db"}
+                {"database": "v3_db_react_basic", "comment": "test db"}
               expected: |
-                {"database": "v3-db-react-basic", "active": true}
-            - name: v3-db-react-empty
+                {"database": "v3_db_react_basic", "active": true}
+            - name: v3_db_react_empty
               create: |
-                {"database": "v3-db-react-empty", "comment": ""}
+                {"database": "v3_db_react_empty", "comment": ""}
               expected: |
-                {"database": "v3-db-react-empty", "active": true}
+                {"database": "v3_db_react_empty", "active": true}
             """,
         )
         fun `reactivate database`(
@@ -228,12 +228,12 @@ class DatabaseControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-db-del-basic
+            - name: v3_db_del_basic
               create: |
-                {"database": "v3-db-del-basic", "comment": "test db"}
-            - name: v3-db-del-empty
+                {"database": "v3_db_del_basic", "comment": "test db"}
+            - name: v3_db_del_empty
               create: |
-                {"database": "v3-db-del-empty", "comment": ""}
+                {"database": "v3_db_del_empty", "comment": ""}
             """,
         )
         fun `delete database`(
@@ -272,7 +272,7 @@ class DatabaseControllerTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class StatusFilterTest {
-        private val dbName = "v3-db-status-filter"
+        private val dbName = "v3_db_status_filter"
 
         @BeforeAll
         fun setup() {
@@ -375,7 +375,7 @@ class DatabaseControllerTest : E2ETestBase() {
         fun `get non-existent database returns 404`() {
             client
                 .get()
-                .uri("/graph/v3/databases/non-existent")
+                .uri("/graph/v3/databases/non_existent")
                 .exchange()
                 .expectStatus()
                 .isNotFound
@@ -385,7 +385,7 @@ class DatabaseControllerTest : E2ETestBase() {
         fun `invalid database name returns 400`() {
             client
                 .get()
-                .uri("/graph/v3/databases/123-invalid")
+                .uri("/graph/v3/databases/123invalid")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/DatabaseControllerTest.kt
@@ -384,8 +384,10 @@ class DatabaseControllerTest : E2ETestBase() {
         @Test
         fun `invalid database name returns 400`() {
             client
-                .get()
-                .uri("/graph/v3/databases/123invalid")
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"database": "123invalid", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest
@@ -394,8 +396,10 @@ class DatabaseControllerTest : E2ETestBase() {
         @Test
         fun `database name with dot returns 400`() {
             client
-                .get()
-                .uri("/graph/v3/databases/db.injection")
+                .post()
+                .uri("/graph/v3/databases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"database": "db.injection", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -855,8 +855,10 @@ class TableControllerTest : E2ETestBase() {
         @Test
         fun `invalid table name returns 400`() {
             client
-                .get()
-                .uri("$baseUri/123invalid")
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"table": "123invalid", "schema": null, "storage": "", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest
@@ -865,8 +867,10 @@ class TableControllerTest : E2ETestBase() {
         @Test
         fun `table name with dot returns 400`() {
             client
-                .get()
-                .uri("$baseUri/table.injection")
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"table": "table.injection", "schema": null, "storage": "", "comment": ""}""")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -12,7 +12,7 @@ import org.springframework.http.MediaType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TableControllerTest : E2ETestBase() {
-    private val db = "v3-table-test-db"
+    private val db = "v3_table_test_db"
     private val baseUri = "/graph/v3/databases/$db/tables"
 
     @BeforeAll
@@ -34,10 +34,10 @@ class TableControllerTest : E2ETestBase() {
         @ObjectSource(
             """
             # Edge table - basic
-            - name: v3-edge-crud
+            - name: v3_edge_crud
               create: |
                 {
-                  "table": "v3-edge-crud",
+                  "table": "v3_edge_crud",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "string", "comment": "src"},
@@ -56,8 +56,8 @@ class TableControllerTest : E2ETestBase() {
               expected: |
                 {
                   "type": "edge",
-                  "table": "v3-edge-crud",
-                  "database": "v3-table-test-db",
+                  "table": "v3_edge_crud",
+                  "database": "v3_table_test_db",
                   "comment": "edge table",
                   "schema": {
                     "type": "edge",
@@ -73,10 +73,10 @@ class TableControllerTest : E2ETestBase() {
                 }
 
             # MultiEdge table - basic
-            - name: v3-multiedge-crud
+            - name: v3_multiedge_crud
               create: |
                 {
-                  "table": "v3-multiedge-crud",
+                  "table": "v3_multiedge_crud",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "order id"},
@@ -94,8 +94,8 @@ class TableControllerTest : E2ETestBase() {
               expected: |
                 {
                   "type": "multiEdge",
-                  "table": "v3-multiedge-crud",
-                  "database": "v3-table-test-db",
+                  "table": "v3_multiedge_crud",
+                  "database": "v3_table_test_db",
                   "comment": "multiedge table",
                   "schema": {
                     "type": "multiEdge",
@@ -110,10 +110,10 @@ class TableControllerTest : E2ETestBase() {
                 }
 
             # Edge table with properties
-            - name: v3-edge-full
+            - name: v3_edge_full
               create: |
                 {
-                  "table": "v3-edge-full",
+                  "table": "v3_edge_full",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "long", "comment": "user"},
@@ -133,8 +133,8 @@ class TableControllerTest : E2ETestBase() {
               expected: |
                 {
                   "type": "edge",
-                  "table": "v3-edge-full",
-                  "database": "v3-table-test-db",
+                  "table": "v3_edge_full",
+                  "database": "v3_table_test_db",
                   "comment": "full edge table",
                   "schema": {
                     "type": "edge",
@@ -151,10 +151,10 @@ class TableControllerTest : E2ETestBase() {
                 }
 
             # MultiEdge table with properties
-            - name: v3-multiedge-full
+            - name: v3_multiedge_full
               create: |
                 {
-                  "table": "v3-multiedge-full",
+                  "table": "v3_multiedge_full",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "txn id"},
@@ -175,8 +175,8 @@ class TableControllerTest : E2ETestBase() {
               expected: |
                 {
                   "type": "multiEdge",
-                  "table": "v3-multiedge-full",
-                  "database": "v3-table-test-db",
+                  "table": "v3_multiedge_full",
+                  "database": "v3_table_test_db",
                   "comment": "full multiedge table",
                   "schema": {
                     "type": "multiEdge",
@@ -223,10 +223,10 @@ class TableControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-edge-upd
+            - name: v3_edge_upd
               create: |
                 {
-                  "table": "v3-edge-upd",
+                  "table": "v3_edge_upd",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "string", "comment": "src"},
@@ -243,11 +243,11 @@ class TableControllerTest : E2ETestBase() {
               update: |
                 {"comment": "updated edge"}
               expected: |
-                {"table": "v3-edge-upd", "comment": "updated edge", "active": true}
-            - name: v3-multiedge-upd
+                {"table": "v3_edge_upd", "comment": "updated edge", "active": true}
+            - name: v3_multiedge_upd
               create: |
                 {
-                  "table": "v3-multiedge-upd",
+                  "table": "v3_multiedge_upd",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "id"},
@@ -265,7 +265,7 @@ class TableControllerTest : E2ETestBase() {
               update: |
                 {"comment": "updated multiedge"}
               expected: |
-                {"table": "v3-multiedge-upd", "comment": "updated multiedge", "active": true}
+                {"table": "v3_multiedge_upd", "comment": "updated multiedge", "active": true}
             """,
         )
         fun `update table`(
@@ -303,10 +303,10 @@ class TableControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-edge-deact
+            - name: v3_edge_deact
               create: |
                 {
-                  "table": "v3-edge-deact",
+                  "table": "v3_edge_deact",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "string", "comment": "src"},
@@ -321,11 +321,11 @@ class TableControllerTest : E2ETestBase() {
                   "comment": "edge table"
                 }
               expected: |
-                {"table": "v3-edge-deact", "active": false}
-            - name: v3-multiedge-deact
+                {"table": "v3_edge_deact", "active": false}
+            - name: v3_multiedge_deact
               create: |
                 {
-                  "table": "v3-multiedge-deact",
+                  "table": "v3_multiedge_deact",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "id"},
@@ -341,7 +341,7 @@ class TableControllerTest : E2ETestBase() {
                   "comment": "multiedge table"
                 }
               expected: |
-                {"table": "v3-multiedge-deact", "active": false}
+                {"table": "v3_multiedge_deact", "active": false}
             """,
         )
         fun `deactivate table`(
@@ -381,10 +381,10 @@ class TableControllerTest : E2ETestBase() {
                 {"active": true}
             """,
             cases = """
-            - name: v3-edge-react
+            - name: v3_edge_react
               create: |
                 {
-                  "table": "v3-edge-react",
+                  "table": "v3_edge_react",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "string", "comment": "src"},
@@ -399,11 +399,11 @@ class TableControllerTest : E2ETestBase() {
                   "comment": "edge table"
                 }
               expected: |
-                {"table": "v3-edge-react", "active": true}
-            - name: v3-multiedge-react
+                {"table": "v3_edge_react", "active": true}
+            - name: v3_multiedge_react
               create: |
                 {
-                  "table": "v3-multiedge-react",
+                  "table": "v3_multiedge_react",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "id"},
@@ -419,7 +419,7 @@ class TableControllerTest : E2ETestBase() {
                   "comment": "multiedge table"
                 }
               expected: |
-                {"table": "v3-multiedge-react", "active": true}
+                {"table": "v3_multiedge_react", "active": true}
             """,
         )
         fun `reactivate table`(
@@ -467,10 +467,10 @@ class TableControllerTest : E2ETestBase() {
                 {"active": false}
             """,
             cases = """
-            - name: v3-edge-del
+            - name: v3_edge_del
               create: |
                 {
-                  "table": "v3-edge-del",
+                  "table": "v3_edge_del",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "string", "comment": "src"},
@@ -484,10 +484,10 @@ class TableControllerTest : E2ETestBase() {
                   "mode": "SYNC",
                   "comment": "edge table"
                 }
-            - name: v3-multiedge-del
+            - name: v3_multiedge_del
               create: |
                 {
-                  "table": "v3-multiedge-del",
+                  "table": "v3_multiedge_del",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "id"},
@@ -540,7 +540,7 @@ class TableControllerTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class StatusFilterTest {
-        private val tableName = "v3-tbl-status-filter"
+        private val tableName = "v3_tbl_status_filter"
 
         @BeforeAll
         fun setup() {
@@ -639,10 +639,10 @@ class TableControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-edge-cache-crud
+            - name: v3_edge_cache_crud
               create: |
                 {
-                  "table": "v3-edge-cache-crud",
+                  "table": "v3_edge_cache_crud",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "long", "comment": "user"},
@@ -669,7 +669,7 @@ class TableControllerTest : E2ETestBase() {
               expected: |
                 {
                   "type": "edge",
-                  "table": "v3-edge-cache-crud",
+                  "table": "v3_edge_cache_crud",
                   "schema": {
                     "type": "edge",
                     "caches": [
@@ -714,10 +714,10 @@ class TableControllerTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: v3-edge-cache-upd
+            - name: v3_edge_cache_upd
               create: |
                 {
-                  "table": "v3-edge-cache-upd",
+                  "table": "v3_edge_cache_upd",
                   "schema": {
                     "type": "EDGE",
                     "source": {"type": "long", "comment": "user"},
@@ -765,7 +765,7 @@ class TableControllerTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "v3-edge-cache-upd",
+                  "table": "v3_edge_cache_upd",
                   "schema": {
                     "caches": [
                       {
@@ -846,7 +846,7 @@ class TableControllerTest : E2ETestBase() {
         fun `get non-existent table returns 404`() {
             client
                 .get()
-                .uri("$baseUri/non-existent")
+                .uri("$baseUri/non_existent")
                 .exchange()
                 .expectStatus()
                 .isNotFound
@@ -856,7 +856,7 @@ class TableControllerTest : E2ETestBase() {
         fun `invalid table name returns 400`() {
             client
                 .get()
-                .uri("$baseUri/123-invalid")
+                .uri("$baseUri/123invalid")
                 .exchange()
                 .expectStatus()
                 .isBadRequest

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableControllerTest.kt
@@ -865,6 +865,18 @@ class TableControllerTest : E2ETestBase() {
         }
 
         @Test
+        fun `table name with hyphen returns 400`() {
+            client
+                .post()
+                .uri(baseUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"table": "my-table", "schema": null, "storage": "", "comment": ""}""")
+                .exchange()
+                .expectStatus()
+                .isBadRequest
+        }
+
+        @Test
         fun `table name with dot returns 400`() {
             client
                 .post()

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V2V3CompatibilityTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V2V3CompatibilityTest.kt
@@ -28,21 +28,21 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: db-v2v3-basic
+            - name: db_v2v3_basic
               create: |
                 {"desc": "test database"}
               expected: |
-                {"database": "db-v2v3-basic", "comment": "test database", "active": true}
-            - name: db-v2v3-empty
+                {"database": "db_v2v3_basic", "comment": "test database", "active": true}
+            - name: db_v2v3_empty
               create: |
                 {"desc": ""}
               expected: |
-                {"database": "db-v2v3-empty", "comment": "", "active": true}
-            - name: db-v2v3-special
+                {"database": "db_v2v3_empty", "comment": "", "active": true}
+            - name: db_v2v3_special
               create: |
                 {"desc": "test @#$%"}
               expected: |
-                {"database": "db-v2v3-special", "comment": "test @#$%", "active": true}
+                {"database": "db_v2v3_special", "comment": "test @#$%", "active": true}
             """,
         )
         fun `V2 create - V3 get`(
@@ -72,21 +72,21 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: db-v3v2-basic
+            - name: db_v3v2_basic
               create: |
-                {"database": "db-v3v2-basic", "comment": "test database"}
+                {"database": "db_v3v2_basic", "comment": "test database"}
               expected: |
-                {"name": "db-v3v2-basic", "desc": "test database", "active": true}
-            - name: db-v3v2-empty
+                {"name": "db_v3v2_basic", "desc": "test database", "active": true}
+            - name: db_v3v2_empty
               create: |
-                {"database": "db-v3v2-empty", "comment": ""}
+                {"database": "db_v3v2_empty", "comment": ""}
               expected: |
-                {"name": "db-v3v2-empty", "desc": "", "active": true}
-            - name: db-v3v2-special
+                {"name": "db_v3v2_empty", "desc": "", "active": true}
+            - name: db_v3v2_special
               create: |
-                {"database": "db-v3v2-special", "comment": "test @#$%"}
+                {"database": "db_v3v2_special", "comment": "test @#$%"}
               expected: |
-                {"name": "db-v3v2-special", "desc": "test @#$%", "active": true}
+                {"name": "db_v3v2_special", "desc": "test @#$%", "active": true}
             """,
         )
         fun `V3 create - V2 get`(
@@ -117,7 +117,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class TableCompatibilityTest {
-        private val db = "tbl-compat-db"
+        private val db = "tbl_compat_db"
 
         @BeforeAll
         fun setup() {
@@ -135,7 +135,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSource(
             """
             # Direction: OUT
-            - name: tbl-v2v3-out
+            - name: tbl_v2v3_out
               create: |
                 {
                   "desc": "direction out",
@@ -150,7 +150,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "tbl-v2v3-out",
+                  "table": "tbl_v2v3_out",
                   "comment": "direction out",
                   "schema": {
                     "type": "edge",
@@ -164,7 +164,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # Direction: IN
-            - name: tbl-v2v3-in
+            - name: tbl_v2v3_in
               create: |
                 {
                   "desc": "direction in",
@@ -179,7 +179,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "tbl-v2v3-in",
+                  "table": "tbl_v2v3_in",
                   "comment": "direction in",
                   "schema": {
                     "type": "edge",
@@ -193,7 +193,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # Direction: BOTH
-            - name: tbl-v2v3-both
+            - name: tbl_v2v3_both
               create: |
                 {
                   "desc": "direction both",
@@ -208,7 +208,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "tbl-v2v3-both",
+                  "table": "tbl_v2v3_both",
                   "comment": "direction both",
                   "schema": {
                     "type": "edge",
@@ -222,7 +222,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # With properties
-            - name: tbl-v2v3-props
+            - name: tbl_v2v3_props
               create: |
                 {
                   "desc": "with props",
@@ -240,7 +240,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "tbl-v2v3-props",
+                  "table": "tbl_v2v3_props",
                   "comment": "with props",
                   "schema": {
                     "type": "edge",
@@ -257,7 +257,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # LONG keys
-            - name: tbl-v2v3-long
+            - name: tbl_v2v3_long
               create: |
                 {
                   "desc": "long keys",
@@ -272,7 +272,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "table": "tbl-v2v3-long",
+                  "table": "tbl_v2v3_long",
                   "comment": "long keys",
                   "schema": {
                     "type": "edge",
@@ -314,10 +314,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSource(
             """
             # Direction: OUT
-            - name: tbl-v3v2-out
+            - name: tbl_v3v2_out
               create: |
                 {
-                  "table": "tbl-v3v2-out",
+                  "table": "tbl_v3v2_out",
                   "schema": {
                     "type": "edge",
                     "source": {"type": "string", "comment": "source"},
@@ -333,7 +333,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "tbl-compat-db.tbl-v3v2-out",
+                  "name": "tbl_compat_db.tbl_v3v2_out",
                   "desc": "direction out",
                   "schema": {
                     "src": {"type": "STRING", "desc": "source"},
@@ -346,10 +346,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # Direction: IN
-            - name: tbl-v3v2-in
+            - name: tbl_v3v2_in
               create: |
                 {
-                  "table": "tbl-v3v2-in",
+                  "table": "tbl_v3v2_in",
                   "schema": {
                     "type": "edge",
                     "source": {"type": "string", "comment": "source"},
@@ -365,7 +365,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "tbl-compat-db.tbl-v3v2-in",
+                  "name": "tbl_compat_db.tbl_v3v2_in",
                   "desc": "direction in",
                   "schema": {
                     "src": {"type": "STRING", "desc": "source"},
@@ -378,10 +378,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # Direction: BOTH
-            - name: tbl-v3v2-both
+            - name: tbl_v3v2_both
               create: |
                 {
-                  "table": "tbl-v3v2-both",
+                  "table": "tbl_v3v2_both",
                   "schema": {
                     "type": "edge",
                     "source": {"type": "string", "comment": "source"},
@@ -397,7 +397,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "tbl-compat-db.tbl-v3v2-both",
+                  "name": "tbl_compat_db.tbl_v3v2_both",
                   "desc": "direction both",
                   "schema": {
                     "src": {"type": "STRING", "desc": "source"},
@@ -410,10 +410,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # With properties
-            - name: tbl-v3v2-props
+            - name: tbl_v3v2_props
               create: |
                 {
-                  "table": "tbl-v3v2-props",
+                  "table": "tbl_v3v2_props",
                   "schema": {
                     "type": "edge",
                     "source": {"type": "string", "comment": "user"},
@@ -432,7 +432,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "tbl-compat-db.tbl-v3v2-props",
+                  "name": "tbl_compat_db.tbl_v3v2_props",
                   "desc": "with props",
                   "schema": {
                     "src": {"type": "STRING", "desc": "user"},
@@ -448,10 +448,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # LONG keys
-            - name: tbl-v3v2-long
+            - name: tbl_v3v2_long
               create: |
                 {
-                  "table": "tbl-v3v2-long",
+                  "table": "tbl_v3v2_long",
                   "schema": {
                     "type": "edge",
                     "source": {"type": "long", "comment": "uid"},
@@ -467,7 +467,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "tbl-compat-db.tbl-v3v2-long",
+                  "name": "tbl_compat_db.tbl_v3v2_long",
                   "desc": "long keys",
                   "schema": {
                     "src": {"type": "LONG", "desc": "uid"},
@@ -508,8 +508,8 @@ class V2V3CompatibilityTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class AliasCompatibilityTest {
-        private val db = "als-compat-db"
-        private val table = "als-target"
+        private val db = "als_compat_db"
+        private val table = "als_target"
 
         @BeforeAll
         fun setup() {
@@ -552,21 +552,21 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: als-v2v3-basic
+            - name: als_v2v3_basic
               create: |
-                {"desc": "test alias", "target": "als-compat-db.als-target"}
+                {"desc": "test alias", "target": "als_compat_db.als_target"}
               expected: |
-                {"alias": "als-v2v3-basic", "table": "als-target", "comment": "test alias", "active": true}
-            - name: als-v2v3-empty
+                {"alias": "als_v2v3_basic", "table": "als_target", "comment": "test alias", "active": true}
+            - name: als_v2v3_empty
               create: |
-                {"desc": "", "target": "als-compat-db.als-target"}
+                {"desc": "", "target": "als_compat_db.als_target"}
               expected: |
-                {"alias": "als-v2v3-empty", "table": "als-target", "comment": "", "active": true}
-            - name: als-v2v3-special
+                {"alias": "als_v2v3_empty", "table": "als_target", "comment": "", "active": true}
+            - name: als_v2v3_special
               create: |
-                {"desc": "alias @#", "target": "als-compat-db.als-target"}
+                {"desc": "alias @#", "target": "als_compat_db.als_target"}
               expected: |
-                {"alias": "als-v2v3-special", "table": "als-target", "comment": "alias @#", "active": true}
+                {"alias": "als_v2v3_special", "table": "als_target", "comment": "alias @#", "active": true}
             """,
         )
         fun `V2 create - V3 get`(
@@ -596,21 +596,21 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSourceParameterizedTest
         @ObjectSource(
             """
-            - name: als-v3v2-basic
+            - name: als_v3v2_basic
               create: |
-                {"alias": "als-v3v2-basic", "table": "als-target", "comment": "test alias"}
+                {"alias": "als_v3v2_basic", "table": "als_target", "comment": "test alias"}
               expected: |
-                {"name": "als-compat-db.als-v3v2-basic", "target": "als-compat-db.als-target", "desc": "test alias", "active": true}
-            - name: als-v3v2-empty
+                {"name": "als_compat_db.als_v3v2_basic", "target": "als_compat_db.als_target", "desc": "test alias", "active": true}
+            - name: als_v3v2_empty
               create: |
-                {"alias": "als-v3v2-empty", "table": "als-target", "comment": ""}
+                {"alias": "als_v3v2_empty", "table": "als_target", "comment": ""}
               expected: |
-                {"name": "als-compat-db.als-v3v2-empty", "target": "als-compat-db.als-target", "desc": "", "active": true}
-            - name: als-v3v2-special
+                {"name": "als_compat_db.als_v3v2_empty", "target": "als_compat_db.als_target", "desc": "", "active": true}
+            - name: als_v3v2_special
               create: |
-                {"alias": "als-v3v2-special", "table": "als-target", "comment": "alias @#"}
+                {"alias": "als_v3v2_special", "table": "als_target", "comment": "alias @#"}
               expected: |
-                {"name": "als-compat-db.als-v3v2-special", "target": "als-compat-db.als-target", "desc": "alias @#", "active": true}
+                {"name": "als_compat_db.als_v3v2_special", "target": "als_compat_db.als_target", "desc": "alias @#", "active": true}
             """,
         )
         fun `V3 create - V2 get`(
@@ -641,7 +641,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class MultiEdgeCompatibilityTest {
-        private val db = "me-compat-db"
+        private val db = "me_compat_db"
 
         @BeforeAll
         fun setup() {
@@ -659,7 +659,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSource(
             """
             # Basic MultiEdge - direction BOTH
-            - name: me-v2v3-basic
+            - name: me_v2v3_basic
               create: |
                 {
                   "desc": "basic multiedge",
@@ -678,7 +678,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
               expected: |
                 {
                   "type": "multiEdge",
-                  "table": "me-v2v3-basic",
+                  "table": "me_v2v3_basic",
                   "comment": "basic multiedge",
                   "schema": {
                     "type": "multiEdge",
@@ -693,7 +693,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # MultiEdge with properties
-            - name: me-v2v3-props
+            - name: me_v2v3_props
               create: |
                 {
                   "desc": "multiedge with props",
@@ -714,7 +714,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
               expected: |
                 {
                   "type": "multiEdge",
-                  "table": "me-v2v3-props",
+                  "table": "me_v2v3_props",
                   "comment": "multiedge with props",
                   "schema": {
                     "type": "multiEdge",
@@ -732,7 +732,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # MultiEdge with STRING keys
-            - name: me-v2v3-string
+            - name: me_v2v3_string
               create: |
                 {
                   "desc": "string key multiedge",
@@ -751,7 +751,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
               expected: |
                 {
                   "type": "multiEdge",
-                  "table": "me-v2v3-string",
+                  "table": "me_v2v3_string",
                   "comment": "string key multiedge",
                   "schema": {
                     "type": "multiEdge",
@@ -794,10 +794,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
         @ObjectSource(
             """
             # Basic MultiEdge - V3 create -> V2 get
-            - name: me-v3v2-basic
+            - name: me_v3v2_basic
               create: |
                 {
-                  "table": "me-v3v2-basic",
+                  "table": "me_v3v2_basic",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "order id"},
@@ -814,7 +814,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "me-compat-db.me-v3v2-basic",
+                  "name": "me_compat_db.me_v3v2_basic",
                   "desc": "basic multiedge",
                   "schema": {
                     "src": {"type": "LONG", "desc": "sender"},
@@ -829,10 +829,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # MultiEdge with properties - V3 create -> V2 get
-            - name: me-v3v2-props
+            - name: me_v3v2_props
               create: |
                 {
-                  "table": "me-v3v2-props",
+                  "table": "me_v3v2_props",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "txn id"},
@@ -852,7 +852,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "me-compat-db.me-v3v2-props",
+                  "name": "me_compat_db.me_v3v2_props",
                   "desc": "multiedge with props",
                   "schema": {
                     "src": {"type": "LONG", "desc": "user"},
@@ -869,10 +869,10 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
 
             # MultiEdge with STRING keys - V3 create -> V2 get
-            - name: me-v3v2-string
+            - name: me_v3v2_string
               create: |
                 {
-                  "table": "me-v3v2-string",
+                  "table": "me_v3v2_string",
                   "schema": {
                     "type": "MULTI_EDGE",
                     "id": {"type": "long", "comment": "msg id"},
@@ -889,7 +889,7 @@ class V2V3CompatibilityTest : E2ETestBase() {
                 }
               expected: |
                 {
-                  "name": "me-compat-db.me-v3v2-string",
+                  "name": "me_compat_db.me_v3v2_string",
                   "desc": "string key multiedge",
                   "schema": {
                     "src": {"type": "STRING", "desc": "from"},

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverterTest.kt
@@ -40,7 +40,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 
 class V3MetadataConverterTest {
-    private val tenant = "test-tenant"
+    private val tenant = "test_tenant"
 
     @Nested
     inner class DatabaseConversionTest {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidatorTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3NameValidatorTest.kt
@@ -15,12 +15,9 @@ class V3NameValidatorTest {
         @ObjectSource(
             """
             - name: mydb
-            - name: MyDB
-            - name: my-db
             - name: my_db
             - name: db123
             - name: a
-            - name: A
             # 64 chars (max valid length)
             - name: abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             """,
@@ -44,7 +41,7 @@ class V3NameValidatorTest {
         fun `name starting with non-letter should fail`(name: String) {
             assertThatThrownBy { V3NameValidator.validateDatabase(name) }
                 .isInstanceOf(ResponseStatusException::class.java)
-                .hasMessageContaining("must start with a letter")
+                .hasMessageContaining("must start with a lowercase letter")
         }
 
         @ObjectSourceParameterizedTest
@@ -56,6 +53,9 @@ class V3NameValidatorTest {
             - name: 'db\name'
             - name: "db name"
             - name: mydb.othertable
+            - name: my-db
+            - name: MyDB
+            - name: A
             """,
         )
         fun `name with invalid characters should fail`(name: String) {


### PR DESCRIPTION
## Summary

Enforces a uniform naming policy — `^[a-z][a-z0-9_]{0,63}$` — across **all** Actionbase metadata create paths: V3 (database, table, alias) and V2 (service, label, alias, storage). Names containing hyphens or uppercase letters are rejected with 400 Bad Request on create. Read, update, and delete paths are unaffected. Note: creating a new table/alias under a legacy-named parent database is rejected, since the parent name is validated on create — intentional, as it also stops new resources accreting under non-conforming databases.

### Why this naming policy

Two constraints that apply simultaneously drove the choice of `^[a-z][a-z0-9_]{0,63}$`:

1. **URL path safety** — Names appear directly in HTTP path segments. Uppercase causes case-sensitivity issues across clients, proxies, and load balancers. Hyphens are technically URL-safe but create ambiguity with path separators in some routing layers.
2. **HBase naming constraints** — Names map directly to HBase table and namespace identifiers. Allowing names that pass HTTP validation but fail HBase validation produces confusing runtime errors deep in the stack.

The intersection of these two constraint sets is: lowercase letters, digits, and underscores only, starting with a letter, max 64 characters.

## Changes

**Single source of truth**
- `core/Constants.Name` — `PATTERN`, `MESSAGE`, `COMMENT_MAX_LENGTH`, `COMMENT_SIZE_MESSAGE`, `STORAGE_URI_PATTERN`, `STORAGE_URI_MESSAGE` as `const val`
- `server/util/NameValidator` — shared validator used by all controllers; throws `ResponseStatusException(400)` on mismatch
- `V3NameValidator` — now delegates to `NameValidator`

**V3 — create paths**
- `DatabaseController`, `TableController`, `AliasController`: name validation on POST only
- `TableCreateRequest`, `AliasCreateRequest`, `AliasUpdateRequest`: `@Pattern` and `@Size` annotations reference `Constants.Name`
- `TableCreateRequest.storage`: datastore URI regex updated to disallow uppercase
- Bug fix: `AliasUpdateRequest.table` was still using the old regex (allowed hyphens/uppercase)

**V2 — create paths only**
- `ServiceController`, `ServiceLabelController`, `ServiceAliasController`, `StorageController`: path variable validated on POST only
- `ServiceLabelController.copy`: new target name validated; existing source names are not

**HBase**
- `DatastoreHBaseService.createTable`: table name qualifier validated via `NameValidator`

**Tests**
- All hyphenated fixture names migrated to underscore style
- Explicit `hyphen returns 400` and `uppercase returns 400` test cases added per resource type
- `AliasControllerTest`: update-path validation tests for `table` field added
- `V3NameValidatorTest`: `my-db`, `MyDB`, `A` moved to invalid cases

## How to Test

Create with a hyphenated name → 400:
```sh
curl -X POST .../graph/v3/databases -d '{"database":"my-db","comment":""}' → 400
curl -X POST .../graph/v2/service/my-service -d '{...}' → 400
```

Read an existing legacy resource → 200:
```sh
curl .../graph/v3/databases/my-db → 200 (if it exists)
```

## ⚠️ Breaking Change — Deploy Prerequisites

This PR is a **breaking change for any code that creates metadata resources**.

Before deploying, all clients and pipelines that automatically create metadata (services, labels, aliases, databases, tables, storages) **must be audited and updated** to ensure they only submit names matching `^[a-z][a-z0-9_]{0,63}$`. Any pipeline submitting names with hyphens or uppercase will receive 400 after this lands.

Existing legacy-named resources remain readable, updatable, and deletable. Only creation is restricted — including new child resources under a legacy-named parent, which now return 400.

## Reviewer Notes

- Update/delete path variables are intentionally excluded from validation — existing legacy-named resources stay readable/updatable/deletable. Create paths do validate the parent name, so new children cannot be added under a legacy-named parent.
- `Constants.Name` is in the `core` module, which is already a dependency of both `engine` and `server`. No new module dependencies introduced.
- PR #399 (remove v2 Storage metadata) is based on this branch; `StorageController` changes here will be superseded by its deletion in #399.

## Checklist

- [x] Small, focused PR
- [x] Self-reviewed the diff
- [x] Tests updated and passing locally
- [x] Build and lint checks pass
- [x] Breaking change documented — clients/pipelines creating resources with hyphenated or uppercase names must be updated before deployment

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Sonnet 4.6
