### PR TITLE
Add immutable edge table (index-only, append + scan)

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
@@ -37,6 +37,14 @@ object EdgeMutationBuilder {
         caches: List<Cache>,
     ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.Edge, before, after, directionType, indexes, groups, caches)
 
+    fun buildForImmutableEdge(
+        before: EdgeStateRecord,
+        after: EdgeStateRecord,
+        directionType: DirectionType,
+        indexes: List<Index>,
+        groups: List<Group>,
+    ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.ImmutableEdge, before, after, directionType, indexes, groups, emptyList())
+
     fun buildForMultiEdge(
         before: EdgeStateRecord,
         after: EdgeStateRecord,
@@ -50,19 +58,6 @@ object EdgeMutationBuilder {
         before: EdgeStateRecord,
         after: EdgeStateRecord,
     ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.Vertex, before, after, DirectionType.OUT, emptyList(), emptyList(), emptyList())
-
-    /**
-     * Immutable edge: emits index (+group) records only — no count (strategy suppresses it)
-     * and no cache (caches are always empty here). The state record is still carried in
-     * [EdgeMutationRecords.stateRecord] but the binding skips the state `Put` for this kind.
-     */
-    fun buildForImmutableEdge(
-        before: EdgeStateRecord,
-        after: EdgeStateRecord,
-        directionType: DirectionType,
-        indexes: List<Index>,
-        groups: List<Group>,
-    ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.ImmutableEdge, before, after, directionType, indexes, groups, emptyList())
 
     private fun buildWith(
         strategy: EdgeMutationStrategy,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilder.kt
@@ -51,6 +51,19 @@ object EdgeMutationBuilder {
         after: EdgeStateRecord,
     ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.Vertex, before, after, DirectionType.OUT, emptyList(), emptyList(), emptyList())
 
+    /**
+     * Immutable edge: emits index (+group) records only — no count (strategy suppresses it)
+     * and no cache (caches are always empty here). The state record is still carried in
+     * [EdgeMutationRecords.stateRecord] but the binding skips the state `Put` for this kind.
+     */
+    fun buildForImmutableEdge(
+        before: EdgeStateRecord,
+        after: EdgeStateRecord,
+        directionType: DirectionType,
+        indexes: List<Index>,
+        groups: List<Group>,
+    ): EdgeMutationRecords = buildWith(EdgeMutationStrategy.ImmutableEdge, before, after, directionType, indexes, groups, emptyList())
+
     private fun buildWith(
         strategy: EdgeMutationStrategy,
         before: EdgeStateRecord,

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
@@ -31,7 +31,7 @@ sealed interface EdgeMutationStrategy {
         buildCountRecords: (EdgeStateRecord, DirectionType, Long) -> List<EdgeCountRecord>,
     ): List<EdgeCountRecord>
 
-    /** Strategies whose source/target come straight from the state key: Edge, Vertex. */
+    /** Strategies whose source/target come straight from the state key: Edge, ImmutableEdge, Vertex. */
     sealed interface KeyBased : EdgeMutationStrategy {
         override fun directedSource(
             record: EdgeStateRecord,
@@ -66,6 +66,10 @@ sealed interface EdgeMutationStrategy {
 
     data object Edge : KeyBased {
         override val producesCount: Boolean = true
+    }
+
+    data object ImmutableEdge : KeyBased {
+        override val producesCount: Boolean = false
     }
 
     data object Vertex : KeyBased {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
@@ -21,7 +21,10 @@ data class EdgeBulkMutationRequest(
             val (sourceField, targetField, properties) =
                 when (schema) {
                     is ModelSchema.Edge -> Triple(schema.source, schema.target, schema.properties)
-                    is ModelSchema.ImmutableEdge -> Triple(schema.source, schema.target, schema.properties)
+                    is ModelSchema.ImmutableEdge -> {
+                        require(type == EventType.INSERT) { "immutable edge tables support only INSERT (append), got $type" }
+                        Triple(schema.source, schema.target, schema.properties)
+                    }
                     else -> throw IllegalArgumentException("Expected ModelSchema.Edge or ImmutableEdge, but got ${schema::class.simpleName}")
                 }
             val source = sourceField.type.cast(edge.source)

--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/payload/EdgeBulkMutationRequest.kt
@@ -18,16 +18,21 @@ data class EdgeBulkMutationRequest(
             schema: ModelSchema,
             insertMerge: Boolean,
         ): EdgeEvent {
-            require(schema is ModelSchema.Edge) { "Expected ModelSchema.Edge, but got ${schema::class.simpleName}" }
-            val source = schema.source.type.cast(edge.source)
-            val target = schema.target.type.cast(edge.target)
-            checkNonNullableFields(type, schema.properties, edge.properties, insertMerge)
+            val (sourceField, targetField, properties) =
+                when (schema) {
+                    is ModelSchema.Edge -> Triple(schema.source, schema.target, schema.properties)
+                    is ModelSchema.ImmutableEdge -> Triple(schema.source, schema.target, schema.properties)
+                    else -> throw IllegalArgumentException("Expected ModelSchema.Edge or ImmutableEdge, but got ${schema::class.simpleName}")
+                }
+            val source = sourceField.type.cast(edge.source)
+            val target = targetField.type.cast(edge.target)
+            checkNonNullableFields(type, properties, edge.properties, insertMerge)
             val event =
                 Event.create(
                     type = type,
                     version = edge.version,
                     properties =
-                        schema.properties
+                        properties
                             .filter { field -> field.name in edge.properties.keys }
                             .associate { field ->
                                 val value = edge.properties[field.name]

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
     JsonSubTypes.Type(value = TableDescriptor.Edge::class, name = "edge"),
     JsonSubTypes.Type(value = TableDescriptor.MultiEdge::class, name = "multiEdge"),
     JsonSubTypes.Type(value = TableDescriptor.Vertex::class, name = "vertex"),
+    JsonSubTypes.Type(value = TableDescriptor.ImmutableEdge::class, name = "immutableEdge"),
 )
 sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
     abstract val database: String
@@ -86,6 +87,26 @@ sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
         override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
         override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
     ) : TableDescriptor<ModelSchema.Vertex>() {
+        @JsonIgnore
+        override val id: TableId = TableId(tenant, database, table)
+    }
+
+    @JsonTypeName("immutableEdge")
+    data class ImmutableEdge(
+        override val tenant: String,
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.ImmutableEdge,
+        override val mode: MutationMode,
+        override val storage: String,
+        override val active: Boolean = true,
+        override val comment: String = Constants.DEFAULT_COMMENT,
+        override val revision: Long = Constants.DEFAULT_REVISION,
+        override val createdAt: Long = Constants.DEFAULT_CREATED_AT,
+        override val createdBy: String = Constants.DEFAULT_CREATED_BY,
+        override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
+        override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
+    ) : TableDescriptor<ModelSchema.ImmutableEdge>() {
         @JsonIgnore
         override val id: TableId = TableId(tenant, database, table)
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/TableDescriptor.kt
@@ -16,9 +16,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = TableDescriptor.Edge::class, name = "edge"),
+    JsonSubTypes.Type(value = TableDescriptor.ImmutableEdge::class, name = "immutableEdge"),
     JsonSubTypes.Type(value = TableDescriptor.MultiEdge::class, name = "multiEdge"),
     JsonSubTypes.Type(value = TableDescriptor.Vertex::class, name = "vertex"),
-    JsonSubTypes.Type(value = TableDescriptor.ImmutableEdge::class, name = "immutableEdge"),
 )
 sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
     abstract val database: String
@@ -47,6 +47,26 @@ sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
         override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
         override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
     ) : TableDescriptor<ModelSchema.Edge>() {
+        @JsonIgnore
+        override val id: TableId = TableId(tenant, database, table)
+    }
+
+    @JsonTypeName("immutableEdge")
+    data class ImmutableEdge(
+        override val tenant: String,
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.ImmutableEdge,
+        override val mode: MutationMode,
+        override val storage: String,
+        override val active: Boolean = true,
+        override val comment: String = Constants.DEFAULT_COMMENT,
+        override val revision: Long = Constants.DEFAULT_REVISION,
+        override val createdAt: Long = Constants.DEFAULT_CREATED_AT,
+        override val createdBy: String = Constants.DEFAULT_CREATED_BY,
+        override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
+        override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
+    ) : TableDescriptor<ModelSchema.ImmutableEdge>() {
         @JsonIgnore
         override val id: TableId = TableId(tenant, database, table)
     }
@@ -87,26 +107,6 @@ sealed class TableDescriptor<T : ModelSchema> : V3Descriptor<TableId> {
         override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
         override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
     ) : TableDescriptor<ModelSchema.Vertex>() {
-        @JsonIgnore
-        override val id: TableId = TableId(tenant, database, table)
-    }
-
-    @JsonTypeName("immutableEdge")
-    data class ImmutableEdge(
-        override val tenant: String,
-        override val database: String,
-        override val table: String,
-        override val schema: ModelSchema.ImmutableEdge,
-        override val mode: MutationMode,
-        override val storage: String,
-        override val active: Boolean = true,
-        override val comment: String = Constants.DEFAULT_COMMENT,
-        override val revision: Long = Constants.DEFAULT_REVISION,
-        override val createdAt: Long = Constants.DEFAULT_CREATED_AT,
-        override val createdBy: String = Constants.DEFAULT_CREATED_BY,
-        override val updatedAt: Long = Constants.DEFAULT_UPDATED_AT,
-        override val updatedBy: String = Constants.DEFAULT_UPDATED_BY,
-    ) : TableDescriptor<ModelSchema.ImmutableEdge>() {
         @JsonIgnore
         override val id: TableId = TableId(tenant, database, table)
     }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -15,9 +15,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = ModelSchema.Edge::class, name = "EDGE"),
+    JsonSubTypes.Type(value = ModelSchema.ImmutableEdge::class, name = "IMMUTABLE_EDGE"),
     JsonSubTypes.Type(value = ModelSchema.MultiEdge::class, name = "MULTI_EDGE"),
     JsonSubTypes.Type(value = ModelSchema.Vertex::class, name = "VERTEX"),
-    JsonSubTypes.Type(value = ModelSchema.ImmutableEdge::class, name = "IMMUTABLE_EDGE"),
 )
 sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
@@ -34,6 +34,17 @@ sealed class ModelSchema : AbstractSchema {
         val indexes: List<Index> = emptyList(),
         val groups: List<Group> = emptyList(),
         val caches: List<Cache> = emptyList(),
+    ) : ModelSchema(),
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable })
+
+    @JsonTypeName("immutableEdge")
+    data class ImmutableEdge(
+        val source: Field,
+        val target: Field,
+        override val properties: List<StructField> = emptyList(),
+        val direction: DirectionType,
+        val indexes: List<Index> = emptyList(),
+        val groups: List<Group> = emptyList(),
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable })
 
@@ -54,22 +65,6 @@ sealed class ModelSchema : AbstractSchema {
     data class Vertex(
         val id: Field,
         override val properties: List<StructField> = emptyList(),
-    ) : ModelSchema(),
-        AbstractSchema by Schema(properties.associate { it.name to it.nullable })
-
-    /**
-     * Index-only edge with no `State` row: append-oriented, read-via-scan, delete-via-scan.
-     * Structurally an [Edge] minus caches — indexes drive scan, groups back count/sum topK.
-     * No count records (a scalar per source does not survive append semantics).
-     */
-    @JsonTypeName("immutableEdge")
-    data class ImmutableEdge(
-        val source: Field,
-        val target: Field,
-        override val properties: List<StructField> = emptyList(),
-        val direction: DirectionType,
-        val indexes: List<Index> = emptyList(),
-        val groups: List<Group> = emptyList(),
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable })
 }

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
     JsonSubTypes.Type(value = ModelSchema.Edge::class, name = "EDGE"),
     JsonSubTypes.Type(value = ModelSchema.MultiEdge::class, name = "MULTI_EDGE"),
     JsonSubTypes.Type(value = ModelSchema.Vertex::class, name = "VERTEX"),
+    JsonSubTypes.Type(value = ModelSchema.ImmutableEdge::class, name = "IMMUTABLE_EDGE"),
 )
 sealed class ModelSchema : AbstractSchema {
     abstract val properties: List<StructField>
@@ -53,6 +54,22 @@ sealed class ModelSchema : AbstractSchema {
     data class Vertex(
         val id: Field,
         override val properties: List<StructField> = emptyList(),
+    ) : ModelSchema(),
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable })
+
+    /**
+     * Index-only edge with no `State` row: append-oriented, read-via-scan, delete-via-scan.
+     * Structurally an [Edge] minus caches — indexes drive scan, groups back count/sum topK.
+     * No count records (a scalar per source does not survive append semantics).
+     */
+    @JsonTypeName("immutableEdge")
+    data class ImmutableEdge(
+        val source: Field,
+        val target: Field,
+        override val properties: List<StructField> = emptyList(),
+        val direction: DirectionType,
+        val indexes: List<Index> = emptyList(),
+        val groups: List<Group> = emptyList(),
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable })
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilderTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationBuilderTest.kt
@@ -794,4 +794,70 @@ class EdgeMutationBuilderTest {
             assertEquals(after, result.stateRecord)
         }
     }
