### PR TITLE
Refactor EdgeMutationStrategy: share key-based resolution via KeyBased

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/edge/mutation/EdgeMutationStrategy.kt
@@ -5,16 +5,7 @@ import com.kakao.actionbase.core.edge.record.EdgeStateRecord
 import com.kakao.actionbase.core.metadata.common.Direction
 import com.kakao.actionbase.core.metadata.common.DirectionType
 
-/**
- * Strategy that encapsulates the behavioral differences between Edge, MultiEdge, and Vertex mutation building.
- *
- * The five axes of difference:
- * 1. Source resolution: Edge/Vertex uses key.source/target, MultiEdge uses properties._source/_target
- * 2. Target resolution (index suffix): Edge/Vertex swaps source/target, MultiEdge always uses key.source (id)
- * 3. DELETE count source: Edge uses after record, MultiEdge uses before record
- * 4. UPDATE count: Edge/Vertex produces none, MultiEdge produces conditionally (when source/target changed)
- * 5. Count generation: Edge/MultiEdge produces count records, Vertex suppresses all count records
- */
+/** Encapsulates how each edge kind derives source/target resolution and count records during mutation. */
 sealed interface EdgeMutationStrategy {
     fun directedSource(
         record: EdgeStateRecord,
@@ -40,9 +31,8 @@ sealed interface EdgeMutationStrategy {
         buildCountRecords: (EdgeStateRecord, DirectionType, Long) -> List<EdgeCountRecord>,
     ): List<EdgeCountRecord>
 
-    data object Edge : EdgeMutationStrategy {
-        override val producesCount: Boolean = true
-
+    /** Strategies whose source/target come straight from the state key: Edge, Vertex. */
+    sealed interface KeyBased : EdgeMutationStrategy {
         override fun directedSource(
             record: EdgeStateRecord,
             direction: Direction,
@@ -72,6 +62,14 @@ sealed interface EdgeMutationStrategy {
             directionType: DirectionType,
             buildCountRecords: (EdgeStateRecord, DirectionType, Long) -> List<EdgeCountRecord>,
         ): List<EdgeCountRecord> = emptyList()
+    }
+
+    data object Edge : KeyBased {
+        override val producesCount: Boolean = true
+    }
+
+    data object Vertex : KeyBased {
+        override val producesCount: Boolean = false
     }
 
     data object MultiEdge : EdgeMutationStrategy {
@@ -113,31 +111,5 @@ sealed interface EdgeMutationStrategy {
                 emptyList()
             }
         }
-    }
-
-    data object Vertex : EdgeMutationStrategy {
-        override val producesCount: Boolean = false
-
-        override fun directedSource(
-            record: EdgeStateRecord,
-            direction: Direction,
-        ): Any = Edge.directedSource(record, direction)
-
-        override fun directedTarget(
-            record: EdgeStateRecord,
-            direction: Direction,
-        ): Any = Edge.directedTarget(record, direction)
-
-        override fun countRecordOnDelete(
-            before: EdgeStateRecord,
-            after: EdgeStateRecord,
-        ): EdgeStateRecord = after
-
-        override fun countRecordsOnUpdate(
-            before: EdgeStateRecord,
-            after: EdgeStateRecord,
-            directionType: DirectionType,
-            buildCountRecords: (EdgeStateRecord, DirectionType, Long) -> List<EdgeCountRecord>,
-        ): List<EdgeCountRecord> = emptyList()
     }
 }


### PR DESCRIPTION
## Summary

Behavior-preserving refactor of `EdgeMutationStrategy`. `Edge` and `Vertex` both resolve `directedSource`/`directedTarget` straight from the state key and produce no update-count records — `Vertex` previously delegated to `Edge.directedSource(...)`. Hoist that shared behavior into a `KeyBased` sub-interface so each object declares only what differs (`producesCount`). `MultiEdge` keeps its own property-based resolution.

No behavior change; splits cleanly out of the immutable-edge work (#433/#434).

Closes #

## Changes

- Add `EdgeMutationStrategy.KeyBased` providing the key-based `directedSource`/`directedTarget` and the no-op `countRecordOnDelete` (= after) / `countRecordsOnUpdate` (= empty) defaults.
- `Edge` and `Vertex` now implement `KeyBased`, overriding only `producesCount`.
- `MultiEdge` unchanged (custom resolution + conditional update counts).

## How to Test

```
./gradlew :core:test --tests "com.kakao.actionbase.core.edge.mutation.*"
```
## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code
