### PR TITLE
Add ByteArrayStore-backed Hash/Indexed labels to `main` (reverted)

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayHashLabel.kt
@@ -1,0 +1,181 @@
+package com.kakao.actionbase.v2.engine.label.bytearray
+
+import com.kakao.actionbase.core.storage.MutationRequest
+import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+import com.kakao.actionbase.engine.storage.StorageOpCollector
+import com.kakao.actionbase.v2.core.code.EdgeEncoder
+import com.kakao.actionbase.v2.core.code.EncodedKey
+import com.kakao.actionbase.v2.core.code.KeyFieldValue
+import com.kakao.actionbase.v2.core.code.KeyValue
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.edge.SchemaEdge
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.engine.edge.decodeByteArray
+import com.kakao.actionbase.v2.engine.edge.toRow
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
+import com.kakao.actionbase.v2.engine.label.AbstractLabel
+import com.kakao.actionbase.v2.engine.sql.DataFrame
+import com.kakao.actionbase.v2.engine.sql.Row
+import com.kakao.actionbase.v2.engine.sql.StatKey
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Arrays
+
+import reactor.core.publisher.Mono
+
+open class ByteArrayHashLabel(
+    entity: LabelEntity,
+    coder: EdgeEncoder<ByteArray>,
+    protected val store: ByteArrayStore,
+) : AbstractLabel<ByteArray>(entity, coder) {
+    override fun findHashEdge(keyField: EncodedKey<ByteArray>): Mono<ByteArray> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.fromCallable { store[keyField.key] }.mapNotNull { it }
+    }
+
+    override fun create(
+        keyField: EncodedKey<ByteArray>,
+        value: ByteArray,
+    ): Mono<List<Any>> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.just(listOf(MutationRequest.Put(keyField.key, value)))
+    }
+
+    override fun update(
+        keyField: EncodedKey<ByteArray>,
+        value: ByteArray,
+    ): Mono<List<Any>> = create(keyField, value)
+
+    override fun delete(keyField: EncodedKey<ByteArray>): Mono<List<Any>> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.just(listOf(MutationRequest.Delete(keyField.key)))
+    }
+
+    override fun incrby(
+        key: ByteArray,
+        acc: Long,
+    ): Mono<List<Any>> = Mono.just(listOf(MutationRequest.Increment(key, acc)))
+
+    override fun handleDeferredRequests(
+        deferredRequests: List<Any>,
+        storageOpCollector: StorageOpCollector?,
+    ): Mono<Boolean> =
+        Mono
+            .fromCallable {
+                deferredRequests.forEach { request ->
+                    when (request) {
+                        is MutationRequest.Put -> store[request.key] = request.value
+                        is MutationRequest.Delete -> store.remove(request.key)
+                        is MutationRequest.Increment -> store.increment(request.key, request.value)
+                        else -> throw IllegalArgumentException("Unsupported request type: $request")
+                    }
+                }
+                true
+            }
+
+    override fun setnx(
+        keyField: EncodedKey<ByteArray>,
+        value: ByteArray,
+    ): Mono<Boolean> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.fromCallable { store.checkAndSet(keyField.key, null, value) }
+    }
+
+    override fun setnxOnLock(
+        keyField: EncodedKey<ByteArray>,
+        value: ByteArray,
+    ): Mono<Boolean> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.fromCallable { store.checkAndSet(keyField.key, null, value) }
+    }
+
+    override fun cad(
+        keyField: EncodedKey<ByteArray>,
+        value: ByteArray,
+    ): Mono<Long> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.fromCallable { if (store.checkAndSet(keyField.key, value, null)) 1L else 0L }
+    }
+
+    override fun findLockValue(keyField: EncodedKey<ByteArray>): Mono<ByteArray> {
+        require(keyField.field == null) { "field must be null" }
+        return Mono.fromCallable { store[keyField.key] }.mapNotNull { it }
+    }
+
+    override fun deleteOnLock(keyField: KeyValue<ByteArray>): Mono<Boolean> = cad(EncodedKey(keyField.key), keyField.value).map { it > 0 }
+
+    override fun scanStorage(
+        prefix: EncodedKey<ByteArray>,
+        limit: Int,
+        start: EncodedKey<ByteArray>?,
+        end: EncodedKey<ByteArray>?,
+    ): Mono<List<KeyFieldValue<ByteArray>>> =
+        Mono.fromCallable {
+            store
+                .prefixScan(prefix.key)
+                .dropWhile { record -> start?.key?.let { Arrays.compareUnsigned(it, record.key) >= 0 } ?: false }
+                .dropLastWhile { record -> end?.key?.let { Arrays.compareUnsigned(it, record.key) < 0 } ?: false }
+                .take(limit)
+                .map { KeyFieldValue(it.key, it.value) }
+        }
+
+    override fun encodedEdgeToSchemaEdge(keyFieldValue: KeyFieldValue<ByteArray>): SchemaEdge = entity.schema.decodeByteArray(keyFieldValue)
+
+    override fun getSelf(
+        src: List<Any>,
+        stats: Set<StatKey>,
+    ): Mono<DataFrame> {
+        val withAll = stats.contains(StatKey.WITH_ALL)
+        return Mono
+            .fromCallable {
+                src
+                    .mapNotNull {
+                        val edge = Edge(0L, it, it).ensureType(entity.schema)
+                        val key = coder.encodeHashEdgeKey(edge, entity.id)
+                        store[key.key]?.let { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
+                    }.filter { withAll || it.isActive }
+                    .map { it.toRow(withAll) }
+            }.map { rows -> toDataFrame(rows, withAll) }
+    }
+
+    override fun get(
+        src: Any,
+        tgt: List<Any>,
+        dir: Direction,
+        stats: Set<StatKey>,
+    ): Mono<DataFrame> {
+        val withAll = stats.contains(StatKey.WITH_ALL)
+        return Mono
+            .fromCallable {
+                tgt
+                    .mapNotNull {
+                        val edge = Edge(0L, src, it).ensureType(entity.schema)
+                        val key = coder.encodeHashEdgeKey(edge, entity.id)
+                        store[key.key]?.let { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
+                    }.filter { withAll || it.isActive }
+                    .map { it.toRow(withAll, isMultiEdge) }
+            }.map { rows -> toDataFrame(rows, withAll) }
+    }
+
+    override fun getCountRows(
+        srcAndKeys: List<Pair<Any, ByteArray>>,
+        dir: Direction,
+    ): Mono<List<Row>> =
+        Mono.fromCallable {
+            srcAndKeys.map { (src, key) ->
+                val value = store[key]
+                val count = if (value == null) 0L else ByteBuffer.wrap(value).order(ByteOrder.BIG_ENDIAN).long
+                Row(arrayOf(src, count, dir))
+            }
+        }
+
+    private fun toDataFrame(
+        rows: List<Row>,
+        withAll: Boolean,
+    ): DataFrame =
+        DataFrame(
+            rows,
+            if (withAll) entity.schema.allStructType else entity.schema.structType,
+        )
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayIndexedLabel.kt
@@ -1,0 +1,47 @@
+package com.kakao.actionbase.v2.engine.label.bytearray
+
+import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+import com.kakao.actionbase.v2.core.code.EdgeEncoder
+import com.kakao.actionbase.v2.core.code.Index
+import com.kakao.actionbase.v2.engine.cdc.CdcContext
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
+import com.kakao.actionbase.v2.engine.label.AbstractLabel
+import com.kakao.actionbase.v2.engine.label.mixin.IndexedLabelMixin
+import com.kakao.actionbase.v2.engine.sql.DataFrame
+import com.kakao.actionbase.v2.engine.sql.ScanFilter
+import com.kakao.actionbase.v2.engine.sql.StatKey
+
+import reactor.core.publisher.Mono
+
+open class ByteArrayIndexedLabel(
+    entity: LabelEntity,
+    coder: EdgeEncoder<ByteArray>,
+    override val indices: List<Index>,
+    override val indexNameToIndex: Map<String, Index>,
+    store: ByteArrayStore,
+) : ByteArrayHashLabel(entity, coder, store),
+    IndexedLabelMixin<ByteArray> {
+    override val self: AbstractLabel<ByteArray> = this
+
+    override fun finalizeEdgeMutationUnderLock(context: CdcContext): Mono<List<Any>> = mutateIndexedEdges(context)
+
+    override fun scan(
+        scanFilter: ScanFilter,
+        stats: Set<StatKey>,
+    ): Mono<DataFrame> = scanIndexedEdges(scanFilter, stats)
+
+    companion object {
+        fun create(
+            entity: LabelEntity,
+            coder: EdgeEncoder<ByteArray>,
+            store: ByteArrayStore,
+        ): ByteArrayIndexedLabel =
+            ByteArrayIndexedLabel(
+                entity = entity,
+                coder = coder,
+                indices = entity.indices,
+                indexNameToIndex = entity.indices.associateBy { it.name },
+                store = store,
+            )
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabelCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabelCompatibilityTest.kt
@@ -1,0 +1,149 @@
+package com.kakao.actionbase.v2.engine.label
+
+import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
+import com.kakao.actionbase.v2.core.code.Index
+import com.kakao.actionbase.v2.core.code.hbase.Order
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.core.types.DataType
+import com.kakao.actionbase.v2.core.types.EdgeSchema
+import com.kakao.actionbase.v2.core.types.Field
+import com.kakao.actionbase.v2.core.types.VertexField
+import com.kakao.actionbase.v2.core.types.VertexType
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
+import com.kakao.actionbase.v2.engine.sql.ScanFilter
+import com.kakao.actionbase.v2.engine.sql.StatKey
+import com.kakao.actionbase.v2.engine.sql.toRowFlux
+
+import kotlin.test.assertEquals
+
+import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
+
+/**
+ * Backend-agnostic compatibility suite for [Label] implementations. Every backend twin
+ * (ByteArrayStore, HBase, ...) is exercised through the standard mutate/read pipeline and must
+ * reproduce identical semantics: the hash round-trip, delete, degree counter, and indexed range
+ * scan. Subclasses provide backend-specific labels via [hashLabel]/[indexedLabel].
+ */
+abstract class AbstractLabelCompatibilityTest {
+    protected val coder = EdgeEncoderFactory().bytesKeyValueEncoder
+
+    protected val schema =
+        EdgeSchema(
+            VertexField(VertexType.STRING),
+            VertexField(VertexType.STRING),
+            listOf(
+                Field("createdAt", DataType.LONG, false),
+            ),
+        )
+
+    protected val indices =
+        listOf(Index("createdAt_asc", listOf(Index.Field("createdAt", Order.ASC))))
+
+    protected val hashEntity =
+        LabelEntity(
+            active = true,
+            name = EntityName("test", "hash"),
+            desc = "hash label",
+            type = LabelType.HASH,
+            schema = schema,
+            dirType = DirectionType.OUT,
+            storage = "mock",
+        )
+
+    protected val indexedEntity =
+        LabelEntity(
+            active = true,
+            name = EntityName("test", "indexed"),
+            desc = "indexed label",
+            type = LabelType.INDEXED,
+            schema = schema,
+            dirType = DirectionType.BOTH,
+            storage = "mock",
+            indices = indices,
+        )
+
+    protected abstract fun hashLabel(): AbstractLabel<*>
+
+    protected abstract fun indexedLabel(): AbstractLabel<*>
+
+    private fun edge(
+        src: String,
+        tgt: String,
+        createdAt: Long,
+    ) = Edge(createdAt, src, tgt, mapOf("createdAt" to createdAt)).toTraceEdge()
+
+    @Test
+    fun `hash - insert round-trips through get`() {
+        val label = hashLabel()
+
+        label
+            .mutate(listOf(edge("u1", "v1", 100L)), EdgeOperation.INSERT)
+            .then(label.get("u1", listOf("v1"), Direction.OUT, emptySet()))
+            .toRowFlux()
+            .map { it["tgt"] }
+            .collectList()
+            .test()
+            .assertNext { assertEquals(listOf("v1"), it) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `hash - delete deactivates the edge`() {
+        val label = hashLabel()
+
+        label
+            .mutate(listOf(edge("u1", "v1", 100L)), EdgeOperation.INSERT)
+            .then(label.mutate(listOf(edge("u1", "v1", 200L)), EdgeOperation.DELETE))
+            .then(label.get("u1", listOf("v1"), Direction.OUT, emptySet()))
+            .toRowFlux()
+            .map { it["tgt"] }
+            .collectList()
+            .test()
+            .assertNext { assertEquals(emptyList<Any?>(), it) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `hash - out-degree counter reflects inserts`() {
+        val label = hashLabel()
+
+        label
+            .mutate(listOf(edge("u1", "v1", 100L), edge("u1", "v2", 110L)), EdgeOperation.INSERT)
+            .then(label.count("u1", Direction.OUT))
+            .toRowFlux()
+            .map { it.getLong("COUNT(1)") }
+            .collectList()
+            .test()
+            .assertNext { assertEquals(listOf(2L), it) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `indexed - inserts are readable through the index scan`() {
+        val label = indexedLabel()
+        val scanFilter =
+            ScanFilter(
+                name = label.name,
+                srcSet = setOf("u1"),
+                dir = Direction.OUT,
+                indexName = "createdAt_asc",
+                limit = 100,
+            )
+
+        label
+            .mutate(listOf(edge("u1", "v1", 100L), edge("u1", "v2", 200L)), EdgeOperation.INSERT)
+            .then(label.scan(scanFilter, emptySet<StatKey>()))
+            .toRowFlux()
+            .map { it["tgt"] }
+            .collectList()
+            .test()
+            .assertNext { assertEquals(listOf("v1", "v2"), it) }
+            .verifyComplete()
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabelCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/AbstractLabelCompatibilityTest.kt
@@ -22,6 +22,7 @@ import com.kakao.actionbase.v2.engine.sql.toRowFlux
 import kotlin.test.assertEquals
 
 import org.junit.jupiter.api.Test
+
 import reactor.kotlin.test.test
 
 /**

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayLabelCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayLabelCompatibilityTest.kt
@@ -1,0 +1,15 @@
+package com.kakao.actionbase.v2.engine.label.bytearray
+
+import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+import com.kakao.actionbase.v2.engine.label.AbstractLabel
+import com.kakao.actionbase.v2.engine.label.AbstractLabelCompatibilityTest
+
+/**
+ * Runs the shared label compatibility suite against the in-memory [ByteArrayStore]-backed labels.
+ * The labels are instantiated directly on a fresh store, without a Graph or table provisioning.
+ */
+class ByteArrayLabelCompatibilityTest : AbstractLabelCompatibilityTest() {
+    override fun hashLabel(): AbstractLabel<*> = ByteArrayHashLabel(hashEntity, coder, ByteArrayStore())
+
+    override fun indexedLabel(): AbstractLabel<*> = ByteArrayIndexedLabel.create(indexedEntity, coder, ByteArrayStore())
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseLabelCompatibilityTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/hbase/HBaseLabelCompatibilityTest.kt
@@ -1,0 +1,68 @@
+package com.kakao.actionbase.v2.engine.label.hbase
+
+import com.kakao.actionbase.core.Constants
+import com.kakao.actionbase.core.codec.ByteArrayBufferPool
+import com.kakao.actionbase.core.edge.mapper.EdgeCacheRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeCountRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeGroupRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeIndexRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeLockRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
+import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
+import com.kakao.actionbase.v2.engine.label.AbstractLabel
+import com.kakao.actionbase.v2.engine.label.AbstractLabelCompatibilityTest
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseConnections
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTable
+import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTables
+import com.kakao.actionbase.v2.engine.storage.hbase.impl.NewMockTable
+
+import org.apache.hadoop.hbase.TableName
+import org.apache.hadoop.hbase.client.mock.MockHTable
+
+import reactor.core.publisher.Mono
+
+/**
+ * Runs the shared label compatibility suite against the HBase-backed labels, the twins the
+ * ByteArrayStore labels mirror. Storage is an in-process [MockHTable] (no real cluster), so the
+ * same edge encoding is exercised end-to-end through the mock HBase client.
+ */
+class HBaseLabelCompatibilityTest : AbstractLabelCompatibilityTest() {
+    private val edgeRecordMapper: EdgeRecordMapper =
+        run {
+            val pool = ByteArrayBufferPool.create(1, Constants.Codec.DEFAULT_BUFFER_SIZE)
+            EdgeRecordMapper(
+                state = EdgeStateRecordMapper.create(pool),
+                index = EdgeIndexRecordMapper.create(pool),
+                count = EdgeCountRecordMapper.create(pool),
+                lock = EdgeLockRecordMapper.create(pool),
+                group = EdgeGroupRecordMapper.create(pool),
+                cache = EdgeCacheRecordMapper.create(pool),
+            )
+        }
+
+    private fun freshTables(): Mono<HBaseTables> {
+        // Each label needs an isolated store, so key the mock connection by a unique namespace.
+        val namespace = "label-compat-${namespaceCounter++}"
+        val conn = HBaseConnections.getMockConnection(namespace)
+        val table = NewMockTable(conn.getTable(TableName.valueOf("edges")) as MockHTable)
+        val hbaseTable = HBaseTable.create(table)
+        return Mono.just(HBaseTables(hbaseTable, hbaseTable))
+    }
+
+    override fun hashLabel(): AbstractLabel<*> = HBaseHashLabel(hashEntity, coder, freshTables())
+
+    override fun indexedLabel(): AbstractLabel<*> =
+        HBaseIndexedLabel(
+            entity = indexedEntity,
+            coder = coder,
+            indices = indices,
+            indexNameToIndex = indices.associateBy { it.name },
+            tables = freshTables(),
+            edgeRecordMapper = edgeRecordMapper,
+            lockTimeout = 300000L,
+        )
+
+    private companion object {
+        var namespaceCounter = 0
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ByteArrayHashLabel` and `ByteArrayIndexedLabel`, storage-agnostic twins of the HBase labels backed by an in-memory `ByteArrayStore`. Every edge kind is encoded in the row key, so a single ordered store reproduces the HBase semantics without table provisioning.

This is the same change previously merged into `bytearray-c` as #419, cherry-picked onto `main` so it no longer depends on the MetastoreInspector removal (#418).

## Changes

- Add `ByteArrayHashLabel` / `ByteArrayIndexedLabel` (row-key encoded, in-memory `ByteArrayStore`).
- Add `AbstractLabelCompatibilityTest`, a backend-agnostic JUnit 5 suite covering the hash round-trip, delete, degree counter, and indexed range scan.
- Add `ByteArrayLabelCompatibilityTest` and `HBaseLabelCompatibilityTest`, which run the shared suite against the ByteArrayStore- and mock-HBase-backed labels so the twins are held to identical semantics.

## How to Test

```
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.label.bytearray.ByteArrayLabelCompatibilityTest" --tests "com.kakao.actionbase.v2.engine.label.hbase.HBaseLabelCompatibilityTest"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.8)