### PR TITLE
Initialize the StorageBackend factory at startup (Step 1 of #422)

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -11,6 +11,7 @@ import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
 import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
 import com.kakao.actionbase.engine.query.LabelProvider
+import com.kakao.actionbase.engine.storage.DefaultStorageBackendFactory
 import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
 import com.kakao.actionbase.v2.core.edge.Edge
@@ -960,6 +961,7 @@ class Graph(
             webClientFactory: WebClientFactory,
         ): Graph {
             DefaultHBaseCluster.initialize(config.hbase)
+            DefaultStorageBackendFactory.initialize(config.hbase)
             log.info("phase: {}", config.phase)
             log.info("tenant: {}", config.tenant)
             log.info("graph config: {}", config)


### PR DESCRIPTION
## Summary

Step 1 of #422 (unify store-backend acquisition): initialize the URI-addressed `StorageBackend` factory at startup so it is live and observable before any consumer depends on it. No consumer is wired yet — this is purely additive.

Part of #422.

## Changes

- `Graph.create()` calls `DefaultStorageBackendFactory.initialize(config.hbase)` right after `DefaultHBaseCluster.initialize(config.hbase)`. Both read the same `hbase` config map; the factory init is idempotent, so there is no behavior change.

## How to Test

`./gradlew :engine:test :server:test` — green; spotless clean. Startup now logs the selected backend (`Initializing StorageBackend with type: ...`).

Note: `PerCellTTLTest` is a pre-existing time-based flake (passes in isolation, unrelated to this change); if CI hits it, re-run.

## AI Assistance

- [x] This PR was written with AI assistance.
  - Tool / model: Claude Code (Opus 4.8)
