### PR TITLE
Disable flaky PerCellTTLTest

### DIFF
--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/hbase/PerCellTTLTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/hbase/PerCellTTLTest.kt
@@ -13,8 +13,10 @@ import kotlin.test.assertNull
 import org.apache.hadoop.hbase.client.Get
 import org.apache.hadoop.hbase.client.Table
 import org.apache.hadoop.hbase.util.Bytes
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.extension.ExtendWith
 
+@Disabled("Re-verifies HBase's own tombstone/TTL ordering rather than actionbase logic; see #431")
 @ExtendWith(HBaseTestingClusterExtension::class)
 class PerCellTTLTest(
     private val table: Table,

--- a/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
+++ b/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
@@ -15,12 +15,19 @@ object OperationHelper {
         operations: String,
     ) {
         val table = this
+        // HBase row tombstones cover cells with timestamp <= tombstone timestamp, so a Put that lands
+        // in the same millisecond as a preceding Delete gets shadowed by it. Track the Delete's
+        // timestamp so the next plain Put is forced strictly after it instead of racing the clock.
+        var previousDeleteTimestamp: Long? = null
         operations.split(", ").withIndex().forEach { (index, op) ->
             when {
                 op == "Put" -> {
                     val put = Put(rowKey)
-                    put.addColumn(family, qualifier, Bytes.toBytes("${valuePrefix}$index"))
+                    val value = Bytes.toBytes("${valuePrefix}$index")
+                    previousDeleteTimestamp?.let { put.addColumn(family, qualifier, it + 1, value) }
+                        ?: put.addColumn(family, qualifier, value)
                     table.put(put)
+                    previousDeleteTimestamp = null
                 }
 
                 op.startsWith("Put(") -> {
@@ -29,11 +36,13 @@ object OperationHelper {
                     put.addColumn(family, qualifier, Bytes.toBytes("${valuePrefix}$index"))
                     put.ttl = ttl
                     table.put(put)
+                    previousDeleteTimestamp = null
                 }
 
                 op == "Delete" -> {
                     val delete = Delete(rowKey)
                     table.delete(delete)
+                    previousDeleteTimestamp = System.currentTimeMillis()
                 }
 
                 op == "Increment" -> {

--- a/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
+++ b/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
@@ -15,37 +15,25 @@ object OperationHelper {
         operations: String,
     ) {
         val table = this
-        // HBase row tombstones cover cells with timestamp <= tombstone timestamp, so a Put that lands
-        // in the same millisecond as a preceding Delete gets shadowed by it. Track the Delete's
-        // timestamp so the next Put (plain or TTL'd) is forced strictly after it instead of racing
-        // the clock.
-        var previousDeleteTimestamp: Long? = null
         operations.split(", ").withIndex().forEach { (index, op) ->
             when {
                 op == "Put" -> {
                     val put = Put(rowKey)
-                    val value = Bytes.toBytes("${valuePrefix}$index")
-                    previousDeleteTimestamp?.let { put.addColumn(family, qualifier, it + 1, value) }
-                        ?: put.addColumn(family, qualifier, value)
+                    put.addColumn(family, qualifier, Bytes.toBytes("${valuePrefix}$index"))
                     table.put(put)
-                    previousDeleteTimestamp = null
                 }
 
                 op.startsWith("Put(") -> {
                     val ttl = op.substringAfter("Put(").substringBefore(")").toLong()
                     val put = Put(rowKey)
-                    val value = Bytes.toBytes("${valuePrefix}$index")
-                    previousDeleteTimestamp?.let { put.addColumn(family, qualifier, it + 1, value) }
-                        ?: put.addColumn(family, qualifier, value)
+                    put.addColumn(family, qualifier, Bytes.toBytes("${valuePrefix}$index"))
                     put.ttl = ttl
                     table.put(put)
-                    previousDeleteTimestamp = null
                 }
 
                 op == "Delete" -> {
                     val delete = Delete(rowKey)
                     table.delete(delete)
-                    previousDeleteTimestamp = System.currentTimeMillis()
                 }
 
                 op == "Increment" -> {

--- a/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
+++ b/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/OperationHelper.kt
@@ -17,7 +17,8 @@ object OperationHelper {
         val table = this
         // HBase row tombstones cover cells with timestamp <= tombstone timestamp, so a Put that lands
         // in the same millisecond as a preceding Delete gets shadowed by it. Track the Delete's
-        // timestamp so the next plain Put is forced strictly after it instead of racing the clock.
+        // timestamp so the next Put (plain or TTL'd) is forced strictly after it instead of racing
+        // the clock.
         var previousDeleteTimestamp: Long? = null
         operations.split(", ").withIndex().forEach { (index, op) ->
             when {
@@ -33,7 +34,9 @@ object OperationHelper {
                 op.startsWith("Put(") -> {
                     val ttl = op.substringAfter("Put(").substringBefore(")").toLong()
                     val put = Put(rowKey)
-                    put.addColumn(family, qualifier, Bytes.toBytes("${valuePrefix}$index"))
+                    val value = Bytes.toBytes("${valuePrefix}$index")
+                    previousDeleteTimestamp?.let { put.addColumn(family, qualifier, it + 1, value) }
+                        ?: put.addColumn(family, qualifier, value)
                     put.ttl = ttl
                     table.put(put)
                     previousDeleteTimestamp = null


### PR DESCRIPTION
## Summary

`PerCellTTLTest` intermittently fails on the "Delete then Put" case: `OperationHelper.perform()` builds Delete/Put mutations without an explicit timestamp, so a Delete immediately followed by a Put can be assigned the same millisecond timestamp by HBase. Since a row tombstone covers cells with `timestamp <= tombstone timestamp`, the new Put gets shadowed — more likely to trigger on fast local machines than on CI.

Per discussion below, this test is really re-verifying HBase's own tombstone/TTL ordering rather than actionbase-specific logic, and that's already well-covered at the HBase level. Disabling it instead of chasing the timing race further.

## Changes

- `@Disabled` on `PerCellTTLTest`, with a pointer back to this PR for context.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Claude Fable 5)