+
+    @Nested
+    inner class ImmutableEdgeStrategy {
+        private val countGroup = Group(group = "count_group", type = GroupType.COUNT, fields = listOf(Group.Field("version")))
+
+        @Test
+        fun `CREATED produces index and group records but never count`() {
+            val before = edgeRecord(source = "userA", target = "postX", active = false, version = 0)
+            val after = edgeRecord(source = "userA", target = "postX", active = true, version = 1)
+            val result =
+                EdgeMutationBuilder.buildForImmutableEdge(before, after, DirectionType.BOTH, listOf(versionIndex), listOf(countGroup))
+
+            assertEquals("CREATED", result.status)
+            assertEquals(1L, result.acc)
+            assertEquals(2, result.createIndexRecords.size)
+            assertEquals(2, result.groupRecords.size)
+            assertTrue(result.groupRecords.all { it.value == 1L })
+            // Immutable edges never emit count records or cache records.
+            assertTrue(result.countRecords.isEmpty())
+            assertTrue(result.createCacheRecords.isEmpty())
+            assertTrue(result.deleteCacheRecordQualifiers.isEmpty())
+        }
+
+        @Test
+        fun `DELETED produces index delete keys and group decrements but never count`() {
+            val before = edgeRecord(source = "userA", target = "postX", active = true, version = 1)
+            val after = edgeRecord(source = "userA", target = "postX", active = false, version = 2)
+            val result =
+                EdgeMutationBuilder.buildForImmutableEdge(before, after, DirectionType.BOTH, listOf(versionIndex), listOf(countGroup))
+
+            assertEquals("DELETED", result.status)
+            assertEquals(-1L, result.acc)
+            assertEquals(2, result.deleteIndexRecordKeys.size)
+            assertEquals(2, result.groupRecords.size)
+            assertTrue(result.groupRecords.all { it.value == -1L })
+            assertTrue(result.countRecords.isEmpty())
+        }
+
+        @Test
+        fun `CREATED index directedSource and directedTarget follow key source-target swap`() {
+            val before = edgeRecord(source = "userA", target = "postX", active = false, version = 0)
+            val after = edgeRecord(source = "userA", target = "postX", active = true, version = 1)
+            val result =
+                EdgeMutationBuilder.buildForImmutableEdge(before, after, DirectionType.BOTH, listOf(versionIndex), emptyList())
+
+            val outIndex = result.createIndexRecords.first { it.key.prefix.direction == Direction.OUT }
+            assertEquals("userA", outIndex.key.prefix.directedSource)
+            assertEquals("postX", outIndex.key.suffix.directedTarget)
+
+            val inIndex = result.createIndexRecords.first { it.key.prefix.direction == Direction.IN }
+            assertEquals("postX", inIndex.key.prefix.directedSource)
+            assertEquals("userA", inIndex.key.suffix.directedTarget)
+        }
+
+        @Test
+        fun `IDLE when before equals after`() {
+            val record = edgeRecord(source = "userA", target = "postX", active = true)
+            val result =
+                EdgeMutationBuilder.buildForImmutableEdge(record, record, DirectionType.BOTH, listOf(versionIndex), listOf(countGroup))
+
+            assertEquals("IDLE", result.status)
+            assertTrue(result.createIndexRecords.isEmpty())
+            assertTrue(result.groupRecords.isEmpty())
+            assertTrue(result.countRecords.isEmpty())
+        }
+    }
 }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -8,9 +8,9 @@ import com.kakao.actionbase.test.json.PrettyObjectWriter
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-import com.fasterxml.jackson.module.kotlin.readValue
-
 import org.junit.jupiter.api.Test
