### PR TITLE
IMMUTABLE_INDEXED encodes index-only in codec-java

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoder.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
  *  v2                | v3         | Description
  * -------------------|------------|----------------------------
  *  HASH              | N/A        | Stores only EdgeState, EdgeCount
- *  INDEXED           | EDGE       | Stores EdgeState, EdgeIndex, EdgeCount
- *  IMMUTABLE_INDEXED | N/A        | (As of 2025/08/10) Currently not used anywhere
- *  N/A               | MULTI_EDGE | Stores multiple edges for the same source, target pair based on id
+ *  INDEXED           | EDGE           | Stores EdgeState, EdgeIndex, EdgeCount
+ *  IMMUTABLE_INDEXED | IMMUTABLE_EDGE | Stores EdgeIndex only (no EdgeState, no EdgeCount)
+ *  N/A               | MULTI_EDGE     | Stores multiple edges for the same source, target pair based on id
  * </pre>
  */
 public class BulkEdgeEncoder {
@@ -202,8 +202,9 @@ public class BulkEdgeEncoder {
         }
       }
 
-      // EdgeCount: Vertex stores State only, no count records
-      if (labelType == LabelType.VERTEX) {
+      // EdgeCount: Vertex stores State only and ImmutableEdge stores EdgeIndex only —
+      // neither produces count records.
+      if (labelType == LabelType.VERTEX || labelType == LabelType.IMMUTABLE_INDEXED) {
         return edges;
       }
       if (label.getDirType() == DirectionType.BOTH) {

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/code/BulkEdgeEncoderTests.java
@@ -111,6 +111,35 @@ public class BulkEdgeEncoderTests {
   }
 
   @Test
+  void testImmutableIndexedEncodesIndexOnly() throws JsonProcessingException {
+    // Immutable edge (IMMUTABLE_INDEXED): index rows only — no hash state, no cache, no counter.
+    String immutableLabelJson =
+        labelJsonString
+            .replace("\"type\":\"INDEXED\"", "\"type\":\"IMMUTABLE_INDEXED\"")
+            .replace(
+                "\"caches\":[{\"cache\":\"top_created_at\",\"fields\":[{\"field\":\"created_at\",\"order\":\"DESC\"}],\"limit\":100}]",
+                "\"caches\":[]");
+    LabelDTO label = objectMapper.readValue(immutableLabelJson, LabelDTO.class);
+    LabelDTO newLabel = label.copy("gift.imm_v1_20240402", "gift.imm_v1_20240402");
+
+    BulkLoadEdge edge = objectMapper.readValue(edgeJsonString, BulkLoadEdge.class);
+
+    EdgeEncoderFactory factory = new EdgeEncoderFactory(1);
+    EdgeEncoder<byte[]> encoder = factory.bytesKeyValueEdgeEncoder;
+
+    List<TypedKeyFieldValue<byte[]>> encodedEdges =
+        BulkEdgeEncoder.bulkEncodeAll(encoder, edge, newLabel);
+
+    // dirType BOTH: 2 indexed rows (OUT/IN) only — no hash state, no cache, no counter.
+    assertEquals(2, encodedEdges.size());
+    for (TypedKeyFieldValue<byte[]> kv : encodedEdges) {
+      assertNull(kv.field, "immutable edge must not emit cache rows");
+      DecodedEdge decodedEdge = DecodedEdge.from(KeyFieldValue.from(kv), Collections.emptyMap());
+      assertEquals(EncodedEdgeType.INDEXED_EDGE_TYPE, decodedEdge.getType());
+    }
+  }
+
+  @Test
   void testFetchIndexedLabelAndEncodeEdgesOutboundOnly() throws JsonProcessingException {
     String labelJsonString1 =
         labelJsonString.replace("\"dirType\":\"BOTH\"", "\"dirType\":\"OUT\"");


### PR DESCRIPTION
## Summary

Make `BulkEdgeEncoder` bulk-encode `IMMUTABLE_INDEXED` as index-only. It already skips the hash-state row and writes index rows, but the EdgeCount early-return only covered `VERTEX`, so an immutable label wrongly emitted counter edges on bulk load. Extend the early-return to `IMMUTABLE_INDEXED` so bulk encoding matches its mutation-path semantics (index-only, no `EdgeCount`).

Independent of the v3 immutable-edge work (#433/#434): operates purely on the pre-existing `LabelType.IMMUTABLE_INDEXED`.

Closes #

## Changes

- `BulkEdgeEncoder`: the EdgeCount early-return now covers `VERTEX` and `IMMUTABLE_INDEXED` (both store no count records).
- Refresh the stale `IMMUTABLE_INDEXED` row in the class doc comment.
- Test: `testImmutableIndexedEncodesIndexOnly` asserts an `IMMUTABLE_INDEXED` bulk row emits index rows only — no hash state, no cache, no counter.

## How to Test

- `./gradlew :codec-java:test --tests "com.kakao.actionbase.v2.core.code.BulkEdgeEncoderTests"`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code
