### PR TITLE
Reshape the feature gate into a feature-centric FeatureFlags abstraction

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/Feature.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/Feature.kt
@@ -1,0 +1,3 @@
+package com.kakao.actionbase.core.metadata.features
+
+sealed interface Feature

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/FeatureFlags.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/FeatureFlags.kt
@@ -1,0 +1,33 @@
+package com.kakao.actionbase.core.metadata.features
+
+class FeatureFlags(
+    baseline: List<Item>,
+) {
+    data class Item(
+        val feature: Feature,
+        val databases: Set<String> = emptySet(),
+    )
+
+    data class Scope(
+        val database: String,
+    )
+
+    private val byDatabase: Map<String, Set<Feature>> = fold(baseline)
+
+    fun has(
+        scope: Scope,
+        feature: Feature,
+    ): Boolean = feature in byDatabase[scope.database].orEmpty()
+
+    companion object {
+        private fun fold(items: List<Item>): Map<String, Set<Feature>> {
+            val byDatabase = mutableMapOf<String, MutableSet<Feature>>()
+            items.forEach { (feature, databases) ->
+                databases.forEach { database ->
+                    byDatabase.getOrPut(database) { mutableSetOf() }.add(feature)
+                }
+            }
+            return byDatabase.mapValues { it.value.toSet() }
+        }
+    }
+}

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/MutationFeature.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/features/MutationFeature.kt
@@ -1,6 +1,6 @@
 package com.kakao.actionbase.core.metadata.features
 