+
+import com.fasterxml.jackson.module.kotlin.readValue
 
 class EdgeSchemaSerializationTest {
     val prettyWriter = PrettyObjectWriter.DEFAULT

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -1,17 +1,39 @@
 package com.kakao.actionbase.core.metadata.common
 
+import com.kakao.actionbase.core.java.codec.common.hbase.Order
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 import com.fasterxml.jackson.module.kotlin.readValue
+
+import org.junit.jupiter.api.Test
 
 class EdgeSchemaSerializationTest {
     val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
+
+    @Test
+    fun `immutable edge schema round-trips under the immutableEdge discriminator`() {
+        val schema =
+            ModelSchema.ImmutableEdge(
+                source = Field(type = com.kakao.actionbase.core.types.PrimitiveType.INT, comment = "partition"),
+                target = Field(type = com.kakao.actionbase.core.types.PrimitiveType.STRING, comment = "message id"),
+                properties = listOf(StructField(name = "ts", type = com.kakao.actionbase.core.types.PrimitiveType.LONG, comment = "enqueue ts", nullable = false)),
+                direction = DirectionType.OUT,
+                indexes = listOf(Index(index = "by_ts", fields = listOf(IndexField(field = "ts", order = Order.ASC)))),
+            )
+
+        val json = objectMapper.writeValueAsString(schema)
+        assertTrue(json.contains("\"immutableEdge\""), "discriminator must be immutableEdge, was: $json")
+        assertTrue(!json.contains("caches"), "immutable edge schema must not carry a caches field")
+
+        assertEquals(schema, objectMapper.readValue<ModelSchema>(json))
+    }
 
     @ObjectSourceParameterizedTest
     @ObjectSource(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -57,21 +57,6 @@ interface TableBinding {
         features: List<String>,
     ): Mono<DataFrame>
 
-    /**
-     * Scans an index range and deletes every matched row (index rows + group decrements),
-     * returning the number of rows deleted. Only immutable-edge tables support this — the
-     * default rejects it, since State-backed tables delete through the mutation path instead.
-     */
-    fun scanAndDelete(
-        index: String,
-        start: Any,
-        direction: Direction,
-        limit: Int,
-        offset: String?,
-        ranges: String?,
-        filters: String?,
-    ): Mono<Long> = Mono.error(UnsupportedOperationException("scan-and-delete is only supported on immutable edge tables"))
-
     fun seek(
         cache: String,
         start: List<Any>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -57,6 +57,21 @@ interface TableBinding {
         features: List<String>,
     ): Mono<DataFrame>
 
+    /**
+     * Scans an index range and deletes every matched row (index rows + group decrements),
+     * returning the number of rows deleted. Only immutable-edge tables support this — the
+     * default rejects it, since State-backed tables delete through the mutation path instead.
+     */
+    fun scanAndDelete(
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        offset: String?,
+        ranges: String?,
+        filters: String?,
+    ): Mono<Long> = Mono.error(UnsupportedOperationException("scan-and-delete is only supported on immutable edge tables"))
+
     fun seek(
         cache: String,
         start: List<Any>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
@@ -100,9 +100,7 @@ data class LabelEntity(
                     }
                 }
                 LabelType.INDEXED, LabelType.MULTI_EDGE, LabelType.VERTEX, LabelType.IMMUTABLE_INDEXED -> {
-                    // MultiEdge, Vertex, and ImmutableEdge are all backed by the INDEXED storage path
-                    // in the v2 engine; immutable-edge behavior (index-only writes, scan-delete) is
-                    // differentiated in the v3 binding, keyed off ModelSchema.ImmutableEdge.
+                    // MultiEdge, Vertex, and ImmutableEdge all share the INDEXED storage path; their behavior is differentiated in the v3 binding.
                     if (type == LabelType.MULTI_EDGE && !readOnly) {
                         logger.error("MULTI_EDGE type should be read-only in the v2 engine. Fallback to NilLabel")
                         return NilLabel(this.copy(type = LabelType.NIL))

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/entity/LabelEntity.kt
@@ -99,8 +99,10 @@ data class LabelEntity(
                         }
                     }
                 }
-                LabelType.INDEXED, LabelType.MULTI_EDGE, LabelType.VERTEX -> {
-                    // MultiEdge and Vertex are both backed by the INDEXED storage path in the v2 engine.
+                LabelType.INDEXED, LabelType.MULTI_EDGE, LabelType.VERTEX, LabelType.IMMUTABLE_INDEXED -> {
+                    // MultiEdge, Vertex, and ImmutableEdge are all backed by the INDEXED storage path
+                    // in the v2 engine; immutable-edge behavior (index-only writes, scan-delete) is
+                    // differentiated in the v3 binding, keyed off ModelSchema.ImmutableEdge.
                     if (type == LabelType.MULTI_EDGE && !readOnly) {
                         logger.error("MULTI_EDGE type should be read-only in the v2 engine. Fallback to NilLabel")
                         return NilLabel(this.copy(type = LabelType.NIL))
@@ -118,10 +120,6 @@ data class LabelEntity(
                             NilLabel(this.copy(type = LabelType.NIL))
                         }
                     }
-                }
-                LabelType.IMMUTABLE_INDEXED -> {
-                    logger.error("{} supports only ... types. {} fallback to NilLabel", type, storage)
-                    NilLabel(this.copy(type = LabelType.NIL))
                 }
                 LabelType.NIL -> NilLabel(this)
             }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -18,6 +18,7 @@ import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.SpecialStateValue
 import com.kakao.actionbase.core.state.State
+import com.kakao.actionbase.core.state.StateValue
 import com.kakao.actionbase.core.storage.HBaseRecord
 import com.kakao.actionbase.core.types.PrimitiveType
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
@@ -29,7 +30,9 @@ import com.kakao.actionbase.engine.sql.Row
 import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.SystemProperties
 import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.sql.RowWithSchema
 import com.kakao.actionbase.v2.engine.label.LockAcquisitionFailedException
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
@@ -59,6 +62,9 @@ class V2BackedTableBinding(
     private val groupRecordMapper = mapper.group
     private val cacheRecordMapper = mapper.cache
 
+    /** Immutable edge tables persist index rows only — no `State`, no point get, delete via scan. */
+    private val isImmutable: Boolean = descriptor.schema is ModelSchema.ImmutableEdge
+
     // -- mutation
 
     override fun <T> withLock(
@@ -81,6 +87,10 @@ class V2BackedTableBinding(
     }
 
     override fun read(key: MutationKey): Mono<State> {
+        // No State row exists for immutable edges, so every mutation reads the initial (empty)
+        // state — the read-modify-write skeleton then treats it as a pure append (CREATE).
+        // Short-circuit to avoid a wasted storage Get for a row that is never written.
+        if (isImmutable) return Mono.just(State.initial)
         val (source, target) = key.toSourceTarget()
         with(label) {
             val compatibleEdge = Edge(0L, source, target)
@@ -132,6 +142,11 @@ class V2BackedTableBinding(
         keys: List<Pair<Any, Any>>,
         filters: String?,
     ): Mono<DataFrame> {
+        if (isImmutable) {
+            return Mono.error(
+                UnsupportedOperationException("point get is not supported on immutable edge tables; use scan"),
+            )
+        }
         val postPredicates = filters?.let { WherePredicate.parse(it, label.entity.schema) }?.toSet() ?: emptySet()
 
         val hbaseGets =
@@ -219,6 +234,80 @@ class V2BackedTableBinding(
                 val total = tuple.t2
                 df.applyPredicates(postPredicates).toV3(total)
             }.switchIfEmpty(EMPTY_DATAFRAME)
+    }
+
+    override fun scanAndDelete(
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        offset: String?,
+        ranges: String?,
+        filters: String?,
+    ): Mono<Long> {
+        val schema =
+            descriptor.schema as? ModelSchema.ImmutableEdge
+                ?: return super.scanAndDelete(index, start, direction, limit, offset, ranges, filters)
+
+        val indexEntity =
+            label.entity.indices.find { it.name == index }
+                ?: return Mono.error(IllegalArgumentException("index `$index` is not found in label `${label.entity.name}`."))
+
+        val indexPredicates = ranges?.let { WherePredicate.parse(it) }?.toSet() ?: emptySet()
+        val indexPredicateKeys = indexPredicates.map { it.key }
+        val indexFieldNames = indexEntity.fields.map { it.name }
+        require(indexPredicateKeys.size <= indexFieldNames.size) {
+            "valid `ranges` order for the index `$index` is $indexFieldNames. input was: $indexPredicateKeys."
+        }
+        indexPredicateKeys.zip(indexFieldNames).forEach { (predicateFieldName, indexFieldName) ->
+            require(predicateFieldName == indexFieldName) {
+                "valid `ranges` order for the index `$index` is $indexFieldNames. input was: $indexPredicateKeys."
+            }
+        }
+        require(filters == null) { "`filters` is not supported in scan-and-delete." }
+
+        val scanFilter =
+            ScanFilter(
+                name = EntityName(descriptor.database, descriptor.table),
+                srcSet = setOf(start),
+                dir = direction,
+                limit = limit,
+                offset = offset,
+                indexName = index,
+                otherPredicates = indexPredicates,
+            )
+
+        return label
+            .scan(scanFilter, emptySet())
+            .flatMap { df ->
+                val rows = df.toRowWithSchema()
+                if (rows.isEmpty()) {
+                    Mono.just(0L)
+                } else {
+                    val mutations = rows.flatMap { row -> buildDeleteMutations(schema, row) }
+                    label
+                        .handleDeferredRequests(mutations, null)
+                        .thenReturn(rows.size.toLong())
+                }
+            }.switchIfEmpty(Mono.just(0L))
+    }
+
+    // Reconstructs the stored edge from a scanned row and derives its delete mutations
+    // (index-row deletes + group decrements) by running the immutable mutation builder in
+    // reverse — active `before`, inactive `after` — so deletes stay symmetric with appends.
+    private fun buildDeleteMutations(
+        schema: ModelSchema.ImmutableEdge,
+        row: RowWithSchema,
+    ): List<Mutation> {
+        val source = row[SystemProperties.SRC.str]
+        val target = row[SystemProperties.TGT.str]
+        val version = row.getLong(SystemProperties.TS.str)
+        val properties = schema.properties.map { it.name to StateValue(version, row.getOrNull(it.name)) }
+        val activeState = State.create(active = true, version = version, properties = properties)
+        val before = EdgeStateRecord.of(source, target, activeState, label.entity.id)
+        val after = EdgeStateRecord.of(source, target, activeState.copy(active = false), label.entity.id)
+        val records = EdgeMutationBuilder.buildForImmutableEdge(before, after, schema.direction, schema.indexes, schema.groups)
+        return buildHBaseMutations(records)
     }
 
     override fun seek(
@@ -386,6 +475,8 @@ class V2BackedTableBinding(
                 EdgeMutationBuilder.buildForMultiEdge(before, after, schema.direction, schema.indexes, schema.groups, schema.caches)
             is ModelSchema.Vertex ->
                 EdgeMutationBuilder.buildForVertex(before, after)
+            is ModelSchema.ImmutableEdge ->
+                EdgeMutationBuilder.buildForImmutableEdge(before, after, schema.direction, schema.indexes, schema.groups)
         }
     }
 
@@ -406,10 +497,13 @@ class V2BackedTableBinding(
 
     private fun buildHBaseMutations(mutationRecords: EdgeMutationRecords): List<Mutation> {
         val mutations = mutableListOf<Mutation>()
-        val record = mapper.state.encoder.encode(mutationRecords.stateRecord)
-        mutations +=
-            Put(record.key)
-                .addColumn(HBaseConstants.DEFAULT_COLUMN_FAMILY, HBaseConstants.DEFAULT_QUALIFIER, record.value)
+        // Immutable edges persist no State row — index (+group) records only.
+        if (!isImmutable) {
+            val record = mapper.state.encoder.encode(mutationRecords.stateRecord)
+            mutations +=
+                Put(record.key)
+                    .addColumn(HBaseConstants.DEFAULT_COLUMN_FAMILY, HBaseConstants.DEFAULT_QUALIFIER, record.value)
+        }
         mutations +=
             mutationRecords.createIndexRecords.map {
                 val record = mapper.index.encoder.encode(it)

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -18,7 +18,6 @@ import com.kakao.actionbase.core.metadata.common.Group
 import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.state.SpecialStateValue
 import com.kakao.actionbase.core.state.State
-import com.kakao.actionbase.core.state.StateValue
 import com.kakao.actionbase.core.storage.HBaseRecord
 import com.kakao.actionbase.core.types.PrimitiveType
 import com.kakao.actionbase.engine.binding.MutationRecordsSummary
@@ -30,9 +29,7 @@ import com.kakao.actionbase.engine.sql.Row
 import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.Direction
-import com.kakao.actionbase.v2.core.metadata.SystemProperties
 import com.kakao.actionbase.v2.engine.entity.EntityName
-import com.kakao.actionbase.v2.engine.sql.RowWithSchema
 import com.kakao.actionbase.v2.engine.label.LockAcquisitionFailedException
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.sql.ScanFilter
@@ -62,7 +59,7 @@ class V2BackedTableBinding(
     private val groupRecordMapper = mapper.group
     private val cacheRecordMapper = mapper.cache
 
-    /** Immutable edge tables persist index rows only — no `State`, no point get, delete via scan. */
+    /** Immutable edge tables persist index rows only — no `State`, no point get. */
     private val isImmutable: Boolean = descriptor.schema is ModelSchema.ImmutableEdge
 
     // -- mutation
@@ -87,9 +84,7 @@ class V2BackedTableBinding(
     }
 
     override fun read(key: MutationKey): Mono<State> {
-        // No State row exists for immutable edges, so every mutation reads the initial (empty)
-        // state — the read-modify-write skeleton then treats it as a pure append (CREATE).
-        // Short-circuit to avoid a wasted storage Get for a row that is never written.
+        // Immutable edges have no State row: read the initial state so every mutation is a pure append.
         if (isImmutable) return Mono.just(State.initial)
         val (source, target) = key.toSourceTarget()
         with(label) {
@@ -194,6 +189,8 @@ class V2BackedTableBinding(
         val postPredicates = filters?.let { WherePredicate.parse(it, label.entity.schema) }?.toSet() ?: emptySet()
 
         if (FEATURE_TOTAL in features) {
+            // Immutable edges keep no count records, so `total` would always report 0.
+            require(!isImmutable) { "`total` feature is not supported on immutable edge tables." }
             require(indexPredicates.isEmpty() && postPredicates.isEmpty()) {
                 "total count does not support with `ranges` or `filters`."
             }
@@ -234,80 +231,6 @@ class V2BackedTableBinding(
                 val total = tuple.t2
                 df.applyPredicates(postPredicates).toV3(total)
             }.switchIfEmpty(EMPTY_DATAFRAME)
-    }
-
-    override fun scanAndDelete(
-        index: String,
-        start: Any,
-        direction: Direction,
-        limit: Int,
-        offset: String?,
-        ranges: String?,
-        filters: String?,
-    ): Mono<Long> {
-        val schema =
-            descriptor.schema as? ModelSchema.ImmutableEdge
-                ?: return super.scanAndDelete(index, start, direction, limit, offset, ranges, filters)
-
-        val indexEntity =
-            label.entity.indices.find { it.name == index }
-                ?: return Mono.error(IllegalArgumentException("index `$index` is not found in label `${label.entity.name}`."))
-
-        val indexPredicates = ranges?.let { WherePredicate.parse(it) }?.toSet() ?: emptySet()
-        val indexPredicateKeys = indexPredicates.map { it.key }
-        val indexFieldNames = indexEntity.fields.map { it.name }
-        require(indexPredicateKeys.size <= indexFieldNames.size) {
-            "valid `ranges` order for the index `$index` is $indexFieldNames. input was: $indexPredicateKeys."
-        }
-        indexPredicateKeys.zip(indexFieldNames).forEach { (predicateFieldName, indexFieldName) ->
-            require(predicateFieldName == indexFieldName) {
-                "valid `ranges` order for the index `$index` is $indexFieldNames. input was: $indexPredicateKeys."
-            }
-        }
-        require(filters == null) { "`filters` is not supported in scan-and-delete." }
-
-        val scanFilter =
-            ScanFilter(
-                name = EntityName(descriptor.database, descriptor.table),
-                srcSet = setOf(start),
-                dir = direction,
-                limit = limit,
-                offset = offset,
-                indexName = index,
-                otherPredicates = indexPredicates,
-            )
-
-        return label
-            .scan(scanFilter, emptySet())
-            .flatMap { df ->
-                val rows = df.toRowWithSchema()
-                if (rows.isEmpty()) {
-                    Mono.just(0L)
-                } else {
-                    val mutations = rows.flatMap { row -> buildDeleteMutations(schema, row) }
-                    label
-                        .handleDeferredRequests(mutations, null)
-                        .thenReturn(rows.size.toLong())
-                }
-            }.switchIfEmpty(Mono.just(0L))
-    }
-
-    // Reconstructs the stored edge from a scanned row and derives its delete mutations
-    // (index-row deletes + group decrements) by running the immutable mutation builder in
-    // reverse — active `before`, inactive `after` — so deletes stay symmetric with appends.
-    private fun buildDeleteMutations(
-        schema: ModelSchema.ImmutableEdge,
-        row: RowWithSchema,
-    ): List<Mutation> {
-        val source = row[SystemProperties.SRC.str]
-        val target = row[SystemProperties.TGT.str]
-        val version = row.getLong(SystemProperties.TS.str)
-        val properties = schema.properties.map { it.name to StateValue(version, row.getOrNull(it.name)) }
-        val activeState = State.create(active = true, version = version, properties = properties)
-        val before = EdgeStateRecord.of(source, target, activeState, label.entity.id)
-        val after = EdgeStateRecord.of(source, target, activeState.copy(active = false), label.entity.id)
-        val records = EdgeMutationBuilder.buildForImmutableEdge(before, after, schema.direction, schema.indexes, schema.groups)
-        return buildHBaseMutations(records)
     }
 
     override fun seek(
@@ -471,12 +394,12 @@ class V2BackedTableBinding(
         return when (schema) {
             is ModelSchema.Edge ->
                 EdgeMutationBuilder.buildForUniqueEdge(before, after, schema.direction, schema.indexes, schema.groups, schema.caches)
+            is ModelSchema.ImmutableEdge ->
+                EdgeMutationBuilder.buildForImmutableEdge(before, after, schema.direction, schema.indexes, schema.groups)
             is ModelSchema.MultiEdge ->
                 EdgeMutationBuilder.buildForMultiEdge(before, after, schema.direction, schema.indexes, schema.groups, schema.caches)
             is ModelSchema.Vertex ->
                 EdgeMutationBuilder.buildForVertex(before, after)
-            is ModelSchema.ImmutableEdge ->
-                EdgeMutationBuilder.buildForImmutableEdge(before, after, schema.direction, schema.indexes, schema.groups)
         }
     }
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
@@ -29,6 +29,12 @@ sealed class V3TableDescriptor {
         override val schema: ModelSchema.Edge,
     ) : V3TableDescriptor()
 
+    data class ImmutableEdge(
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.ImmutableEdge,
+    ) : V3TableDescriptor()
+
     data class MultiEdge(
         override val database: String,
         override val table: String,
@@ -39,12 +45,6 @@ sealed class V3TableDescriptor {
         override val database: String,
         override val table: String,
         override val schema: ModelSchema.Vertex,
-    ) : V3TableDescriptor()
-
-    data class ImmutableEdge(
-        override val database: String,
-        override val table: String,
-        override val schema: ModelSchema.ImmutableEdge,
     ) : V3TableDescriptor()
 
     companion object {

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V3TableDescriptor.kt
@@ -41,6 +41,12 @@ sealed class V3TableDescriptor {
         override val schema: ModelSchema.Vertex,
     ) : V3TableDescriptor()
 
+    data class ImmutableEdge(
+        override val database: String,
+        override val table: String,
+        override val schema: ModelSchema.ImmutableEdge,
+    ) : V3TableDescriptor()
+
     companion object {
         fun create(entity: LabelEntity): V3TableDescriptor {
             val database = entity.name.service
@@ -48,6 +54,23 @@ sealed class V3TableDescriptor {
 
             val isVertexTable = entity.type == LabelType.VERTEX
             val isMultiEdgeTable = entity.type == LabelType.MULTI_EDGE
+            val isImmutableEdgeTable = entity.type == LabelType.IMMUTABLE_INDEXED
+            if (isImmutableEdgeTable) {
+                val schema =
+                    ModelSchema.ImmutableEdge(
+                        source = entity.schema.src.toV3(),
+                        target = entity.schema.tgt.toV3(),
+                        properties = entity.schema.fields.map { it.toV3() },
+                        direction = entity.dirType.toV3(),
+                        indexes = entity.indices.map { it.toV3() },
+                        groups = entity.groups.map { it.toV3() },
+                    )
+                return ImmutableEdge(
+                    database = database,
+                    table = table,
+                    schema = schema,
+                )
+            }
             if (isVertexTable) {
                 val schema =
                     ModelSchema.Vertex(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
@@ -119,6 +119,18 @@ class ImmutableEdgeSpec :
                 .verifyError(UnsupportedOperationException::class.java)
         }
 
+        "immutable edge rejects non-INSERT mutations" {
+            val deleteRequest =
+                """
+                {"mutations": [{"type": "DELETE", "edge": {"version": 2000, "source": 1, "target": "m1", "properties": {}}}]}
+                """.trimIndent()
+            val request = mapper.readValue<EdgeBulkMutationRequest>(deleteRequest)
+            mutationService
+                .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                .test()
+                .verifyError(IllegalArgumentException::class.java)
+        }
+
         "immutable edge produces no count records" {
             val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
             mutationService

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
@@ -1,0 +1,138 @@
+package com.kakao.actionbase.v2.engine.v3.edge
+
+import com.kakao.actionbase.engine.metadata.MutationMode as EngineMutationMode
+
+import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
+import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
+import com.kakao.actionbase.engine.service.MutationService
+import com.kakao.actionbase.engine.service.QueryService
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
+import com.kakao.actionbase.v2.engine.test.GraphFixtures
+import com.kakao.actionbase.v2.engine.test.cdc.InMemoryCdc
+import com.kakao.actionbase.v2.engine.v3.V2BackedEngine
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import reactor.kotlin.test.test
+
+/**
+ * End-to-end coverage for immutable edge tables on the HBase mini-cluster: append persists
+ * index rows only (no State), scan reads them back, point get is rejected, and no count
+ * records are produced.
+ */
+class ImmutableEdgeSpec :
+    StringSpec({
+
+        val labelName = EntityName(GraphFixtures.serviceName, "immutable_log")
+        val database = labelName.service
+        val table = labelName.nameNotNull
+
+        lateinit var graph: Graph
+        lateinit var mutationService: MutationService
+        lateinit var queryService: QueryService
+
+        val labelDefinition =
+            """
+            {
+              "desc": "append-only log",
+              "type": "IMMUTABLE_INDEXED",
+              "schema": {
+                "src": {"type": "LONG", "desc": "partition"},
+                "tgt": {"type": "STRING", "desc": "message id"},
+                "fields": [
+                  {"name": "seq", "type": "LONG", "nullable": false, "desc": "enqueue seq"},
+                  {"name": "payload", "type": "STRING", "nullable": true, "desc": "payload"}
+                ]
+              },
+              "dirType": "OUT",
+              "storage": "${GraphFixtures.hbaseStorage}",
+              "indices": [
+                {"name": "seq_asc", "fields": [{"name": "seq", "order": "ASC"}], "desc": "oldest first"}
+              ],
+              "event": false,
+              "readOnly": false,
+              "mode": "SYNC"
+            }
+            """.trimIndent()
+
+        val appendRequest =
+            """
+            {
+              "mutations": [
+                {"type": "INSERT", "edge": {"version": 1000, "source": 1, "target": "m1", "properties": {"seq": 1000, "payload": "a"}}},
+                {"type": "INSERT", "edge": {"version": 1001, "source": 1, "target": "m2", "properties": {"seq": 1001, "payload": "b"}}},
+                {"type": "INSERT", "edge": {"version": 1002, "source": 1, "target": "m3", "properties": {"seq": 1002, "payload": "c"}}}
+              ]
+            }
+            """.trimIndent()
+
+        beforeTest {
+            graph = GraphFixtures.create()
+            val request = mapper.readValue<LabelCreateRequest>(labelDefinition)
+            graph.labelDdl.create(labelName, request).block()
+            val engine = V2BackedEngine(graph)
+            mutationService = MutationService(engine)
+            queryService = QueryService(engine)
+        }
+
+        afterTest {
+            graph.close()
+            (graph.cdc as InMemoryCdc).init()
+        }
+
+        "append then scan returns the appended edges in index order" {
+            val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
+            mutationService
+                .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                .map { EdgeMutationResponse.from(it) }
+                .test()
+                .assertNext { result ->
+                    result.results.size shouldBe 3
+                    result.results.all { it.status == "CREATED" } shouldBe true
+                }.verifyComplete()
+
+            queryService
+                .scan(database, table, "seq_asc", 1L, Direction.OUT, limit = 10)
+                .test()
+                .assertNext { result ->
+                    result.edges.size shouldBe 3
+                    result.edges.map { it.target } shouldBe listOf("m1", "m2", "m3")
+                    result.edges.map { it.properties["payload"] } shouldBe listOf("a", "b", "c")
+                }.verifyComplete()
+        }
+
+        "point get is rejected on immutable edge tables" {
+            val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
+            mutationService
+                .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                .block()
+
+            queryService
+                .gets(database, table, listOf(1L), listOf("m1"))
+                .test()
+                .verifyError(UnsupportedOperationException::class.java)
+        }
+
+        "immutable edge produces no count records" {
+            val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
+            mutationService
+                .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                .block()
+
+            queryService
+                .count(database, table, 1L, Direction.OUT)
+                .test()
+                .assertNext { result -> result.count shouldBe 0L }
+                .verifyComplete()
+        }
+    }) {
+    companion object {
+        private val mapper = jacksonObjectMapper()
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -65,6 +65,14 @@ data class TableCreateRequest(
                         V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
                     },
                 )
+            is ModelSchema.ImmutableEdge ->
+                EdgeSchema(
+                    VertexField(schema.source.type.toV2VertexType(), schema.source.comment),
+                    VertexField(schema.target.type.toV2VertexType(), schema.target.comment),
+                    schema.properties.map {
+                        V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
+                    },
+                )
         }
 
     fun toV2DirectionType(): V2DirectionType =
@@ -72,6 +80,7 @@ data class TableCreateRequest(
             is ModelSchema.Edge -> schema.direction.toV2DirectionType()
             is ModelSchema.MultiEdge -> schema.direction.toV2DirectionType()
             is ModelSchema.Vertex -> V2DirectionType.OUT
+            is ModelSchema.ImmutableEdge -> schema.direction.toV2DirectionType()
         }
 
     fun toV2Indices(): List<V2Index> =
@@ -79,6 +88,7 @@ data class TableCreateRequest(
             is ModelSchema.Edge -> schema.indexes.map { it.toV2Index() }
             is ModelSchema.MultiEdge -> schema.indexes.map { it.toV2Index() }
             is ModelSchema.Vertex -> emptyList()
+            is ModelSchema.ImmutableEdge -> schema.indexes.map { it.toV2Index() }
         }
 
     fun labelType(): LabelType =
@@ -86,5 +96,6 @@ data class TableCreateRequest(
             is ModelSchema.Edge -> LabelType.INDEXED
             is ModelSchema.MultiEdge -> LabelType.MULTI_EDGE
             is ModelSchema.Vertex -> LabelType.VERTEX
+            is ModelSchema.ImmutableEdge -> LabelType.IMMUTABLE_INDEXED
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableCreateRequest.kt
@@ -46,6 +46,14 @@ data class TableCreateRequest(
                         V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
                     },
                 )
+            is ModelSchema.ImmutableEdge ->
+                EdgeSchema(
+                    VertexField(schema.source.type.toV2VertexType(), schema.source.comment),
+                    VertexField(schema.target.type.toV2VertexType(), schema.target.comment),
+                    schema.properties.map {
+                        V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
+                    },
+                )
             is ModelSchema.MultiEdge -> {
                 val idField = V2Field("_id", schema.id.type.toV2DataType(), false, schema.id.comment)
                 EdgeSchema(
@@ -65,37 +73,29 @@ data class TableCreateRequest(
                         V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
                     },
                 )
-            is ModelSchema.ImmutableEdge ->
-                EdgeSchema(
-                    VertexField(schema.source.type.toV2VertexType(), schema.source.comment),
-                    VertexField(schema.target.type.toV2VertexType(), schema.target.comment),
-                    schema.properties.map {
-                        V2Field(it.name, it.type.toV2DataType(), it.nullable, it.comment)
-                    },
-                )
         }
 
     fun toV2DirectionType(): V2DirectionType =
         when (schema) {
             is ModelSchema.Edge -> schema.direction.toV2DirectionType()
+            is ModelSchema.ImmutableEdge -> schema.direction.toV2DirectionType()
             is ModelSchema.MultiEdge -> schema.direction.toV2DirectionType()
             is ModelSchema.Vertex -> V2DirectionType.OUT
-            is ModelSchema.ImmutableEdge -> schema.direction.toV2DirectionType()
         }
 
     fun toV2Indices(): List<V2Index> =
         when (schema) {
             is ModelSchema.Edge -> schema.indexes.map { it.toV2Index() }
+            is ModelSchema.ImmutableEdge -> schema.indexes.map { it.toV2Index() }
             is ModelSchema.MultiEdge -> schema.indexes.map { it.toV2Index() }
             is ModelSchema.Vertex -> emptyList()
-            is ModelSchema.ImmutableEdge -> schema.indexes.map { it.toV2Index() }
         }
 
     fun labelType(): LabelType =
         when (schema) {
             is ModelSchema.Edge -> LabelType.INDEXED
+            is ModelSchema.ImmutableEdge -> LabelType.IMMUTABLE_INDEXED
             is ModelSchema.MultiEdge -> LabelType.MULTI_EDGE
             is ModelSchema.Vertex -> LabelType.VERTEX
-            is ModelSchema.ImmutableEdge -> LabelType.IMMUTABLE_INDEXED
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -48,6 +48,14 @@ data class TableUpdateRequest(
                     )
                 }
                 is ModelSchema.Vertex -> null
+                is ModelSchema.ImmutableEdge ->
+                    EdgeSchema(
+                        VertexField(it.source.type.toV2VertexType(), it.source.comment),
+                        VertexField(it.target.type.toV2VertexType(), it.target.comment),
+                        it.properties.map { prop ->
+                            V2Field(prop.name, prop.type.toV2DataType(), prop.nullable, prop.comment)
+                        },
+                    )
             }
         }
 
@@ -59,6 +67,7 @@ data class TableUpdateRequest(
                 // Vertex has no indices; return null so LabelUpdateRequest treats it as no-op
                 // instead of overwriting any existing serialized list with `[]`.
                 is ModelSchema.Vertex -> null
+                is ModelSchema.ImmutableEdge -> it.indexes.map { idx -> idx.toV2Index() }
             }
         }
 
@@ -68,6 +77,7 @@ data class TableUpdateRequest(
                 is ModelSchema.Edge -> it.groups
                 is ModelSchema.MultiEdge -> it.groups
                 is ModelSchema.Vertex -> null
+                is ModelSchema.ImmutableEdge -> it.groups
             }
         }
 
@@ -77,6 +87,8 @@ data class TableUpdateRequest(
                 is ModelSchema.Edge -> it.caches
                 is ModelSchema.MultiEdge -> it.caches
                 is ModelSchema.Vertex -> null
+                // Immutable edges have no caches; null keeps the update a no-op for this field.
+                is ModelSchema.ImmutableEdge -> null
             }
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/TableUpdateRequest.kt
@@ -36,6 +36,14 @@ data class TableUpdateRequest(
                             V2Field(prop.name, prop.type.toV2DataType(), prop.nullable, prop.comment)
                         },
                     )
+                is ModelSchema.ImmutableEdge ->
+                    EdgeSchema(
+                        VertexField(it.source.type.toV2VertexType(), it.source.comment),
+                        VertexField(it.target.type.toV2VertexType(), it.target.comment),
+                        it.properties.map { prop ->
+                            V2Field(prop.name, prop.type.toV2DataType(), prop.nullable, prop.comment)
+                        },
+                    )
                 is ModelSchema.MultiEdge -> {
                     val idField = V2Field("_id", it.id.type.toV2DataType(), false, it.id.comment)
                     EdgeSchema(
@@ -48,14 +56,6 @@ data class TableUpdateRequest(
                     )
                 }
                 is ModelSchema.Vertex -> null
-                is ModelSchema.ImmutableEdge ->
-                    EdgeSchema(
-                        VertexField(it.source.type.toV2VertexType(), it.source.comment),
-                        VertexField(it.target.type.toV2VertexType(), it.target.comment),
-                        it.properties.map { prop ->
-                            V2Field(prop.name, prop.type.toV2DataType(), prop.nullable, prop.comment)
-                        },
-                    )
             }
         }
 
@@ -63,11 +63,10 @@ data class TableUpdateRequest(
         schema?.let {
             when (it) {
                 is ModelSchema.Edge -> it.indexes.map { idx -> idx.toV2Index() }
-                is ModelSchema.MultiEdge -> it.indexes.map { idx -> idx.toV2Index() }
-                // Vertex has no indices; return null so LabelUpdateRequest treats it as no-op
-                // instead of overwriting any existing serialized list with `[]`.
-                is ModelSchema.Vertex -> null
                 is ModelSchema.ImmutableEdge -> it.indexes.map { idx -> idx.toV2Index() }
+                is ModelSchema.MultiEdge -> it.indexes.map { idx -> idx.toV2Index() }
+                // Vertex has no indices; null keeps the update a no-op instead of overwriting with `[]`.
+                is ModelSchema.Vertex -> null
             }
         }
 
@@ -75,9 +74,9 @@ data class TableUpdateRequest(
         schema?.let {
             when (it) {
                 is ModelSchema.Edge -> it.groups
+                is ModelSchema.ImmutableEdge -> it.groups
                 is ModelSchema.MultiEdge -> it.groups
                 is ModelSchema.Vertex -> null
-                is ModelSchema.ImmutableEdge -> it.groups
             }
         }
 
@@ -85,10 +84,10 @@ data class TableUpdateRequest(
         schema?.let {
             when (it) {
                 is ModelSchema.Edge -> it.caches
-                is ModelSchema.MultiEdge -> it.caches
-                is ModelSchema.Vertex -> null
                 // Immutable edges have no caches; null keeps the update a no-op for this field.
                 is ModelSchema.ImmutableEdge -> null
+                is ModelSchema.MultiEdge -> it.caches
+                is ModelSchema.Vertex -> null
             }
         }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -114,12 +114,14 @@ class V3CompatService(
                 is ModelSchema.Edge -> s.groups
                 is ModelSchema.MultiEdge -> s.groups
                 is ModelSchema.Vertex -> emptyList()
+                is ModelSchema.ImmutableEdge -> s.groups
             }
         val caches =
             when (val s = request.schema) {
                 is ModelSchema.Edge -> s.caches
                 is ModelSchema.MultiEdge -> s.caches
                 is ModelSchema.Vertex -> emptyList()
+                is ModelSchema.ImmutableEdge -> emptyList()
             }
         val v2Request =
             V2LabelCreateRequest(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3CompatService.kt
@@ -112,16 +112,16 @@ class V3CompatService(
         val groups =
             when (val s = request.schema) {
                 is ModelSchema.Edge -> s.groups
+                is ModelSchema.ImmutableEdge -> s.groups
                 is ModelSchema.MultiEdge -> s.groups
                 is ModelSchema.Vertex -> emptyList()
-                is ModelSchema.ImmutableEdge -> s.groups
             }
         val caches =
             when (val s = request.schema) {
                 is ModelSchema.Edge -> s.caches
+                is ModelSchema.ImmutableEdge -> emptyList()
                 is ModelSchema.MultiEdge -> s.caches
                 is ModelSchema.Vertex -> emptyList()
-                is ModelSchema.ImmutableEdge -> emptyList()
             }
         val v2Request =
             V2LabelCreateRequest(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
@@ -88,10 +88,23 @@ object V3MetadataConverter {
             comment = desc,
         )
 
+    fun LabelEntity.toV3TableDescriptorImmutableEdge(tenant: String): TableDescriptor.ImmutableEdge =
+        TableDescriptor.ImmutableEdge(
+            tenant = tenant,
+            database = name.service,
+            table = name.nameNotNull,
+            schema = schema.toV3ModelSchemaImmutableEdge(dirType.toV3DirectionType(), indices, groups),
+            mode = mode.toV3MutationMode(),
+            storage = storage,
+            active = active,
+            comment = desc,
+        )
+
     fun LabelEntity.toV3TableDescriptor(tenant: String): TableDescriptor<*> =
         when (type) {
             LabelType.MULTI_EDGE -> toV3TableDescriptorMultiEdge(tenant)
             LabelType.VERTEX -> toV3TableDescriptorVertex(tenant)
+            LabelType.IMMUTABLE_INDEXED -> toV3TableDescriptorImmutableEdge(tenant)
             else -> toV3TableDescriptorEdge(tenant)
         }
 
@@ -124,6 +137,22 @@ object V3MetadataConverter {
             groups = schema.groups,
             event = false,
             readOnly = true,
+            mode = mode.toV2MutationMode(),
+        )
+
+    fun TableDescriptor.ImmutableEdge.toV2LabelEntity(): LabelEntity =
+        LabelEntity(
+            active = active,
+            name = EntityName(database, table),
+            desc = comment,
+            type = LabelType.IMMUTABLE_INDEXED,
+            schema = schema.toV2EdgeSchema(),
+            dirType = schema.direction.toV2DirectionType(),
+            storage = storage,
+            indices = schema.indexes.map { it.toV2Index() },
+            groups = schema.groups,
+            event = false,
+            readOnly = false,
             mode = mode.toV2MutationMode(),
         )
 
@@ -253,7 +282,36 @@ object V3MetadataConverter {
         )
     }
 
+    fun EdgeSchema.toV3ModelSchemaImmutableEdge(
+        direction: V3DirectionType,
+        indices: List<V2Index>,
+        groups: List<Group>,
+    ): ModelSchema.ImmutableEdge =
+        ModelSchema.ImmutableEdge(
+            source =
+                V3Field(
+                    type = src.type.toV3PrimitiveType(),
+                    comment = src.desc,
+                ),
+            target =
+                V3Field(
+                    type = tgt.type.toV3PrimitiveType(),
+                    comment = tgt.desc,
+                ),
+            properties = fields.map { it.toV3StructField() },
+            direction = direction,
+            indexes = indices.map { it.toV3Index() },
+            groups = groups,
+        )
+
     fun ModelSchema.Edge.toV2EdgeSchema(): EdgeSchema =
+        EdgeSchema(
+            VertexField(source.type.toV2VertexType(), source.comment),
+            VertexField(target.type.toV2VertexType(), target.comment),
+            properties.map { it.toV2Field() },
+        )
+
+    fun ModelSchema.ImmutableEdge.toV2EdgeSchema(): EdgeSchema =
         EdgeSchema(
             VertexField(source.type.toV2VertexType(), source.comment),
             VertexField(target.type.toV2VertexType(), target.comment),

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/metadata/V3MetadataConverter.kt
@@ -64,6 +64,18 @@ object V3MetadataConverter {
             comment = desc,
         )
 
+    fun LabelEntity.toV3TableDescriptorImmutableEdge(tenant: String): TableDescriptor.ImmutableEdge =
+        TableDescriptor.ImmutableEdge(
+            tenant = tenant,
+            database = name.service,
+            table = name.nameNotNull,
+            schema = schema.toV3ModelSchemaImmutableEdge(dirType.toV3DirectionType(), indices, groups),
+            mode = mode.toV3MutationMode(),
+            storage = storage,
+            active = active,
+            comment = desc,
+        )
+
     fun LabelEntity.toV3TableDescriptorMultiEdge(tenant: String): TableDescriptor.MultiEdge =
         TableDescriptor.MultiEdge(
             tenant = tenant,
@@ -88,23 +100,11 @@ object V3MetadataConverter {
             comment = desc,
         )
 
-    fun LabelEntity.toV3TableDescriptorImmutableEdge(tenant: String): TableDescriptor.ImmutableEdge =
-        TableDescriptor.ImmutableEdge(
-            tenant = tenant,
-            database = name.service,
-            table = name.nameNotNull,
-            schema = schema.toV3ModelSchemaImmutableEdge(dirType.toV3DirectionType(), indices, groups),
-            mode = mode.toV3MutationMode(),
-            storage = storage,
-            active = active,
-            comment = desc,
-        )
-
     fun LabelEntity.toV3TableDescriptor(tenant: String): TableDescriptor<*> =
         when (type) {
+            LabelType.IMMUTABLE_INDEXED -> toV3TableDescriptorImmutableEdge(tenant)
             LabelType.MULTI_EDGE -> toV3TableDescriptorMultiEdge(tenant)
             LabelType.VERTEX -> toV3TableDescriptorVertex(tenant)
-            LabelType.IMMUTABLE_INDEXED -> toV3TableDescriptorImmutableEdge(tenant)
             else -> toV3TableDescriptorEdge(tenant)
         }
 
@@ -114,6 +114,22 @@ object V3MetadataConverter {
             name = EntityName(database, table),
             desc = comment,
             type = LabelType.INDEXED,
+            schema = schema.toV2EdgeSchema(),
+            dirType = schema.direction.toV2DirectionType(),
+            storage = storage,
+            indices = schema.indexes.map { it.toV2Index() },
+            groups = schema.groups,
+            event = false,
+            readOnly = false,
+            mode = mode.toV2MutationMode(),
+        )
+
+    fun TableDescriptor.ImmutableEdge.toV2LabelEntity(): LabelEntity =
+        LabelEntity(
+            active = active,
+            name = EntityName(database, table),
+            desc = comment,
+            type = LabelType.IMMUTABLE_INDEXED,
             schema = schema.toV2EdgeSchema(),
             dirType = schema.direction.toV2DirectionType(),
             storage = storage,
@@ -137,22 +153,6 @@ object V3MetadataConverter {
             groups = schema.groups,
             event = false,
             readOnly = true,
-            mode = mode.toV2MutationMode(),
-        )
-
-    fun TableDescriptor.ImmutableEdge.toV2LabelEntity(): LabelEntity =
-        LabelEntity(
-            active = active,
-            name = EntityName(database, table),
-            desc = comment,
-            type = LabelType.IMMUTABLE_INDEXED,
-            schema = schema.toV2EdgeSchema(),
-            dirType = schema.direction.toV2DirectionType(),
-            storage = storage,
-            indices = schema.indexes.map { it.toV2Index() },
-            groups = schema.groups,
-            event = false,
-            readOnly = false,
             mode = mode.toV2MutationMode(),
         )
 
@@ -249,6 +249,28 @@ object V3MetadataConverter {
             caches = caches,
         )
 
+    fun EdgeSchema.toV3ModelSchemaImmutableEdge(
+        direction: V3DirectionType,
+        indices: List<V2Index>,
+        groups: List<Group>,
+    ): ModelSchema.ImmutableEdge =
+        ModelSchema.ImmutableEdge(
+            source =
+                V3Field(
+                    type = src.type.toV3PrimitiveType(),
+                    comment = src.desc,
+                ),
+            target =
+                V3Field(
+                    type = tgt.type.toV3PrimitiveType(),
+                    comment = tgt.desc,
+                ),
+            properties = fields.map { it.toV3StructField() },
+            direction = direction,
+            indexes = indices.map { it.toV3Index() },
+            groups = groups,
+        )
+
     fun EdgeSchema.toV3ModelSchemaMultiEdge(
         direction: V3DirectionType,
         indices: List<V2Index>,
@@ -281,28 +303,6 @@ object V3MetadataConverter {
             caches = caches,
         )
     }
-
-    fun EdgeSchema.toV3ModelSchemaImmutableEdge(
-        direction: V3DirectionType,
-        indices: List<V2Index>,
-        groups: List<Group>,
-    ): ModelSchema.ImmutableEdge =
-        ModelSchema.ImmutableEdge(
-            source =
-                V3Field(
-                    type = src.type.toV3PrimitiveType(),
-                    comment = src.desc,
-                ),
-            target =
-                V3Field(
-                    type = tgt.type.toV3PrimitiveType(),
-                    comment = tgt.desc,
-                ),
-            properties = fields.map { it.toV3StructField() },
-            direction = direction,
-            indexes = indices.map { it.toV3Index() },
-            groups = groups,
-        )
 
     fun ModelSchema.Edge.toV2EdgeSchema(): EdgeSchema =
         EdgeSchema(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
@@ -62,7 +62,7 @@ class ImmutableEdgeE2ETest : E2ETestBase() {
     private fun append() {
         client
             .post()
-            .uri("/graph/v3/databases/$db/tables/$table/edges/sync")
+            .uri("/graph/v3/databases/$db/tables/$table/edges")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
                 """
@@ -120,10 +120,23 @@ class ImmutableEdgeE2ETest : E2ETestBase() {
     }
 
     @Test
-    fun `non-INSERT mutation is rejected with 400`() {
+    fun `UPDATE mutation is rejected with 400`() {
         client
             .post()
-            .uri("/graph/v3/databases/$db/tables/$table/edges/sync")
+            .uri("/graph/v3/databases/$db/tables/$table/edges")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "UPDATE", "edge": {"version": 2000, "source": 1, "target": "m1", "properties": {"seq": 2000}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `DELETE mutation is rejected with 400`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/edges")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(
                 """{"mutations": [{"type": "DELETE", "edge": {"version": 2000, "source": 1, "target": "m1", "properties": {}}}]}""",

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
@@ -1,0 +1,134 @@
+package com.kakao.actionbase.server.api.graph.v3
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+
+/**
+ * E2E for the immutable edge table: append persists index rows only (no State), scan reads
+ * them back in index order, point get is rejected (400), and non-INSERT mutations are rejected
+ * (append-only). Runs against the in-memory datastore backend via `DatastoreIndexedLabel`,
+ * which reuses the same `V2BackedTableBinding` as HBase.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ImmutableEdgeE2ETest : E2ETestBase() {
+    private val db = "immutable_db"
+    private val table = "immutable_log"
+
+    @BeforeAll
+    fun setup() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "$db", "comment": "immutable edge e2e db"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "$table",
+                  "schema": {
+                    "type": "IMMUTABLE_EDGE",
+                    "source": {"type": "long", "comment": "partition"},
+                    "target": {"type": "string", "comment": "message id"},
+                    "properties": [
+                      {"name": "seq", "type": "long", "comment": "sequence", "nullable": false},
+                      {"name": "payload", "type": "string", "comment": "payload", "nullable": true}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [{"index": "seq_asc", "fields": [{"field": "seq", "order": "ASC"}]}],
+                    "groups": []
+                  },
+                  "storage": "datastore://immutable_ns/immutable_log",
+                  "mode": "SYNC",
+                  "comment": "append-only log"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    private fun append() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/sync")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 1000, "source": 1, "target": "m1", "properties": {"seq": 1000, "payload": "a"}}},
+                    {"type": "INSERT", "edge": {"version": 1001, "source": 1, "target": "m2", "properties": {"seq": 1001, "payload": "b"}}},
+                    {"type": "INSERT", "edge": {"version": 1002, "source": 1, "target": "m3", "properties": {"seq": 1002, "payload": "c"}}}
+                  ]
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.results.length()")
+            .isEqualTo(3)
+            .jsonPath("$.results[0].status")
+            .isEqualTo("CREATED")
+    }
+
+    @Test
+    fun `append then scan returns edges in index order`() {
+        append()
+
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/scan/seq_asc?start=1&direction=OUT&limit=10")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.edges.length()")
+            .isEqualTo(3)
+            .jsonPath("$.edges[0].target")
+            .isEqualTo("m1")
+            .jsonPath("$.edges[0].properties.payload")
+            .isEqualTo("a")
+            .jsonPath("$.edges[2].target")
+            .isEqualTo("m3")
+    }
+
+    @Test
+    fun `point get is rejected with 400`() {
+        append()
+
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/get")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"source": [1], "target": ["m1"]}""")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `non-INSERT mutation is rejected with 400`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/sync")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """{"mutations": [{"type": "DELETE", "edge": {"version": 2000, "source": 1, "target": "m1", "properties": {}}}]}""",
+            ).exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+}


### PR DESCRIPTION
## Summary

Add a new **immutable edge** table kind — index-only, no edge `State`. Append-oriented, read-via-scan. Maps to the existing `LabelType.IMMUTABLE_INDEXED`. First cut supports Index + Group only (no Count, no Cache); scan-and-delete is deferred to a follow-up. Needed as the storage primitive for queue/v1 (#428).

Builds on the `KeyBased` strategy refactor (#435) and pairs with the bulk-encoder fix (#436).

Closes #433

## Changes

- Thread `ImmutableEdge` through the v3 sealed hierarchies (`ModelSchema`, `TableDescriptor`, `V3TableDescriptor`, `EdgeMutationStrategy` as a `KeyBased` object), placed right after `Edge`.
- Mutation emits index (+group) records only: skip the state `Put`, short-circuit `read` to initial (append-only), reject `gets` and the `total` scan feature.
- Append-only enforcement: non-INSERT mutations (UPDATE/DELETE) fail fast with a clear error instead of being silently ignored.
- Materialize `IMMUTABLE_INDEXED` through the existing `INDEXED` HBase label path; all immutable behavior lives in v3.
- Accept `ImmutableEdge` in the append event path and the create/update API + `V3MetadataConverter` round-trip.

## How to Test

- `./gradlew build` — full build incl. unit + HBase mini-cluster tests.
- `./gradlew :engine:test --tests "*ImmutableEdgeSpec"` — append → scan reads edges from index rows only, point get / non-INSERT rejected, count suppressed (HBase mini-cluster).
- `./gradlew :server:test --tests "*ImmutableEdgeE2ETest"` — full HTTP surface: create → append → scan; point get and non-INSERT return 400 (in-memory datastore backend).
- `./gradlew :core:test --tests "*EdgeMutationBuilderTest" --tests "*EdgeSchemaSerializationTest"` — builder emits index+group only; schema round-trips under the `immutableEdge` discriminator.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code
