### PR TITLE
Add -e flag for non-interactive command execution

### DIFF
--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -40,10 +40,9 @@ func main() {
 
 	host, found := parser.Get(hostParamKey)
 	if !found {
+		host = DefaultHost
 		if env := os.Getenv("ACT_HOST"); env != "" {
 			host = env
-		} else {
-			host = DefaultHost
 		}
 	}
 

--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -17,6 +17,7 @@ const (
 
 	hostParamKey = "host"
 	authParamKey = "authKey"
+	execParamKey = "e"
 )
 
 func main() {
@@ -37,11 +38,23 @@ func main() {
 		isDebugEnabled = true
 	}
 
+	authKey, _ := parser.Get(authParamKey)
+
+	if cmd, found := parser.Get(execParamKey); found {
+		util.SetPlainMode(true)
+		console := runner.NewActionbaseCommandLineRunner(Version, host, &authKey, "", false, isDebugEnabled)
+		console.CheckConnection()
+		resp, _ := console.RunCommand(cmd)
+		if resp == nil || !resp.IsSuccess {
+			os.Exit(1)
+		}
+		return
+	}
+
 	if _, found := parser.GetLenient("plain"); found {
 		util.SetPlainMode(true)
 	}
 
-	authKey, _ := parser.Get(authParamKey)
 	console := runner.NewActionbaseCommandLineRunner(Version, host, &authKey, "", false, isDebugEnabled)
 	console.CheckConnection()
 	console.StartServer(parser)

--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -40,7 +40,11 @@ func main() {
 
 	host, found := parser.Get(hostParamKey)
 	if !found {
-		host = DefaultHost
+		if env := os.Getenv("ACT_HOST"); env != "" {
+			host = env
+		} else {
+			host = DefaultHost
+		}
 	}
 
 	isDebugEnabled := false
@@ -49,6 +53,9 @@ func main() {
 	}
 
 	authKey, _ := parser.Get(authParamKey)
+	if authKey == "" {
+		authKey = os.Getenv("ACT_API_KEY")
+	}
 
 	if execCmd != "" {
 		util.SetPlainMode(true)

--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -17,7 +17,7 @@ const (
 
 	hostParamKey = "host"
 	authParamKey = "authKey"
-	execParamKey = "e"
+	execParamKey = "exec"
 )
 
 func main() {

--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -20,7 +20,6 @@ const (
 )
 
 func main() {
-	// Extract -e before ParseArgs, which only handles --key flags.
 	var execCmd string
 	args := os.Args
 	for i, arg := range args {

--- a/cli/cmd/actionbase/main.go
+++ b/cli/cmd/actionbase/main.go
@@ -17,11 +17,21 @@ const (
 
 	hostParamKey = "host"
 	authParamKey = "authKey"
-	execParamKey = "exec"
 )
 
 func main() {
-	parser := util.ParseArgs(os.Args)
+	// Extract -e before ParseArgs, which only handles --key flags.
+	var execCmd string
+	args := os.Args
+	for i, arg := range args {
+		if arg == "-e" && i+1 < len(args) {
+			execCmd = args[i+1]
+			args = append(args[:i:i], args[i+2:]...)
+			break
+		}
+	}
+
+	parser := util.ParseArgs(args)
 
 	if _, found := parser.GetLenient("version"); found {
 		fmt.Println("v" + Version)
@@ -40,11 +50,11 @@ func main() {
 
 	authKey, _ := parser.Get(authParamKey)
 
-	if cmd, found := parser.Get(execParamKey); found {
+	if execCmd != "" {
 		util.SetPlainMode(true)
 		console := runner.NewActionbaseCommandLineRunner(Version, host, &authKey, "", false, isDebugEnabled)
 		console.CheckConnection()
-		resp, _ := console.RunCommand(cmd)
+		resp, _ := console.RunCommand(execCmd)
 		if resp == nil || !resp.IsSuccess {
 			os.Exit(1)
 		}

--- a/cli/internal/runner/actionbase_runner.go
+++ b/cli/internal/runner/actionbase_runner.go
@@ -152,7 +152,9 @@ func (r *ActionbaseCommandLineRunner) RunCommand(input string) (*model.Response,
 	result := r.executeCommand(cmdName, args)
 	elapsed := time.Since(start).Seconds()
 
-	util.Print("\033[90m(Took %.4f seconds)\033[0m\n\n", elapsed)
+	if !util.IsPlainMode() {
+		util.Print("\033[90m(Took %.4f seconds)\033[0m\n\n", elapsed)
+	}
 	return result, elapsed
 }
 

--- a/cli/internal/util/print.go
+++ b/cli/internal/util/print.go
@@ -16,6 +16,10 @@ func SetPlainMode(enabled bool) {
 	plainMode.Store(enabled)
 }
 
+func IsPlainMode() bool {
+	return plainMode.Load()
+}
+
 func getPrefix() string {
 	if plainMode.Load() {
 		return ""


### PR DESCRIPTION
## Summary

Adds `-e` flag and env var defaults so the CLI can be used non-interactively — analogous to `mysql -e`.

## Changes

- `cli/cmd/actionbase/main.go`: `-e "command"` runs the command without entering the REPL, enables plain mode, exits 1 on failure; `ACT_HOST` / `ACT_API_KEY` env vars as defaults for `--host` / `--authKey`
- `cli/internal/util/print.go`: adds `IsPlainMode()` accessor
- `cli/internal/runner/actionbase_runner.go`: suppresses timing output in plain mode

## How to Test

```sh
export ACT_HOST=http://localhost:8080

actionbase -e "show databases"
actionbase -e "show databases" | grep my_db
actionbase --host http://other -e "show databases"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Sonnet 4.6