### PR TITLE
Gate INSERT activating-merge behind the INSERT_MERGE feature

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/MutationEvent.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/MutationEvent.kt
@@ -20,5 +20,8 @@ sealed interface MutationEvent {
 }
 
 interface UnresolvedEvent {
-    fun createEvent(schema: ModelSchema): MutationEvent
+    fun createEvent(
+        schema: ModelSchema,
+        insertMerge: Boolean = false,
+    ): MutationEvent
 }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
@@ -14,11 +14,14 @@ data class EdgeBulkMutationRequest(
         val type: EventType,
         val edge: Edge,
     ) : UnresolvedEvent {
-        override fun createEvent(schema: ModelSchema): EdgeEvent {
+        override fun createEvent(
+            schema: ModelSchema,
+            insertMerge: Boolean,
+        ): EdgeEvent {
             require(schema is ModelSchema.Edge) { "Expected ModelSchema.Edge, but got ${schema::class.simpleName}" }
             val source = schema.source.type.cast(edge.source)
             val target = schema.target.type.cast(edge.target)
-            checkNonNullableFields(type, schema.properties, edge.properties)
+            checkNonNullableFields(type, schema.properties, edge.properties, insertMerge)
             val event =
                 Event.create(
                     type = type,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MultiEdgeBulkMutationRequest.kt
@@ -14,10 +14,13 @@ data class MultiEdgeBulkMutationRequest(
         val type: EventType,
         val edge: MultiEdge,
     ) : UnresolvedEvent {
-        override fun createEvent(schema: ModelSchema): MultiEdgeEvent {
+        override fun createEvent(
+            schema: ModelSchema,
+            insertMerge: Boolean,
+        ): MultiEdgeEvent {
             require(schema is ModelSchema.MultiEdge) { "Expected ModelSchema.MultiEdge, but got ${schema::class.simpleName}" }
             val id = schema.id.type.cast(edge.id)
-            checkNonNullableFields(type, schema.properties, edge.properties)
+            checkNonNullableFields(type, schema.properties, edge.properties, insertMerge)
             val additionalProperties =
                 listOfNotNull(
                     edge.source?.let { "_source" to schema.source.type.cast(it) },

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/MutationRequestValidator.kt
@@ -4,22 +4,18 @@ import com.kakao.actionbase.core.metadata.common.StructField
 import com.kakao.actionbase.core.state.EventType
 
 /**
- * Validates payload-deterministic nullability constraints against the schema.
- *
- * Rules by event type:
- * - INSERT: every non-nullable field must be present and non-null.
- * - UPDATE: every non-nullable field, if present in the payload, must be non-null.
- *   Absent fields are legal (they retain their existing value).
- * - DELETE: no property validation (tombstone semantics).
- *
- * Throws [IllegalArgumentException] on violation so the global exception handler maps it to 400.
+ * Validates payload nullability against the schema (throws [IllegalArgumentException] -> 400):
+ * INSERT (snapshot) requires every non-nullable field present and non-null; INSERT_MERGE and
+ * UPDATE only require present non-nullable fields to be non-null (row completeness is checked
+ * later in `State.transit`); DELETE validates nothing.
  */
 internal fun checkNonNullableFields(
     eventType: EventType,
     properties: List<StructField>,
     payload: Map<String, Any?>,
+    insertMerge: Boolean = false,
 ) {
-    if (eventType == EventType.INSERT) {
+    if (eventType == EventType.INSERT && !insertMerge) {
         for (field in properties) {
             if (field.nullable) continue
             require(payload.containsKey(field.name)) {
@@ -29,7 +25,7 @@ internal fun checkNonNullableFields(
                 "Property '${field.name}' cannot be null"
             }
         }
-    } else if (eventType == EventType.UPDATE) {
+    } else if (eventType == EventType.INSERT || eventType == EventType.UPDATE) {
         for (field in properties) {
             if (field.nullable) continue
             if (payload.containsKey(field.name)) {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/state/InvalidMutationException.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/state/InvalidMutationException.kt
@@ -1,0 +1,9 @@
+package com.kakao.actionbase.core.state
+
+/**
+ * A permanently invalid mutation (e.g. an activating write leaving a non-nullable field unset).
+ * Surfaces as a per-item INVALID status; a replay/WAL consumer must not retry it.
+ */
+class InvalidMutationException(
+    message: String,
+) : IllegalArgumentException(message)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/state/StateExtensions.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/state/StateExtensions.kt
@@ -6,8 +6,9 @@ import com.kakao.actionbase.core.state.SpecialStateValue
 fun State.transit(
     event: Event,
     fields: AbstractSchema,
+    insertMerge: Boolean = false,
 ): State {
-    val nextProperties = transitProperties(properties, event, fields)
+    val nextProperties = transitProperties(properties, event, fields, insertMerge)
 
     val shouldOverride = event.version == version
     val nextVersion = maxOf(event.version, version)
@@ -49,7 +50,7 @@ fun State.transit(
             nextProperties,
         )
 
-    nextState.checkValid(fields)
+    nextState.checkValid(fields, insertMerge)
 
     return nextState
 }
@@ -62,9 +63,16 @@ private fun transitProperties(
     currentProperties: Map<String, StateValue>,
     event: Event,
     fields: AbstractSchema,
+    insertMerge: Boolean,
 ): Map<String, StateValue> =
     when (event.type) {
-        EventType.INSERT -> processInsertOperation(currentProperties, event, fields)
+        // INSERT_MERGE: INSERT merges like UPDATE (omitted kept, null clears); default snapshots (omitted -> UNSET).
+        EventType.INSERT ->
+            if (insertMerge) {
+                processUpdateOperation(currentProperties, event, fields)
+            } else {
+                processInsertOperation(currentProperties, event, fields)
+            }
         EventType.UPDATE -> processUpdateOperation(currentProperties, event, fields)
         EventType.DELETE -> processDeleteOperation(currentProperties, event, fields)
     }
@@ -182,7 +190,10 @@ private fun processDeleteOperation(
         }
     }
 
-private fun State.checkValid(fields: AbstractSchema) {
+private fun State.checkValid(
+    fields: AbstractSchema,
+    insertMerge: Boolean = false,
+) {
     val createdAt = createdAt
     val deletedAt = deletedAt
 
@@ -210,7 +221,10 @@ private fun State.checkValid(fields: AbstractSchema) {
                 }
 
             if (isInvalid && !fields.isNullable(fieldName)) {
-                throw IllegalArgumentException("$fieldName must be provided")
+                val message = "$fieldName must be provided"
+                // Under INSERT_MERGE an activating merge can leave a non-nullable field unset —
+                // permanent, so surfaced as INVALID. The default path keeps its original exception.
+                throw if (insertMerge) InvalidMutationException(message) else IllegalArgumentException(message)
             }
         }
 

--- a/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/vertex/payload/VertexBulkMutationRequest.kt
@@ -17,11 +17,14 @@ data class VertexBulkMutationRequest(
         val type: EventType,
         val vertex: Vertex,
     ) : UnresolvedEvent {
-        override fun createEvent(schema: ModelSchema): MutationEvent {
+        override fun createEvent(
+            schema: ModelSchema,
+            insertMerge: Boolean,
+        ): MutationEvent {
             require(schema is ModelSchema.Vertex) { "Expected ModelSchema.Vertex, but got ${schema::class.simpleName}" }
             val id = schema.id.type.cast(vertex.id)
             require(id.toString() != VERTEX_MARKER) { "Vertex id cannot be '$VERTEX_MARKER' (reserved marker)" }
-            checkNonNullableFields(type, schema.properties, vertex.properties)
+            checkNonNullableFields(type, schema.properties, vertex.properties, insertMerge)
             val event =
                 Event.create(
                     type = type,

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeBulkMutationRequestTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/EdgeBulkMutationRequestTest.kt
@@ -60,6 +60,19 @@ class EdgeBulkMutationRequestTest {
     }
 
     @Test
+    fun `INSERT missing non-nullable field succeeds with insertMerge (completeness enforced at activation)`() {
+        val event = item(EventType.INSERT, mapOf("optional" to "value")).createEvent(schema, insertMerge = true)
+        assertTrue(event.event.properties.containsKey("optional"))
+    }
+
+    @Test
+    fun `INSERT with explicit null for non-nullable field throws even with insertMerge`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, mapOf("required" to null)).createEvent(schema, insertMerge = true)
+        }
+    }
+
+    @Test
     fun `UPDATE missing non-nullable field succeeds (keeps existing value)`() {
         val event = item(EventType.UPDATE, mapOf("optional" to "value")).createEvent(schema)
         assertTrue(event.event.properties.containsKey("optional"))

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeBulkMutationRequestTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/MultiEdgeBulkMutationRequestTest.kt
@@ -66,6 +66,19 @@ class MultiEdgeBulkMutationRequestTest {
     }
 
     @Test
+    fun `INSERT missing non-nullable field succeeds with insertMerge (completeness enforced at activation)`() {
+        val event = item(EventType.INSERT, mapOf("optional" to "value")).createEvent(schema, insertMerge = true)
+        assertTrue(event.event.properties.containsKey("optional"))
+    }
+
+    @Test
+    fun `INSERT with explicit null for non-nullable field throws even with insertMerge`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, mapOf("required" to null)).createEvent(schema, insertMerge = true)
+        }
+    }
+
+    @Test
     fun `UPDATE missing non-nullable field succeeds (keeps existing value)`() {
         val event = item(EventType.UPDATE, mapOf("optional" to "value")).createEvent(schema)
         assertTrue(event.event.properties.containsKey("optional"))

--- a/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/payload/VertexBulkMutationRequestTest.kt
@@ -65,6 +65,19 @@ class VertexBulkMutationRequestTest {
     }
 
     @Test
+    fun `INSERT missing non-nullable field succeeds with insertMerge (completeness enforced at activation)`() {
+        val event = item(EventType.INSERT, properties = mapOf("age" to 20L)).createEvent(schema, insertMerge = true)
+        assertTrue(event.event.properties.containsKey("age"))
+    }
+
+    @Test
+    fun `INSERT with explicit null for non-nullable field throws even with insertMerge`() {
+        assertFailsWith<IllegalArgumentException> {
+            item(EventType.INSERT, properties = mapOf("name" to null)).createEvent(schema, insertMerge = true)
+        }
+    }
+
+    @Test
     fun `UPDATE missing non-nullable field succeeds (keeps existing value)`() {
         val event = item(EventType.UPDATE, properties = mapOf("age" to 21L)).createEvent(schema)
         assertTrue(event.event.properties.containsKey("age"))

--- a/core/src/test/kotlin/com/kakao/actionbase/core/state/InsertMergeTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/state/InsertMergeTest.kt
@@ -1,0 +1,308 @@
+package com.kakao.actionbase.core.state
+
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.test.documentations.params.TableSource
+import com.kakao.actionbase.test.handleSpecialValue
+import com.kakao.actionbase.test.state.StateTestFixture
+import com.kakao.actionbase.test.toBooleanFlexible
+import com.kakao.actionbase.test.toEventSequence
+import com.kakao.actionbase.test.toEventType
+import com.kakao.actionbase.test.toStateValue
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Golden tests for `transit(insertMerge = true)`: INSERT merges like UPDATE (omitted kept, null
+ * clears) and only activates the row. Snapshot goldens live in [SingleTransitionTest]/[ProcessingOrderTest].
+ */
+class InsertMergeTest {
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+          #    |                                                                 | active | v  | c  | d | name  | age | email  | comment | event | v  | type | name    | age | email    | comment | expected | ex | active | v  | c  | d  | name    | age | email    | comment | n  | a  | e  | c  | size
+          #----|-----------------------------------------------------------------|--------|----|----|---|-------|-----|--------|---------|-------|----|------|---------|-----|----------|---------|----------|----|--------|----|----|----|---------|-----|----------|---------|----|----|----|----|-----
+          - 1  | Empty state INSERT keeps omitted fields absent                  | F      | 0  | ~  | ~ | ~     | ~   | ~      | ~       | event | 1  | I    | Alice   | 30  | ~        | ~       | expected | F  | T      | 1  | 1  | ~  | Alice   | 30  | ~        | ~       | 1  | 1  | ~  | ~  | 2
+          - 2  | Empty state INSERT with required + EMAIL                        | F      | 0  | ~  | ~ | ~     | ~   | ~      | ~       | event | 1  | I    | Alice   | 30  | alice@   | ~       | expected | F  | T      | 1  | 1  | ~  | Alice   | 30  | alice@   | ~       | 1  | 1  | 1  | ~  | 3
+          - 3  | Empty state INSERT with required + COMMENT                      | F      | 0  | ~  | ~ | ~     | ~   | ~      | ~       | event | 1  | I    | Alice   | 30  | ~        | Nice    | expected | F  | T      | 1  | 1  | ~  | Alice   | 30  | ~        | Nice    | 1  | 1  | ~  | 1  | 3
+          - 4  | INSERT missing required field NAME on empty state (Exception)   | F      | 0  | ~  | ~ | ~     | ~   | ~      | ~       | event | 1  | I    | ~       | 30  | ~        | ~       | expected | T  | ~      | ~  | ~  | ~  | ~       | ~   | ~        | ~       | ~  | ~  | ~  | ~  | ~
+          - 5  | Partial INSERT on active state keeps omitted fields (fan-in)    | T      | 5  | 3  | ~ | Alice | 30  | alice@ | Nice    | event | 10 | I    | Bob     | ~   | ~        | ~       | expected | F  | T      | 10 | 10 | ~  | Bob     | 30  | alice@   | Nice    | 10 | 5  | 5  | 5  | 4
+          - 6  | Reactivating INSERT keeps tombstones on omitted fields          | F      | 8  | 3  | 7 | D     | D   | D      | D       | event | 15 | I    | Bob     | 25  | ~        | ~       | expected | F  | T      | 15 | 15 | 7  | Bob     | 25  | D        | D       | 15 | 15 | 8  | 8  | 4
+        """,
+    )
+    @DisplayName("Single transition with INSERT_MERGE")
+    fun `single transition with insert merge`(
+        testIndex: Int,
+        testName: String,
+        initialActive: String,
+        initialVersion: Long,
+        initialCreatedAt: Long?,
+        initialDeletedAt: Long?,
+        initialName: String?,
+        initialAge: String?,
+        initialEmail: String?,
+        initialComment: String?,
+        eventMark: String,
+        eventVersion: Long,
+        eventType: String,
+        eventName: String?,
+        eventAge: String?,
+        eventEmail: String?,
+        eventComment: String?,
+        expectedMark: String,
+        expectedException: String,
+        expectedActive: String?,
+        expectedVersion: Long?,
+        expectedCreatedAt: Long?,
+        expectedDeletedAt: Long?,
+        expectedName: String?,
+        expectedAge: String?,
+        expectedEmail: String?,
+        expectedComment: String?,
+        expectedNameVersion: Long?,
+        expectedAgeVersion: Long?,
+        expectedEmailVersion: Long?,
+        expectedCommentVersion: Long?,
+        expectedPropertiesSize: Int?,
+    ) {
+        with(StateTestFixture) {
+            // given - Initial State
+            val state =
+                State.createNotNull(
+                    active = initialActive.toBooleanFlexible(),
+                    version = initialVersion,
+                    createdAt = initialCreatedAt,
+                    deletedAt = initialDeletedAt,
+                    initialName?.let { NAME_KEY to it.handleSpecialValue().toStateValue(initialVersion) },
+                    initialAge?.let { AGE_KEY to it.handleSpecialValue { toInt() }.toStateValue(initialVersion) },
+                    initialEmail?.let { EMAIL_KEY to it.handleSpecialValue().toStateValue(initialVersion) },
+                    initialComment?.let { COMMENT_KEY to it.handleSpecialValue().toStateValue(initialVersion) },
+                )
+
+            // given - Event
+            val event =
+                Event.createNotNull(
+                    type = eventType.toEventType(),
+                    version = eventVersion,
+                    eventName?.let { NAME_KEY to it },
+                    eventAge?.let { AGE_KEY to it.toInt() },
+                    eventEmail?.let { EMAIL_KEY to it },
+                    eventComment?.let { COMMENT_KEY to it },
+                )
+
+            if (expectedException.toBooleanFlexible()) {
+                // when - State Transition
+                assertThrows<Exception> {
+                    state.transit(event, fields, insertMerge = true)
+                }
+            } else {
+                // when - State Transition
+                val nextState = state.transit(event, fields, insertMerge = true)
+
+                // then
+                assertAll(
+                    nextState,
+                    expectedActive,
+                    expectedVersion,
+                    expectedCreatedAt,
+                    expectedDeletedAt,
+                    expectedName,
+                    expectedAge,
+                    expectedEmail,
+                    expectedComment,
+                    expectedNameVersion,
+                    expectedAgeVersion,
+                    expectedEmailVersion,
+                    expectedCommentVersion,
+                    expectedPropertiesSize,
+                )
+            }
+        }
+    }
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+          #                    | v | n | a | e | c | c | d | a | n | a | e | c | size
+          - I1                 | 1 | 1 | 1 | ~ | ~ | 1 | ~ | T | n | 7 | ~ | ~ | 2
+          - A1                 | 1 | ~ | 1 | ~ | ~ | ~ | ~ | F | ~ | 8 | ~ | ~ | 1
+          - E1                 | 1 | ~ | ~ | 1 | ~ | ~ | ~ | F | ~ | ~ | e | ~ | 1
+          - C1                 | 1 | ~ | ~ | ~ | 1 | ~ | ~ | F | ~ | ~ | ~ | c | 1
+          - D1                 | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | D | D | D | 4
+
+          # insert and update both merge; only insert refreshes createdAt/version
+          - I1; A1             | 1 | 1 | 1 | ~ | ~ | 1 | ~ | T | n | 8 | ~ | ~ | 2   # UPDATE wins on age
+          - A1; I1             | 1 | 1 | 1 | ~ | ~ | 1 | ~ | T | n | 7 | ~ | ~ | 2   # INSERT wins on age
+          - I1; A1; E1; C1     | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 8 | e | c | 4   # UPDATE wins on age
+          - A1; I1; E1; C1     | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 7 | e | c | 4   # INSERT wins on age
+          - A1; E1; I1; C1     | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 7 | e | c | 4   # INSERT wins on age
+          - A1; E1; C1; I1     | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 7 | e | c | 4   # INSERT wins on age
+
+          # normal case (all values are updated)
+          - I1; A2; E2; C2     | 2 | 1 | 2 | 2 | 2 | 1 | ~ | T | n | 8 | e | c | 4
+          - A2; I1; E2; C2     | 2 | 1 | 2 | 2 | 2 | 1 | ~ | T | n | 8 | e | c | 4
+          - A2; E2; I1; C2     | 2 | 1 | 2 | 2 | 2 | 1 | ~ | T | n | 8 | e | c | 4
+          - A2; E2; C2; I1     | 2 | 1 | 2 | 2 | 2 | 1 | ~ | T | n | 8 | e | c | 4
+
+          # insert merges: it refreshes name/age and version but does not clobber fields it omits
+          - I2; A1; E1; C1     | 2 | 2 | 2 | 1 | 1 | 2 | ~ | T | n | 7 | e | c | 4
+          - A1; I2; E1; C1     | 2 | 2 | 2 | 1 | 1 | 2 | ~ | T | n | 7 | e | c | 4
+          - A1; E1; I2; C1     | 2 | 2 | 2 | 1 | 1 | 2 | ~ | T | n | 7 | e | c | 4
+          - A1; E1; C1; I2     | 2 | 2 | 2 | 1 | 1 | 2 | ~ | T | n | 7 | e | c | 4
+
+          # overwrite by delete
+          - D1; I1             | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 7 | D | D | 4   # INSERT reactivates; omitted email/comment keep the tombstone
+          - I1; D1             | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | D | D | D | 4   # DELETE wins
+          - D1; I1; A1; E1; C1 | 1 | 1 | 1 | 1 | 1 | 1 | ~ | T | n | 8 | e | c | 4   # INSERT wins
+          - I1; D1; A1; E1; C1 | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | 8 | e | c | 4   # DELETE wins
+          - I1; A1; D1; E1; C1 | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | D | e | c | 4   # DELETE wins
+          - I1; A1; E1; D1; C1 | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | D | D | c | 4   # DELETE wins
+          - I1; A1; E1; C1; D1 | 1 | 1 | 1 | 1 | 1 | ~ | 1 | F | D | D | D | D | 4   # DELETE wins
+
+          # pairs
+          - I1; E1             | 1 | 1 | 1 | 1 | ~ | 1 | ~ | T | n | 7 | e | ~ | 3
+          - E1; I1             | 1 | 1 | 1 | 1 | ~ | 1 | ~ | T | n | 7 | e | ~ | 3
+          - I1; C1             | 1 | 1 | 1 | ~ | 1 | 1 | ~ | T | n | 7 | ~ | c | 3
+          - C1; I1             | 1 | 1 | 1 | ~ | 1 | 1 | ~ | T | n | 7 | ~ | c | 3
+
+          # update comment to null
+          - I1; C1             | 1 | 1 | 1 | ~ | 1 | 1 | ~ | T | n | 7 | ~ | c | 3
+          - I1; C1; N1         | 1 | 1 | 1 | ~ | 1 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - I1; N1; C1         | 1 | 1 | 1 | ~ | 1 | 1 | ~ | T | n | 7 | ~ | c | 3
+
+          # normal case (set comment to null)
+          - I1; C2; N3         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - I1; N3; C2         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - C2; I1; N3         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - C2; N3; I1         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - N3; I1; C2         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+          - N3; C2; I1         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | U | 3
+
+          # normal case (set comment to c)
+          - I1; N2; C3         | 3 | 1 | 1 | ~ | 3 | 1 | ~ | T | n | 7 | ~ | c | 3
+
+          # eventual consistency (these cases are covered by StateCompanion Test)
+          - I1; A2             | 2 | 1 | 2 | ~ | ~ | 1 | ~ | T | n | 8 | ~ | ~ | 2
+          - A2; I1             | 2 | 1 | 2 | ~ | ~ | 1 | ~ | T | n | 8 | ~ | ~ | 2
+
+          # ISSUE-3233 see [com.kakao.actionbase.v2.engine.IssueSpec]
+          # under merge semantics, an insert that omits "c" no longer invalidates it
+          - I2; C1             | 2 | 2 | 2 | ~ | 1 | 2 | ~ | T | n | 7 | ~ | c | 3
+          - C1; I2             | 2 | 2 | 2 | ~ | 1 | 2 | ~ | T | n | 7 | ~ | c | 3
+        """,
+    )
+    @DisplayName("Processing order with INSERT_MERGE")
+    fun `processing order with insert merge`(
+        notation: String,
+        expectedVersion: Long,
+        expectedNameVersion: Long?,
+        expectedAgeVersion: Long?,
+        expectedEmailVersion: Long?,
+        expectedCommentVersion: Long?,
+        expectedCreatedAt: Long?,
+        expectedDeletedAt: Long?,
+        expectedActive: String,
+        expectedName: String?,
+        expectedAge: String?,
+        expectedEmail: String?,
+        expectedComment: String?,
+        expectedPropertiesSize: Int,
+    ) {
+        with(StateTestFixture) {
+            // given
+            val processingSequence =
+                notation.toEventSequence { event, version ->
+                    when (event) {
+                        "I" -> insertEvent.copy(version = version)
+                        "A" -> updateAgeEvent.copy(version = version)
+                        "E" -> updateEmailEvent.copy(version = version)
+                        "C" -> updateCommentEvent.copy(version = version)
+                        "N" -> updateCommentNullEvent.copy(version = version)
+                        "D" -> deleteEvent.copy(version = version)
+                        else -> throw IllegalArgumentException("Unknown event type: $event")
+                    }
+                }
+
+            // when
+            val state =
+                processingSequence.fold(State.initial) { state, event ->
+                    state.transit(event, StateTestFixture.fields, insertMerge = true)
+                }
+
+            // then
+            assertAll(
+                state,
+                expectedActive,
+                expectedVersion,
+                expectedCreatedAt,
+                expectedDeletedAt,
+                expectedName,
+                expectedAge,
+                expectedEmail,
+                expectedComment,
+                expectedNameVersion,
+                expectedAgeVersion,
+                expectedEmailVersion,
+                expectedCommentVersion,
+                expectedPropertiesSize,
+            )
+        }
+    }
+
+    companion object {
+        private const val VERSION = 0L
+        private const val INSERT_NAME_VALUE = "n"
+        private const val INSERT_AGE_VALUE = 7
+        private const val UPDATE_AGE_VALUE = 8
+        private const val UPDATE_EMAIL_VALUE = "e"
+        private const val UPDATE_COMMENT_VALUE = "c"
+
+        private val insertEvent =
+            with(StateTestFixture) {
+                Event.create(
+                    EventType.INSERT,
+                    VERSION,
+                    NAME_KEY to INSERT_NAME_VALUE,
+                    AGE_KEY to INSERT_AGE_VALUE,
+                )
+            }
+
+        private val updateAgeEvent =
+            with(StateTestFixture) {
+                Event.create(
+                    EventType.UPDATE,
+                    VERSION,
+                    AGE_KEY to UPDATE_AGE_VALUE,
+                )
+            }
+
+        private val updateEmailEvent =
+            with(StateTestFixture) {
+                Event.create(
+                    EventType.UPDATE,
+                    VERSION,
+                    EMAIL_KEY to UPDATE_EMAIL_VALUE,
+                )
+            }
+
+        private val updateCommentEvent =
+            with(StateTestFixture) {
+                Event.create(
+                    EventType.UPDATE,
+                    VERSION,
+                    COMMENT_KEY to UPDATE_COMMENT_VALUE,
+                )
+            }
+
+        private val updateCommentNullEvent =
+            with(StateTestFixture) {
+                Event.create(
+                    EventType.UPDATE,
+                    VERSION,
+                    COMMENT_KEY to null,
+                )
+            }
+
+        private val deleteEvent = Event.create(EventType.DELETE, VERSION)
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -4,7 +4,10 @@ import com.kakao.actionbase.core.edge.MutationEvent
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.UnresolvedEvent
 import com.kakao.actionbase.core.edge.payload.MutationResult
+import com.kakao.actionbase.core.metadata.features.FeatureFlags
+import com.kakao.actionbase.core.metadata.features.MutationFeature
 import com.kakao.actionbase.core.state.EventType
+import com.kakao.actionbase.core.state.InvalidMutationException
 import com.kakao.actionbase.core.state.transit
 import com.kakao.actionbase.engine.Audit
 import com.kakao.actionbase.engine.MutationContext
@@ -25,6 +28,7 @@ import reactor.core.publisher.Mono
 
 class MutationService(
     private val engine: MutationEngine,
+    private val featureFlags: FeatureFlags = FeatureFlags(emptyList()),
 ) {
     fun mutate(
         database: String,
@@ -34,8 +38,9 @@ class MutationService(
         syncMode: MutationMode? = null,
         forceSyncMode: Boolean = false,
         requestContext: RequestContext = RequestContext.DEFAULT,
-    ): Mono<List<MutationResult>> =
-        Mono
+    ): Mono<List<MutationResult>> {
+        val insertMerge = featureFlags.has(FeatureFlags.Scope(database), MutationFeature.INSERT_MERGE)
+        return Mono
             .fromCallable {
                 val tb = engine.getTableBinding(database, alias)
                 val ctx =
@@ -51,7 +56,7 @@ class MutationService(
             }.flatMap { (ctx, tb) ->
                 Flux
                     .fromIterable(unresolvedEvents)
-                    .map { it.createEvent(tb.schema) }
+                    .map { it.createEvent(tb.schema, insertMerge) }
                     .collectList()
                     .flatMapMany { Flux.fromIterable(it) }
                     .flatMap { event -> engine.writeWal(ctx, event).thenReturn(event) }
@@ -62,12 +67,14 @@ class MutationService(
                         } else {
                             groupMono.flatMap { group ->
                                 val sorted = group.sortedBy { it.event.version }
-                                readModifyWrite(tb, key, sorted, acquireLock, requestContext.newCollector())
+                                readModifyWrite(tb, key, sorted, acquireLock, requestContext.newCollector(), insertMerge)
                                     .doOnNext { result ->
                                         engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
-                                    }.onErrorResume {
-                                        tb.handleMutationError(it)
-                                        Mono.just(MutationResult.of(key, 0, ERROR))
+                                    }.onErrorResume { error ->
+                                        tb.handleMutationError(error)
+                                        // Permanent (bad input) vs transient (retryable).
+                                        val status = if (error.isInvalidMutation()) INVALID else ERROR
+                                        Mono.just(MutationResult.of(key, 0, status))
                                     }
                             }
                         }
@@ -75,6 +82,7 @@ class MutationService(
                     .timeout(Duration.ofMillis(engine.mutationRequestTimeout))
                     .runEvenIfCancelled()
             }
+    }
 
     /**
      * For `system=ASYNC + label=SYNC` (no force), return the SYNC-shaped status derived from
@@ -103,12 +111,13 @@ class MutationService(
         sorted: List<MutationEvent>,
         acquireLock: Boolean,
         collector: StorageOpCollector?,
+        insertMerge: Boolean,
     ): Mono<MutationResult> {
         val rwm = {
             tb
                 .read(key)
                 .flatMap { state ->
-                    val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema) }
+                    val after = sorted.fold(state) { acc, m -> acc.transit(m.event, tb.schema, insertMerge) }
                     tb.write(key, state, after, collector)
                 }.map { summary ->
                     val context = collector?.toContextMap()
@@ -121,5 +130,8 @@ class MutationService(
     private companion object {
         const val QUEUED = "QUEUED"
         const val ERROR = "ERROR"
+        const val INVALID = "INVALID"
+
+        private fun Throwable.isInvalidMutation(): Boolean = generateSequence(this) { it.cause }.any { it is InvalidMutationException }
     }
 }

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/MutationServiceSpec.kt
@@ -4,6 +4,8 @@ import com.kakao.actionbase.core.Constants.VERTEX_MARKER
 import com.kakao.actionbase.core.edge.payload.DataFrameEdgePayload
 import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
 import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.core.metadata.features.FeatureFlags
+import com.kakao.actionbase.core.metadata.features.MutationFeature
 import com.kakao.actionbase.core.vertex.payload.VertexBulkMutationRequest
 import com.kakao.actionbase.core.vertex.payload.VertexMutationResponse
 import com.kakao.actionbase.engine.service.MutationService
@@ -32,12 +34,18 @@ class MutationServiceSpec :
 
         lateinit var graph: Graph
         lateinit var mutationService: MutationService
+        lateinit var mergeMutationService: MutationService
         lateinit var queryService: QueryService
 
         beforeTest {
             graph = GraphFixtures.create()
             val engine = V2BackedEngine(graph)
             mutationService = MutationService(engine)
+            mergeMutationService =
+                MutationService(
+                    engine,
+                    FeatureFlags(listOf(FeatureFlags.Item(MutationFeature.INSERT_MERGE, setOf(GraphFixtures.serviceName)))),
+                )
             queryService = QueryService(engine)
         }
 
@@ -544,6 +552,83 @@ class MutationServiceSpec :
                     .block()!!
             afterDeleteResult.edges.size shouldBe 1
             afterDeleteResult.edges[0].source.toString() shouldBe "user1"
+        }
+
+        "INSERT missing non-nullable field with INSERT_MERGE surfaces INVALID at transit" {
+            val database = GraphFixtures.serviceName
+            val table = GraphFixtures.hbaseIndexed // createdAt: LONG, nullable=false
+
+            // With the merge gate an omitted field passes request validation (it may be supplied
+            // by a prior write); on this empty row completeness fails at transit, post-WAL, and
+            // surfaces as a per-item INVALID (permanent) status instead of a transient ERROR.
+            val request =
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 10, "source": "4000", "target": "9000", "properties": {"permission": "na"}}}
+                  ]
+                }
+                """.trimIndent().toEdgeBulkMutationRequest()
+
+            mergeMutationService
+                .mutate(database, table, request.mutations)
+                .test()
+                .assertNext { results ->
+                    results.size shouldBe 1
+                    results[0].status shouldBe "INVALID"
+                }.verifyComplete()
+
+            // No row should be persisted
+            queryService
+                .gets(database, table, listOf("4000"), listOf("9000"))
+                .test()
+                .assertNext { it.edges.isEmpty() shouldBe true }
+                .verifyComplete()
+        }
+
+        "partial INSERTs with INSERT_MERGE merge into one row (fan-in)" {
+            val database = GraphFixtures.serviceName
+            val table = GraphFixtures.hbaseIndexed
+
+            val first =
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 10, "source": "5000", "target": "9000", "properties": {"permission": "na", "createdAt": 10}}}
+                  ]
+                }
+                """.trimIndent().toEdgeBulkMutationRequest()
+            val second =
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 20, "source": "5000", "target": "9000", "properties": {"permission": "nb"}}}
+                  ]
+                }
+                """.trimIndent().toEdgeBulkMutationRequest()
+
+            mergeMutationService
+                .mutate(database, table, first.mutations)
+                .test()
+                .assertNext { it[0].status shouldBe "CREATED" }
+                .verifyComplete()
+
+            // The second INSERT omits the non-nullable createdAt — legal under merge: the value
+            // written by the first source is kept, the row stays active.
+            mergeMutationService
+                .mutate(database, table, second.mutations)
+                .test()
+                .assertNext { it[0].status shouldBe "UPDATED" }
+                .verifyComplete()
+
+            queryService
+                .gets(database, table, listOf("5000"), listOf("9000"))
+                .test()
+                .assertNext { payload ->
+                    payload.edges.size shouldBe 1
+                    payload.edges[0].properties["permission"] shouldBe "nb"
+                    payload.edges[0].properties["createdAt"] shouldBe 10L
+                }.verifyComplete()
         }
     }) {
     companion object {

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
@@ -139,5 +139,8 @@ class GraphConfiguration {
     fun provideQueryService(engine: V2BackedEngine): QueryService = QueryService(engine)
 
     @Bean
-    fun provideMutationService(engine: V2BackedEngine): MutationService = MutationService(engine)
+    fun provideMutationService(
+        engine: V2BackedEngine,
+        graph: Graph,
+    ): MutationService = MutationService(engine, graph.featureFlags)
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationInsertMergeTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationInsertMergeTest.kt
@@ -1,0 +1,114 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.reactive.server.StatusAssertions
+
+/**
+ * E2E for a database under `actionbase.feature-flags` with `INSERT_MERGE`: an omitted field is a
+ * legal partial write (per-item INVALID if the row stays incomplete); an explicit null on a
+ * non-nullable field is still 400. Snapshot behavior is in [EdgeMutationValidationTest].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(
+    properties = [
+        "actionbase.feature-flags[0].feature=INSERT_MERGE",
+        "actionbase.feature-flags[0].scope.databases[0]=merge_test_db",
+    ],
+)
+class EdgeMutationInsertMergeTest : E2ETestBase() {
+    private val db = "merge_test_db"
+    private val syncTable = "merge_sync_edge"
+
+    // Schema: "required" (long, non-nullable), "optional" (string, nullable)
+    private fun tableDdl(
+        table: String,
+        storage: String,
+        mode: String,
+    ) = """
+        {
+          "table": "$table",
+          "schema": {
+            "type": "EDGE",
+            "source": {"type": "string", "comment": "src"},
+            "target": {"type": "string", "comment": "tgt"},
+            "properties": [
+              {"name": "required", "type": "long",   "comment": "required", "nullable": false},
+              {"name": "optional", "type": "string", "comment": "optional", "nullable": true}
+            ],
+            "direction": "OUT",
+            "indexes": [],
+            "groups": []
+          },
+          "storage": "$storage",
+          "mode": "$mode",
+          "comment": "$mode edge for insert-merge test"
+        }
+        """.trimIndent()
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "insert-merge test db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(tableDdl(syncTable, "datastore://test_namespace/merge_sync_edge", "SYNC"))
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    private fun mutateSync(body: String): StatusAssertions =
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$syncTable/edges/sync")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+
+    @Test
+    fun `sync INSERT missing non-nullable field on an empty row is reported as INVALID`() {
+        mutateSync("""{"mutations":[{"type":"INSERT","edge":{"version":1,"source":"A","target":"B","properties":{"optional":"hello"}}}]}""")
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("INVALID")
+    }
+
+    @Test
+    fun `sync INSERT with explicit null for non-nullable field still returns 400`() {
+        mutateSync("""{"mutations":[{"type":"INSERT","edge":{"version":1,"source":"A","target":"B","properties":{"required":null}}}]}""")
+            .isBadRequest
+    }
+
+    @Test
+    fun `sync partial INSERTs merge into one row (fan-in)`() {
+        mutateSync("""{"mutations":[{"type":"INSERT","edge":{"version":1,"source":"C","target":"D","properties":{"required":7}}}]}""")
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+
+        // Omits the non-nullable "required" — legal under merge, the existing value is kept.
+        mutateSync("""{"mutations":[{"type":"INSERT","edge":{"version":2,"source":"C","target":"D","properties":{"optional":"hello"}}}]}""")
+            .isOk
+            .expectBody()
+            .jsonPath("$.results[0].status")
+            .isEqualTo("UPDATED")
+    }
+}


### PR DESCRIPTION
## Summary

For a database enabled for `INSERT_MERGE` via `actionbase.feature-flags` (#432), INSERT becomes an activating merge: an omitted field keeps its existing value, an explicit null clears it, and only INSERT activates the row. This lets multi-source fan-in writers each INSERT the subset of fields they own without clobbering each other.

Without the feature (default), INSERT keeps snapshot semantics — ungated databases are unaffected, pre-gate WAL entries replay identically, and the completeness check keeps its original `IllegalArgumentException` (surfaced as `ERROR`).

```yaml
actionbase:
  feature-flags:
    - feature: INSERT_MERGE
      scope:
        databases: [fanin]
```

Behavior on an existing row, `email = "a@x.com"` (nullable):

| client input | INSERT (default, snapshot) | INSERT (INSERT_MERGE) | UPDATE |
|---|---|---|---|
| `{email:"b"}` | `"b"` | `"b"` | `"b"` |
| `{email:null}` | `null` (clear) | `null` (clear) | `null` |
| `{}` (omitted) | `null` (cleared) | **`"a@x.com"` (kept)** | kept |

## Changes

- `StateExtensions.transit(insertMerge)`: INSERT branches between merge and snapshot property handling. The active-row completeness check throws `InvalidMutationException` only under `insertMerge`; the default path keeps its original `IllegalArgumentException`, so ungated behavior is unchanged
- `MutationRequestValidator`: with the feature, INSERT relaxes to present-only nullability validation; explicit null on a non-nullable field still fails pre-WAL. Completeness of an activated row is enforced at transit (permanent)
- `MutationService`: resolves the feature once per request via the injected `FeatureFlags` (`has(Scope(database), INSERT_MERGE)`); a permanently invalid mutation surfaces as a per-item `INVALID` status (vs transient `ERROR`), detected across the exception cause chain
- `GraphConfiguration`: wires `MutationService` to `Graph.featureFlags`
- Tests: snapshot goldens unchanged from main; merge goldens in new `InsertMergeTest`; new `EdgeMutationInsertMergeTest` pins the gated pipeline end to end

## How to Test

- `./gradlew :core:test --tests "*InsertMergeTest"` — merge goldens
- `./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.MutationServiceSpec"` — per-item `INVALID` and fan-in merge through the RMW pipeline
- `./gradlew :server:test --tests "com.kakao.actionbase.server.api.graph.v3.EdgeMutationInsertMergeTest"` — E2E with the feature enabled via config

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.8, 1M context)