-enum class TableFeature {
+enum class MutationFeature : Feature {
     /**
      * INSERT merges into the existing row: an omitted field keeps its current value instead of
      * being cleared to UNSET (snapshot).

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/features/FeatureFlagsTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/features/FeatureFlagsTest.kt
@@ -1,0 +1,33 @@
+package com.kakao.actionbase.core.metadata.features
+
+import com.kakao.actionbase.core.metadata.features.FeatureFlags.Item
+import com.kakao.actionbase.core.metadata.features.FeatureFlags.Scope
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.Test
+
+class FeatureFlagsTest {
+    @Test
+    fun `resolves a feature for its databases`() {
+        val flags = FeatureFlags(listOf(Item(MutationFeature.INSERT_MERGE, setOf("fanin", "timeline"))))
+
+        assertTrue(flags.has(Scope("fanin"), MutationFeature.INSERT_MERGE))
+        assertTrue(flags.has(Scope("timeline"), MutationFeature.INSERT_MERGE))
+    }
+
+    @Test
+    fun `an unlisted database has no features`() {
+        val flags = FeatureFlags(listOf(Item(MutationFeature.INSERT_MERGE, setOf("fanin"))))
+
+        assertFalse(flags.has(Scope("other"), MutationFeature.INSERT_MERGE))
+    }
+
+    @Test
+    fun `an empty baseline gates nothing`() {
+        val flags = FeatureFlags(emptyList())
+
+        assertFalse(flags.has(Scope("fanin"), MutationFeature.INSERT_MERGE))
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/Graph.kt
@@ -9,6 +9,7 @@ import com.kakao.actionbase.core.edge.mapper.EdgeIndexRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeLockRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeRecordMapper
 import com.kakao.actionbase.core.edge.mapper.EdgeStateRecordMapper
+import com.kakao.actionbase.core.metadata.features.FeatureFlags
 import com.kakao.actionbase.engine.query.LabelProvider
 import com.kakao.actionbase.engine.storage.DefaultStorageBackendFactory
 import com.kakao.actionbase.engine.storage.StorageOpCollector
@@ -115,6 +116,8 @@ class Graph(
     AutoCloseable {
     internal val mutationRequestTimeout = config.mutationRequestTimeout
     internal val readOnly = config.readOnly
+
+    val featureFlags = FeatureFlags(config.featureFlags)
 
     private var metadataInitialized = false
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphConfig.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/GraphConfig.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine
 
+import com.kakao.actionbase.core.metadata.features.FeatureFlags
 import com.kakao.actionbase.v2.core.metadata.MutationMode
 import com.kakao.actionbase.v2.engine.entity.DefaultStorageEntity
 import com.kakao.actionbase.v2.engine.service.ddl.DdlService
@@ -37,6 +38,7 @@ data class GraphConfig(
     val systemMutationMode: MutationMode? = null,
     val readOnly: Boolean = false,
     val useJdbcMetastore: Boolean = true,
+    val featureFlags: List<FeatureFlags.Item> = emptyList(),
 ) {
     companion object {
         val builder: Builder
@@ -68,6 +70,7 @@ data class GraphConfig(
         private var systemMutationMode: MutationMode? = null
         private var readOnly: Boolean = false
         private var useJdbcMetastore: Boolean = true
+        private var featureFlags: List<FeatureFlags.Item> = emptyList()
 
         // Aligned with nginx.conf proxy_read_timeout 300
         private var mutationRequestTimeout: Long = 300_000
@@ -132,6 +135,8 @@ data class GraphConfig(
 
         fun withUseJdbcMetastore(enabled: Boolean) = apply { this.useJdbcMetastore = enabled }
 
+        fun withFeatureFlags(featureFlags: List<FeatureFlags.Item>) = apply { this.featureFlags = featureFlags }
+
         fun build(): GraphConfig =
             GraphConfig(
                 phase = phase,
@@ -159,6 +164,7 @@ data class GraphConfig(
                 systemMutationMode = systemMutationMode,
                 readOnly = readOnly,
                 useJdbcMetastore = useJdbcMetastore,
+                featureFlags = featureFlags,
             )
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/GraphConfiguration.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.configuration
 
+import com.kakao.actionbase.core.metadata.features.FeatureFlags
 import com.kakao.actionbase.engine.service.MutationService
 import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.server.client.kafka.SpringKafkaClientFactory
@@ -84,6 +85,11 @@ class GraphConfiguration {
                 properties.systemMutationMode?.let { withSystemMutationMode(it) }
                 withReadOnly(serverProperties.readOnly)
                 withUseJdbcMetastore(properties.useJdbcMetastore)
+                withFeatureFlags(
+                    serverProperties.featureFlags.map {
+                        FeatureFlags.Item(it.feature, it.scope.databases)
+                    },
+                )
             }
         return builder.build()
     }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServerProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/configuration/ServerProperties.kt
@@ -1,9 +1,8 @@
 package com.kakao.actionbase.server.configuration
 
-import com.kakao.actionbase.core.Constants
 import com.kakao.actionbase.core.metadata.DatastoreDescriptor
 import com.kakao.actionbase.core.metadata.common.DatastoreType
-import com.kakao.actionbase.core.metadata.features.TableFeature
+import com.kakao.actionbase.core.metadata.features.MutationFeature
 
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -15,35 +14,30 @@ data class ServerProperties(
     val tenant: String,
     val datastore: DatastoreProperties,
     val readOnly: Boolean = false,
-    val databaseLevelFeatures: List<DatabaseFeatures> = emptyList(),
+    val featureFlags: List<FeatureFlag> = emptyList(),
 ) {
-    private val featuresByDatabase: Map<String, Set<TableFeature>>
-
     init {
-        val invalidNames = databaseLevelFeatures.map { it.database }.filterNot { it.matches(DATABASE_NAME_REGEX) }
-        require(invalidNames.isEmpty()) {
-            "Invalid database names in actionbase.database-level-features: $invalidNames (must match ${Constants.Name.PATTERN})"
-        }
         val duplicates =
-            databaseLevelFeatures
-                .groupingBy { it.database }
+            featureFlags
+                .groupingBy { it.feature }
                 .eachCount()
                 .filterValues { it > 1 }
                 .keys
         require(duplicates.isEmpty()) {
-            "Duplicate database entries in actionbase.database-level-features: $duplicates"
+            "Duplicate feature entries in actionbase.feature-flags: $duplicates"
         }
-        featuresByDatabase = databaseLevelFeatures.associate { it.database to it.features }
-        if (featuresByDatabase.isNotEmpty()) {
-            log.info("database-level-features: {}", featuresByDatabase)
+        if (featureFlags.isNotEmpty()) {
+            log.info("feature-flags: {}", featureFlags)
         }
     }
 
-    fun featuresOf(database: String): Set<TableFeature> = featuresByDatabase[database] ?: emptySet()
+    data class FeatureFlag(
+        val feature: MutationFeature,
+        val scope: Scope = Scope(),
+    )
 
-    data class DatabaseFeatures(
-        val database: String,
-        val features: Set<TableFeature> = emptySet(),
+    data class Scope(
+        val databases: Set<String> = emptySet(),
     )
 
     data class DatastoreProperties(
@@ -63,6 +57,5 @@ data class ServerProperties(
 
     companion object {
         private val log = LoggerFactory.getLogger(ServerProperties::class.java)
-        private val DATABASE_NAME_REGEX = Regex(Constants.Name.PATTERN)
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/configuration/ServerPropertiesTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/configuration/ServerPropertiesTest.kt
@@ -1,6 +1,6 @@
 package com.kakao.actionbase.server.configuration
 
-import com.kakao.actionbase.core.metadata.features.TableFeature
+import com.kakao.actionbase.core.metadata.features.MutationFeature
 
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -25,36 +25,65 @@ class ServerPropertiesTest {
     }
 
     @Test
-    fun `binds database-level-features entries from kebab-case keys`() {
+    fun `binds feature-flags entries from kebab-case keys`() {
         val bound =
             bind(
                 mapOf(
-                    "actionbase.database-level-features[0].database" to "fanin",
-                    "actionbase.database-level-features[0].features[0]" to "INSERT_MERGE",
+                    "actionbase.feature-flags[0].feature" to "INSERT_MERGE",
+                    "actionbase.feature-flags[0].scope.databases[0]" to "fanin",
                 ),
             )
 
-        assertEquals(setOf(TableFeature.INSERT_MERGE), bound.featuresOf("fanin"))
+        assertEquals(
+            listOf(
+                ServerProperties.FeatureFlag(
+                    MutationFeature.INSERT_MERGE,
+                    ServerProperties.Scope(setOf("fanin")),
+                ),
+            ),
+            bound.featureFlags,
+        )
     }
 
     @Test
-    fun `featuresOf returns empty set for an unlisted database`() {
+    fun `a feature with no scope binds to an empty scope`() {
         val bound =
             bind(
                 mapOf(
-                    "actionbase.database-level-features[0].database" to "fanin",
-                    "actionbase.database-level-features[0].features[0]" to "INSERT_MERGE",
+                    "actionbase.feature-flags[0].feature" to "INSERT_MERGE",
                 ),
             )
 
-        assertEquals(emptySet(), bound.featuresOf("other"))
+        assertEquals(
+            listOf(ServerProperties.FeatureFlag(MutationFeature.INSERT_MERGE, ServerProperties.Scope())),
+            bound.featureFlags,
+        )
+    }
+
+    @Test
+    fun `a feature can target multiple databases`() {
+        val bound =
+            bind(
+                mapOf(
+                    "actionbase.feature-flags[0].feature" to "INSERT_MERGE",
+                    "actionbase.feature-flags[0].scope.databases[0]" to "fanin",
+                    "actionbase.feature-flags[0].scope.databases[1]" to "timeline",
+                ),
+            )
+
+        assertEquals(
+            setOf("fanin", "timeline"),
+            bound.featureFlags
+                .single()
+                .scope.databases,
+        )
     }
 
     @Test
     fun `no entries binds to an empty gate`() {
         val bound = bind(emptyMap())
 
-        assertEquals(emptySet(), bound.featuresOf("fanin"))
+        assertEquals(emptyList(), bound.featureFlags)
     }
 
     @Test
@@ -63,23 +92,25 @@ class ServerPropertiesTest {
             assertFailsWith<BindException> {
                 bind(
                     mapOf(
-                        "actionbase.database-level-features[0].database" to "fanin",
-                        "actionbase.database-level-features[0].features[0]" to "INSERT_MEGRE",
+                        "actionbase.feature-flags[0].feature" to "INSERT_MEGRE",
+                        "actionbase.feature-flags[0].scope.databases[0]" to "fanin",
                     ),
                 )
             }
 
-        assertTrue(exception.message!!.contains("database-level-features"))
+        assertTrue(exception.message!!.contains("feature-flags"))
     }
 
     @Test
-    fun `invalid database name fails binding`() {
+    fun `duplicate feature entries fail binding`() {
         val exception =
             assertFailsWith<BindException> {
                 bind(
                     mapOf(
-                        "actionbase.database-level-features[0].database" to "fanin-svc",
-                        "actionbase.database-level-features[0].features[0]" to "INSERT_MERGE",
+                        "actionbase.feature-flags[0].feature" to "INSERT_MERGE",
+                        "actionbase.feature-flags[0].scope.databases[0]" to "fanin",
+                        "actionbase.feature-flags[1].feature" to "INSERT_MERGE",
+                        "actionbase.feature-flags[1].scope.databases[0]" to "timeline",
                     ),
                 )
             }
@@ -88,29 +119,7 @@ class ServerPropertiesTest {
             exception.cause!!
                 .cause!!
                 .message!!
-                .contains("Invalid database names"),
-        )
-    }
-
-    @Test
-    fun `duplicate database entries fail binding`() {
-        val exception =
-            assertFailsWith<BindException> {
-                bind(
-                    mapOf(
-                        "actionbase.database-level-features[0].database" to "fanin",
-                        "actionbase.database-level-features[0].features[0]" to "INSERT_MERGE",
-                        "actionbase.database-level-features[1].database" to "fanin",
-                        "actionbase.database-level-features[1].features[0]" to "INSERT_MERGE",
-                    ),
-                )
-            }
-
-        assertTrue(
-            exception.cause!!
-                .cause!!
-                .message!!
-                .contains("Duplicate database entries"),
+                .contains("Duplicate feature entries"),
         )
     }
 }


### PR DESCRIPTION
## Summary

Reworks #430's database-keyed feature gate into a feature-centric, scope-targeted config backed by a general `FeatureFlags`. Infrastructure only — `INSERT_MERGE` is reserved but not consumed yet.

```yaml
actionbase:
  feature-flags:
    - feature: INSERT_MERGE
      scope:
        databases: [fanin]
```

## Changes

- `Feature` (sealed) + `MutationFeature` (renamed from `TableFeature`): a feature is named by its nature, not its target
- `FeatureFlags` (core): folds the baseline once into an immutable `database -> features` map; `has(scope, feature)` is allocation-free on the hot path
- `ServerProperties`: bind `actionbase.feature-flags` with the `scope.databases` shape; boot fails on unknown or duplicate feature
- `GraphConfig` / `Graph`: thread the baseline; `Graph` exposes `featureFlags`

## How to Test

`./gradlew :core:test --tests "*FeatureFlagsTest" :server:test --tests "*ServerPropertiesTest"`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.8, 1M context)
