### PR TITLE
Remove dead system storage and V2 label constants

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -1017,7 +1017,6 @@ class Graph(
 
             val storageEntities =
                 listOfNotNull(
-                    Metadata.localOnlyStorageEntity,
                     Metadata.localBackedMetastoreEntity,
                     Metadata.metastoreStorageEntity,
                     defaultHBaseStorageEntity,
@@ -1042,8 +1041,7 @@ class Graph(
 
             val storageLabel =
                 Metadata.storageLabelEntity.materialize(defaults) {
-                    mutate(Metadata.localOnlyStorageEntity.toEdge(), EdgeOperation.INSERT)
-                        .then(mutate(Metadata.localBackedMetastoreEntity.toEdge(), EdgeOperation.INSERT))
+                    mutate(Metadata.localBackedMetastoreEntity.toEdge(), EdgeOperation.INSERT)
                         .then(mutate(Metadata.metastoreStorageEntity.toEdge(), EdgeOperation.INSERT))
                         .let { chain ->
                             if (defaultHBaseStorageEntity != null) {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metadata/Metadata.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metadata/Metadata.kt
@@ -24,8 +24,6 @@ object Metadata {
 
     const val sysServiceName = "sys"
 
-    const val localOnlyStorageName = "local_only_storage"
-
     const val localBackedMetastoreName = "local_backed_metastore"
 
     const val metastoreName = "metastore"
@@ -46,22 +44,11 @@ object Metadata {
 
     const val heartBeatLabelName = "heartbeat"
 
-    const val sysOnlineMetadataLabelName = "online_metadata"
-
     const val sysOnlineMetadataLabelV2Name = "online_metadata_v2"
 
     const val sysNilLabelName = "nil"
 
     val heartBeatEntityName = EntityName(sysServiceName, heartBeatLabelName)
-
-    val localOnlyStorageEntity =
-        StorageEntity(
-            active = true,
-            name = EntityName.fromOrigin(localOnlyStorageName),
-            desc = "local storage",
-            type = StorageType.LOCAL,
-            conf = jackson.createObjectNode().apply { put("useGlobal", false) },
-        )
 
     val localBackedMetastoreEntity =
         StorageEntity(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/test/GraphFixtures.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/test/GraphFixtures.kt
@@ -258,7 +258,6 @@ object GraphFixtures {
 
     val defaultStorages =
         listOf(
-            EntityName.fromOrigin(Metadata.localOnlyStorageName),
             EntityName.fromOrigin(Metadata.localBackedMetastoreName),
             EntityName.fromOrigin(Metadata.metastoreName),
         )
@@ -280,11 +279,6 @@ object GraphFixtures {
             // "origin" -> "service"
             listOf(EntityName.withPhase(Metadata.origin, Metadata.sysServiceName), Metadata.serviceLabelEntity.id, null),
             // "origin" -> storage
-            listOf(
-                EntityName.withPhase(Metadata.origin, Metadata.localOnlyStorageName),
-                Metadata.storageLabelEntity.id,
-                null,
-            ),
             listOf(
                 EntityName.withPhase(Metadata.origin, Metadata.localBackedMetastoreName),
                 Metadata.storageLabelEntity.id,


### PR DESCRIPTION
## Summary

Remove two never-referenced system declarations. No behavior change.

- `localOnlyStorageEntity` / `localOnlyStorageName` — seeded into the metastore on boot, but no label references it as its `storage`. Dead since only `local_backed_metastore` / `metastore` / the HBase datastore back actual labels.
- `sysOnlineMetadataLabelName` (`"online_metadata"`, v1) — only the v2 name (`online_metadata_v2`) is used; the v1 constant has no reader.

## Changes

- Remove both declarations from `Metadata`.
- Drop the boot-time seeding of the local-only storage in `Graph`.
- Drop the matching `defaultStorages` / `defaultMetadata` entries in the test fixture.

## How to Test

`./gradlew :engine:test` — boot and metadata seeding are unchanged aside from the removed dead entries.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Opus 4.8
