### PR TITLE
Back the ByteArray labels with the StorageTable seam (Step 2 of #422)

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayHashLabel.kt
@@ -3,6 +3,8 @@ package com.kakao.actionbase.v2.engine.label.bytearray
 import com.kakao.actionbase.core.storage.MutationRequest
 import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
 import com.kakao.actionbase.engine.storage.StorageOpCollector
+import com.kakao.actionbase.engine.storage.StorageTable
+import com.kakao.actionbase.engine.storage.memory.MemoryStorageTable
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.EncodedKey
 import com.kakao.actionbase.v2.core.code.KeyFieldValue
@@ -22,16 +24,23 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.Arrays
 
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 open class ByteArrayHashLabel(
     entity: LabelEntity,
     coder: EdgeEncoder<ByteArray>,
-    protected val store: ByteArrayStore,
+    protected val table: StorageTable,
 ) : AbstractLabel<ByteArray>(entity, coder) {
+    constructor(
+        entity: LabelEntity,
+        coder: EdgeEncoder<ByteArray>,
+        store: ByteArrayStore,
+    ) : this(entity, coder, MemoryStorageTable(store))
+
     override fun findHashEdge(keyField: EncodedKey<ByteArray>): Mono<ByteArray> {
         require(keyField.field == null) { "field must be null" }
-        return Mono.fromCallable { store[keyField.key] }.mapNotNull { it }
+        return table.get(keyField.key).mapNotNull { it }
     }
 
     override fun create(
@@ -61,25 +70,19 @@ open class ByteArrayHashLabel(
         deferredRequests: List<Any>,
         storageOpCollector: StorageOpCollector?,
     ): Mono<Boolean> =
-        Mono
-            .fromCallable {
-                deferredRequests.forEach { request ->
-                    when (request) {
-                        is MutationRequest.Put -> store[request.key] = request.value
-                        is MutationRequest.Delete -> store.remove(request.key)
-                        is MutationRequest.Increment -> store.increment(request.key, request.value)
-                        else -> throw IllegalArgumentException("Unsupported request type: $request")
-                    }
-                }
-                true
-            }
+        table
+            .batch(
+                deferredRequests.map {
+                    it as? MutationRequest ?: throw IllegalArgumentException("Unsupported request type: $it")
+                },
+            ).thenReturn(true)
 
     override fun setnx(
         keyField: EncodedKey<ByteArray>,
         value: ByteArray,
     ): Mono<Boolean> {
         require(keyField.field == null) { "field must be null" }
-        return Mono.fromCallable { store.checkAndSet(keyField.key, null, value) }
+        return table.setIfNotExists(keyField.key, value)
     }
 
     override fun setnxOnLock(
@@ -87,7 +90,7 @@ open class ByteArrayHashLabel(
         value: ByteArray,
     ): Mono<Boolean> {
         require(keyField.field == null) { "field must be null" }
-        return Mono.fromCallable { store.checkAndSet(keyField.key, null, value) }
+        return table.setIfNotExists(keyField.key, value)
     }
 
     override fun cad(
@@ -95,12 +98,12 @@ open class ByteArrayHashLabel(
         value: ByteArray,
     ): Mono<Long> {
         require(keyField.field == null) { "field must be null" }
-        return Mono.fromCallable { if (store.checkAndSet(keyField.key, value, null)) 1L else 0L }
+        return table.deleteIfEquals(keyField.key, value).map { if (it) 1L else 0L }
     }
 
     override fun findLockValue(keyField: EncodedKey<ByteArray>): Mono<ByteArray> {
         require(keyField.field == null) { "field must be null" }
-        return Mono.fromCallable { store[keyField.key] }.mapNotNull { it }
+        return table.get(keyField.key).mapNotNull { it }
     }
 
     override fun deleteOnLock(keyField: KeyValue<ByteArray>): Mono<Boolean> = cad(EncodedKey(keyField.key), keyField.value).map { it > 0 }
@@ -111,9 +114,11 @@ open class ByteArrayHashLabel(
         start: EncodedKey<ByteArray>?,
         end: EncodedKey<ByteArray>?,
     ): Mono<List<KeyFieldValue<ByteArray>>> =
-        Mono.fromCallable {
-            store
-                .prefixScan(prefix.key)
+        // The store scan is a pure prefix read; the start (exclusive) / end (inclusive) bounds are
+        // applied here, not pushed to the backend, so the contract is identical across backends
+        // regardless of the backend's own bound convention.
+        table.scan(prefix.key, Int.MAX_VALUE, null, null).map { records ->
+            records
                 .dropWhile { record -> start?.key?.let { Arrays.compareUnsigned(it, record.key) >= 0 } ?: false }
                 .dropLastWhile { record -> end?.key?.let { Arrays.compareUnsigned(it, record.key) < 0 } ?: false }
                 .take(limit)
@@ -127,16 +132,16 @@ open class ByteArrayHashLabel(
         stats: Set<StatKey>,
     ): Mono<DataFrame> {
         val withAll = stats.contains(StatKey.WITH_ALL)
-        return Mono
-            .fromCallable {
-                src
-                    .mapNotNull {
-                        val edge = Edge(0L, it, it).ensureType(entity.schema)
-                        val key = coder.encodeHashEdgeKey(edge, entity.id)
-                        store[key.key]?.let { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
-                    }.filter { withAll || it.isActive }
-                    .map { it.toRow(withAll) }
-            }.map { rows -> toDataFrame(rows, withAll) }
+        return Flux
+            .fromIterable(src)
+            .concatMap {
+                val edge = Edge(0L, it, it).ensureType(entity.schema)
+                val key = coder.encodeHashEdgeKey(edge, entity.id)
+                table.get(key.key).map { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
+            }.filter { withAll || it.isActive }
+            .map { it.toRow(withAll) }
+            .collectList()
+            .map { rows -> toDataFrame(rows, withAll) }
     }
 
     override fun get(
@@ -146,29 +151,30 @@ open class ByteArrayHashLabel(
         stats: Set<StatKey>,
     ): Mono<DataFrame> {
         val withAll = stats.contains(StatKey.WITH_ALL)
-        return Mono
-            .fromCallable {
-                tgt
-                    .mapNotNull {
-                        val edge = Edge(0L, src, it).ensureType(entity.schema)
-                        val key = coder.encodeHashEdgeKey(edge, entity.id)
-                        store[key.key]?.let { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
-                    }.filter { withAll || it.isActive }
-                    .map { it.toRow(withAll, isMultiEdge) }
-            }.map { rows -> toDataFrame(rows, withAll) }
+        return Flux
+            .fromIterable(tgt)
+            .concatMap {
+                val edge = Edge(0L, src, it).ensureType(entity.schema)
+                val key = coder.encodeHashEdgeKey(edge, entity.id)
+                table.get(key.key).map { value -> encodedEdgeToSchemaEdge(KeyFieldValue(key.key, value)) }
+            }.filter { withAll || it.isActive }
+            .map { it.toRow(withAll, isMultiEdge) }
+            .collectList()
+            .map { rows -> toDataFrame(rows, withAll) }
     }
 
     override fun getCountRows(
         srcAndKeys: List<Pair<Any, ByteArray>>,
         dir: Direction,
     ): Mono<List<Row>> =
-        Mono.fromCallable {
-            srcAndKeys.map { (src, key) ->
-                val value = store[key]
-                val count = if (value == null) 0L else ByteBuffer.wrap(value).order(ByteOrder.BIG_ENDIAN).long
-                Row(arrayOf(src, count, dir))
-            }
-        }
+        Flux
+            .fromIterable(srcAndKeys)
+            .concatMap { (src, key) ->
+                table
+                    .get(key)
+                    .map { value -> Row(arrayOf(src, ByteBuffer.wrap(value).order(ByteOrder.BIG_ENDIAN).long, dir)) }
+                    .defaultIfEmpty(Row(arrayOf(src, 0L, dir)))
+            }.collectList()
 
     private fun toDataFrame(
         rows: List<Row>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayIndexedLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/bytearray/ByteArrayIndexedLabel.kt
@@ -1,6 +1,8 @@
 package com.kakao.actionbase.v2.engine.label.bytearray
 
 import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+import com.kakao.actionbase.engine.storage.StorageTable
+import com.kakao.actionbase.engine.storage.memory.MemoryStorageTable
 import com.kakao.actionbase.v2.core.code.EdgeEncoder
 import com.kakao.actionbase.v2.core.code.Index
 import com.kakao.actionbase.v2.engine.cdc.CdcContext
@@ -18,8 +20,8 @@ open class ByteArrayIndexedLabel(
     coder: EdgeEncoder<ByteArray>,
     override val indices: List<Index>,
     override val indexNameToIndex: Map<String, Index>,
-    store: ByteArrayStore,
-) : ByteArrayHashLabel(entity, coder, store),
+    table: StorageTable,
+) : ByteArrayHashLabel(entity, coder, table),
     IndexedLabelMixin<ByteArray> {
     override val self: AbstractLabel<ByteArray> = this
 
@@ -35,13 +37,19 @@ open class ByteArrayIndexedLabel(
             entity: LabelEntity,
             coder: EdgeEncoder<ByteArray>,
             store: ByteArrayStore,
+        ): ByteArrayIndexedLabel = create(entity, coder, MemoryStorageTable(store))
+
+        fun create(
+            entity: LabelEntity,
+            coder: EdgeEncoder<ByteArray>,
+            table: StorageTable,
         ): ByteArrayIndexedLabel =
             ByteArrayIndexedLabel(
                 entity = entity,
                 coder = coder,
                 indices = entity.indices,
                 indexNameToIndex = entity.indices.associateBy { it.name },
-                store = store,
+                table = table,
             )
     }
 }


### PR DESCRIPTION
## Summary

Step 2 of #422 (unify store-backend acquisition): rework the ByteArray label family to consume the `StorageTable` seam instead of a concrete `ByteArrayStore`, reactively. This decouples the label logic from the in-memory store, so a later step can point the same label at an HBase-backed `StorageTable` by configuration alone.

Part of #422.

## Changes

- `ByteArrayHashLabel` / `ByteArrayIndexedLabel` primary constructor now takes a `StorageTable`. A secondary constructor / `create` overload keeps the `ByteArrayStore` path by wrapping it in a `MemoryStorageTable`, so existing callers (`Graph`, `LocalBackedJdbcHashLabel`, tests) are unchanged.
- All store access goes through `StorageTable`: `get` / `setIfNotExists` / `deleteIfEquals` / `increment` / `batch` / `scan`. Reads (`getSelf` / `get` / `getCountRows`) fan out reactively, preserving input order.
- `scanStorage` still applies the **start-exclusive / end-inclusive** bounds in the label (not pushed to the backend), preserving the contract locked in #425 — `StorageTable.scan` uses the opposite HBase-native convention, so the trimming stays in the label.

## How to Test

`./gradlew :engine:test :server:test` — green (623 engine tests, incl. the cross-backend `AbstractLabelCompatibilityTest` and the #425 pagination-contract lock); spotless clean. No wiring changed outside the label classes.

## AI Assistance

- [x] This PR was written with AI assistance.
  - Tool / model: Claude Code (Opus 4.8)
