### PR TITLE
Acquire the metastore stores via the StorageBackend seam (Step 3 of #422)

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -9,10 +9,11 @@ import com.kakao.actionbase.core.edge.mapper.EdgeIndexRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeLockRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
-import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
 import com.kakao.actionbase.engine.query.LabelProvider
 import com.kakao.actionbase.engine.storage.DefaultStorageBackendFactory
 import com.kakao.actionbase.engine.storage.StorageOpCollector
+import com.kakao.actionbase.engine.storage.StorageTable
+import com.kakao.actionbase.engine.storage.memory.MemoryStorageBackend
 import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.edge.TraceEdge
@@ -92,10 +93,10 @@ import reactor.util.Loggers
 class Graph(
     val wal: Wal,
     val cdc: Cdc,
-    override val localStore: ByteArrayStore,
+    override val localStore: StorageTable,
     override val metastore: Database,
     override val metadataTable: MetadataTable,
-    override val consolidatedStore: ByteArrayStore,
+    override val consolidatedStore: StorageTable,
     override val edgeEncoderFactory: EdgeEncoderFactory,
     override val edgeRecordMapper: EdgeRecordMapper,
     override val datastore: DefaultHBaseCluster,
@@ -1019,12 +1020,19 @@ class Graph(
             val storageEntities =
                 listOfNotNull(defaultHBaseStorageEntity).associateBy { it.name }
 
+            // System metastore stores are in-memory and acquired through the StorageBackend seam by
+            // distinct URIs (seed vs overlay); routing the operational overlay through the configured
+            // backend is a later, migration-gated step.
+            val systemStorageBackend = MemoryStorageBackend()
+            val localStore = systemStorageBackend.getStorageTable("datastore://metastore/seed").block()!!
+            val consolidatedStore = systemStorageBackend.getStorageTable("datastore://metastore/overlay").block()!!
+
             val defaults =
                 AbstractGraphDefaults(
-                    ByteArrayStore(),
+                    localStore,
                     metastore,
                     metadataTable,
-                    ByteArrayStore(),
+                    consolidatedStore,
                     config.useJdbcMetastore,
                     edgeEncoderFactory,
                     edgeRecordMapper,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphDefaults.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphDefaults.kt
@@ -2,7 +2,7 @@ package com.kakao.actionbase.v2.engine
 
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.engine.EngineConstants
-import com.kakao.actionbase.engine.datastore.impl.ByteArrayStore
+import com.kakao.actionbase.engine.storage.StorageTable
 import com.kakao.actionbase.v2.core.code.EdgeEncoderFactory
 import com.kakao.actionbase.v2.engine.compat.DefaultHBaseCluster
 import com.kakao.actionbase.v2.engine.entity.EntityName
@@ -15,10 +15,10 @@ import org.jetbrains.exposed.sql.Database
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 interface GraphDefaults {
-    val localStore: ByteArrayStore
+    val localStore: StorageTable
     val metastore: Database
     val metadataTable: MetadataTable
-    val consolidatedStore: ByteArrayStore
+    val consolidatedStore: StorageTable
     val useJdbcMetastore: Boolean
     val storages: Map<EntityName, StorageEntity>
     val edgeEncoderFactory: EdgeEncoderFactory
@@ -42,10 +42,10 @@ interface GraphDefaults {
 }
 
 data class AbstractGraphDefaults(
-    override val localStore: ByteArrayStore,
+    override val localStore: StorageTable,
     override val metastore: Database,
     override val metadataTable: MetadataTable,
-    override val consolidatedStore: ByteArrayStore,
+    override val consolidatedStore: StorageTable,
     override val useJdbcMetastore: Boolean,
     override val edgeEncoderFactory: EdgeEncoderFactory,
     override val edgeRecordMapper: EdgeRecordMapper,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/metastore/LocalBackedJdbcHashLabel.kt
@@ -173,7 +173,7 @@ class LocalBackedJdbcHashLabel internal constructor(
                         ByteArrayIndexedLabel.create(
                             entity = indexedEntity,
                             coder = graph.edgeEncoderFactory.bytesKeyValueEncoder,
-                            store = graph.localStore,
+                            table = graph.localStore,
                         ),
                     globalLabel =
                         JdbcHashLabel(
@@ -186,7 +186,7 @@ class LocalBackedJdbcHashLabel internal constructor(
                         ByteArrayIndexedLabel.create(
                             entity = indexedEntity,
                             coder = graph.edgeEncoderFactory.bytesKeyValueEncoder,
-                            store = graph.consolidatedStore,
+                            table = graph.consolidatedStore,
                         ),
                 )
             label.block()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/test/GraphFixtures.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/test/GraphFixtures.kt
@@ -408,11 +408,14 @@ class GraphTestFixtures(
 
     fun getLocalMetadata(): Flux<DecodedEdge> =
         graph.localStore
-            .prefixScan(ByteArray(0))
-            .mapNotNull { record ->
-                runCatching { DecodedEdge.from(KeyFieldValue(record.key, record.value), emptyMap()) }.getOrNull()
-            }.filter { it.type == EncodedEdgeType.HASH_EDGE_TYPE }
-            .toFlux()
+            .scan(ByteArray(0), Int.MAX_VALUE, null, null)
+            .flatMapMany { records ->
+                records
+                    .mapNotNull { record ->
+                        runCatching { DecodedEdge.from(KeyFieldValue(record.key, record.value), emptyMap()) }.getOrNull()
+                    }.filter { it.type == EncodedEdgeType.HASH_EDGE_TYPE }
+                    .toFlux()
+            }
 }
 
 infix fun Graph.shouldContainServicesExactly(names: List<EntityName>) {


### PR DESCRIPTION
## Summary

Step 3 of #422 (unify store-backend acquisition): stop constructing `ByteArrayStore` directly and acquire the metastore stores through the `StorageBackend` seam, addressed by `datastore://` URIs.

Part of #422.

## Changes

- `Graph.create()` replaces the two raw `ByteArrayStore()` literals with `StorageTable`s obtained from a `MemoryStorageBackend` via distinct URIs — `datastore://metastore/seed` and `datastore://metastore/overlay`.
- `GraphDefaults.localStore` / `consolidatedStore` change type from `ByteArrayStore` to `StorageTable`.
- `LocalBackedJdbcHashLabel` builds its local/overlay labels from the `StorageTable` `create` overload added in Step 2.
- `GraphFixtures.getLocalMetadata` reads through `StorageTable.scan`.

## Safety / scope

Both stores stay **in-memory**, so behavior and the deploy/rollback safety of the metastore overlay (#390) are unchanged. Distinct table names keep the seed and overlay stores separate (`MemoryStorageBackend` memoizes by `namespace:name`). Routing the operational overlay through the configured (potentially HBase) `StorageBackend` is a later, migration-gated step; the local seed store stays in-memory by design.

## How to Test

`./gradlew :engine:test :server:test` — green (929 tests); spotless clean.

## AI Assistance

- [x] This PR was written with AI assistance.
  - Tool / model: Claude Code (Opus 4.8)
