### PR TITLE
Add scan-and-delete for immutable edge tables

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -57,6 +57,18 @@ interface TableBinding {
         features: List<String>,
     ): Mono<DataFrame>
 
+    /**
+     * Scans one page of `index`/`ranges` and deletes the matched rows, returning the count deleted.
+     * Immutable edge tables only — their index rows are the whole record. Bounded by `limit`.
+     */
+    fun scanDelete(
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        ranges: String?,
+    ): Mono<Int>
+
     fun seek(
         cache: String,
         start: List<Any>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -57,11 +57,6 @@ interface TableBinding {
         features: List<String>,
     ): Mono<DataFrame>
 
-    /**
-     * Scans one page of `index`/`ranges` and deletes the matched rows, returning the count deleted.
-     * Immutable edge tables only — their index rows are the whole record. This is eviction: group
-     * aggregates count appends and are not decremented (an append is permanent). Bounded by `limit`.
-     */
     fun scanDelete(
         index: String,
         start: Any,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/binding/TableBinding.kt
@@ -59,7 +59,8 @@ interface TableBinding {
 
     /**
      * Scans one page of `index`/`ranges` and deletes the matched rows, returning the count deleted.
-     * Immutable edge tables only — their index rows are the whole record. Bounded by `limit`.
+     * Immutable edge tables only — their index rows are the whole record. This is eviction: group
+     * aggregates count appends and are not decremented (an append is permanent). Bounded by `limit`.
      */
     fun scanDelete(
         index: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -32,12 +32,6 @@ class MutationService(
     private val engine: MutationEngine,
     private val featureFlags: FeatureFlags = FeatureFlags(emptyList()),
 ) {
-    /**
-     * Scans one page of `index`/`ranges` on an immutable edge table and deletes the matched rows,
-     * returning the count deleted (bounded by `limit`). Used for retention / eviction; callers loop
-     * to trim a larger range. Group aggregates count appends and are not decremented (an append is
-     * permanent).
-     */
     fun scanDelete(
         database: String,
         alias: String,
@@ -46,10 +40,14 @@ class MutationService(
         direction: Direction,
         limit: Int,
         ranges: String?,
-    ): Mono<Int> =
-        Mono
+    ): Mono<Int> {
+        require(limit in 1..MAX_SCAN_DELETE_LIMIT) {
+            "`limit` must be in 1..$MAX_SCAN_DELETE_LIMIT for scanDelete, but was $limit."
+        }
+        return Mono
             .fromCallable { engine.getTableBinding(database, alias) }
             .flatMap { it.scanDelete(index, start, direction, limit, ranges) }
+    }
 
     fun mutate(
         database: String,
@@ -151,10 +149,12 @@ class MutationService(
         return if (acquireLock) tb.withLock(key, rwm) else rwm()
     }
 
-    private companion object {
-        const val QUEUED = "QUEUED"
-        const val ERROR = "ERROR"
-        const val INVALID = "INVALID"
+    companion object {
+        const val MAX_SCAN_DELETE_LIMIT = 1_000
+
+        private const val QUEUED = "QUEUED"
+        private const val ERROR = "ERROR"
+        private const val INVALID = "INVALID"
 
         private fun Throwable.isInvalidMutation(): Boolean = generateSequence(this) { it.cause }.any { it is InvalidMutationException }
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -21,6 +21,7 @@ import com.kakao.actionbase.engine.storage.StorageOpCollector
 import com.kakao.actionbase.engine.util.component1
 import com.kakao.actionbase.engine.util.component2
 import com.kakao.actionbase.engine.util.runEvenIfCancelled
+import com.kakao.actionbase.v2.core.metadata.Direction
 
 import java.time.Duration
 
@@ -31,6 +32,24 @@ class MutationService(
     private val engine: MutationEngine,
     private val featureFlags: FeatureFlags = FeatureFlags(emptyList()),
 ) {
+    /**
+     * Scans one page of `index`/`ranges` on an immutable edge table and deletes the matched rows,
+     * returning the count deleted (bounded by `limit`). Used for retention / eviction; callers loop
+     * to trim a larger range.
+     */
+    fun scanDelete(
+        database: String,
+        alias: String,
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        ranges: String?,
+    ): Mono<Int> =
+        Mono
+            .fromCallable { engine.getTableBinding(database, alias) }
+            .flatMap { it.scanDelete(index, start, direction, limit, ranges) }
+
     fun mutate(
         database: String,
         alias: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -35,7 +35,8 @@ class MutationService(
     /**
      * Scans one page of `index`/`ranges` on an immutable edge table and deletes the matched rows,
      * returning the count deleted (bounded by `limit`). Used for retention / eviction; callers loop
-     * to trim a larger range.
+     * to trim a larger range. Group aggregates count appends and are not decremented (an append is
+     * permanent).
      */
     fun scanDelete(
         database: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
@@ -276,16 +276,6 @@ interface IndexedLabelMixin<T> {
                 it.flatten()
             }
 
-    /**
-     * Scans one page of the given range and deletes the matched index rows, returning the count.
-     * Immutable edge tables only — their sole persisted records are these index rows, so deleting the
-     * scanned keys is a complete delete (no State row or count to reconcile).
-     *
-     * This is eviction (retention), not a logical un-append: group aggregates count appends and are
-     * intentionally not decremented — on an append-only log an append is a permanent fact, so a group
-     * is a lifetime append count, not a live count. Bounded by `scanFilter.limit`; callers loop to
-     * trim a larger range.
-     */
     fun scanAndDeleteIndexedEdges(scanFilter: ScanFilter): Mono<Int> {
         require(self.entity.type == LabelType.IMMUTABLE_INDEXED) {
             "scanAndDeleteIndexedEdges is only valid on immutable edge tables; on a mutable table it " +

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.v2.core.code.hbase.Order
 import com.kakao.actionbase.v2.core.metadata.Active
 import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.core.metadata.LabelType
 import com.kakao.actionbase.v2.core.types.StructType
 import com.kakao.actionbase.v2.engine.cdc.CdcContext
 import com.kakao.actionbase.v2.engine.edge.HashEdge
@@ -277,12 +278,20 @@ interface IndexedLabelMixin<T> {
 
     /**
      * Scans one page of the given range and deletes the matched index rows, returning the count.
-     * Correct only for immutable edges, whose sole persisted records are these index rows, so
-     * deleting the scanned keys is a complete delete (no State row or count to reconcile). Bounded by
-     * `scanFilter.limit`; callers loop to trim a larger range.
+     * Immutable edge tables only — their sole persisted records are these index rows, so deleting the
+     * scanned keys is a complete delete (no State row or count to reconcile).
+     *
+     * This is eviction (retention), not a logical un-append: group aggregates count appends and are
+     * intentionally not decremented — on an append-only log an append is a permanent fact, so a group
+     * is a lifetime append count, not a live count. Bounded by `scanFilter.limit`; callers loop to
+     * trim a larger range.
      */
-    fun scanAndDeleteIndexedEdges(scanFilter: ScanFilter): Mono<Int> =
-        Flux
+    fun scanAndDeleteIndexedEdges(scanFilter: ScanFilter): Mono<Int> {
+        require(self.entity.type == LabelType.IMMUTABLE_INDEXED) {
+            "scanAndDeleteIndexedEdges is only valid on immutable edge tables; on a mutable table it " +
+                "would delete index rows while leaving the State row and count records dangling"
+        }
+        return Flux
             .fromIterable(makeIndexedEdgeScanKeys(scanFilter))
             .flatMap { rangeKey ->
                 self.scanStorage(rangeKey.prefix, scanFilter.limit, rangeKey.start, rangeKey.stop)
@@ -294,6 +303,7 @@ interface IndexedLabelMixin<T> {
                         .flatMap { deferred -> self.handleDeferredRequests(deferred, null).thenReturn(group.size) }
                 }
             }.reduce(0) { acc, deleted -> acc + deleted }
+    }
 
     fun insertIndexedEdges(keyFieldValues: List<KeyFieldValue<T>>): Mono<List<Any>> =
         Flux

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/label/mixin/IndexedLabelMixin.kt
@@ -275,6 +275,26 @@ interface IndexedLabelMixin<T> {
                 it.flatten()
             }
 
+    /**
+     * Scans one page of the given range and deletes the matched index rows, returning the count.
+     * Correct only for immutable edges, whose sole persisted records are these index rows, so
+     * deleting the scanned keys is a complete delete (no State row or count to reconcile). Bounded by
+     * `scanFilter.limit`; callers loop to trim a larger range.
+     */
+    fun scanAndDeleteIndexedEdges(scanFilter: ScanFilter): Mono<Int> =
+        Flux
+            .fromIterable(makeIndexedEdgeScanKeys(scanFilter))
+            .flatMap { rangeKey ->
+                self.scanStorage(rangeKey.prefix, scanFilter.limit, rangeKey.start, rangeKey.stop)
+            }.flatMap { group ->
+                if (group.isEmpty()) {
+                    Mono.just(0)
+                } else {
+                    deleteIndexedEdges(group.map { EncodedKey(it.key) })
+                        .flatMap { deferred -> self.handleDeferredRequests(deferred, null).thenReturn(group.size) }
+                }
+            }.reduce(0) { acc, deleted -> acc + deleted }
+
     fun insertIndexedEdges(keyFieldValues: List<KeyFieldValue<T>>): Mono<List<Any>> =
         Flux
             .fromIterable(keyFieldValues)

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/NilTableBinding.kt
@@ -57,6 +57,14 @@ class NilTableBinding(
         features: List<String>,
     ): Mono<DataFrame> = V2BackedTableBinding.EMPTY_DATAFRAME
 
+    override fun scanDelete(
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        ranges: String?,
+    ): Mono<Int> = Mono.just(0)
+
     override fun seek(
         cache: String,
         start: List<Any>,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedTableBinding.kt
@@ -233,6 +233,43 @@ class V2BackedTableBinding(
             }.switchIfEmpty(EMPTY_DATAFRAME)
     }
 
+    override fun scanDelete(
+        index: String,
+        start: Any,
+        direction: Direction,
+        limit: Int,
+        ranges: String?,
+    ): Mono<Int> {
+        require(isImmutable) { "`scanDelete` is only supported on immutable edge tables." }
+
+        val indexFieldNames =
+            label.entity.indices
+                .find { it.name == index }
+                ?.let { it.fields.map { field -> field.name } }
+        requireNotNull(indexFieldNames) { "index `$index` is not found in label `${label.entity.name}`." }
+
+        val indexPredicates = ranges?.let { WherePredicate.parse(it) }?.toSet() ?: emptySet()
+        val indexPredicateKeys = indexPredicates.map { it.key }
+        val lazyIndexMismatchErrorMessage: () -> String = {
+            "valid `ranges` order for the index `$index` is $indexFieldNames. input was: $indexPredicateKeys."
+        }
+        require(indexPredicateKeys.size <= indexFieldNames.size, lazyIndexMismatchErrorMessage)
+        indexPredicateKeys.zip(indexFieldNames).forEach { (predicateFieldName, indexFieldName) ->
+            require(predicateFieldName == indexFieldName, lazyIndexMismatchErrorMessage)
+        }
+
+        val scanFilter =
+            ScanFilter(
+                name = EntityName(descriptor.database, descriptor.table),
+                srcSet = setOf(start),
+                dir = direction,
+                limit = limit,
+                indexName = index,
+                otherPredicates = indexPredicates,
+            )
+        return label.scanAndDeleteIndexedEdges(scanFilter)
+    }
+
     override fun seek(
         cache: String,
         start: List<Any>,

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
@@ -108,6 +108,28 @@ class ImmutableEdgeSpec :
                 }.verifyComplete()
         }
 
+        "scanDelete removes the matched edges and leaves the rest" {
+            val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
+            mutationService
+                .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                .block()
+
+            // delete seq <= 1001 (m1, m2)
+            mutationService
+                .scanDelete(database, table, "seq_asc", 1L, Direction.OUT, limit = 10, ranges = "seq:lte:1001")
+                .test()
+                .assertNext { deleted -> deleted shouldBe 2 }
+                .verifyComplete()
+
+            // only m3 (seq 1002) remains
+            queryService
+                .scan(database, table, "seq_asc", 1L, Direction.OUT, limit = 10)
+                .test()
+                .assertNext { result ->
+                    result.edges.map { it.target } shouldBe listOf("m3")
+                }.verifyComplete()
+        }
+
         "point get is rejected on immutable edge tables" {
             val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
             mutationService

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
@@ -114,14 +114,12 @@ class ImmutableEdgeSpec :
                 .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
                 .block()
 
-            // delete seq <= 1001 (m1, m2)
             mutationService
                 .scanDelete(database, table, "seq_asc", 1L, Direction.OUT, limit = 10, ranges = "seq:lte:1001")
                 .test()
                 .assertNext { deleted -> deleted shouldBe 2 }
                 .verifyComplete()
 
-            // only m3 (seq 1002) remains
             queryService
                 .scan(database, table, "seq_asc", 1L, Direction.OUT, limit = 10)
                 .test()

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/EdgeMutationController.kt
@@ -5,8 +5,12 @@ import com.kakao.actionbase.core.edge.payload.EdgeMutationResponse
 import com.kakao.actionbase.engine.context.RequestContext
 import com.kakao.actionbase.engine.metadata.MutationMode
 import com.kakao.actionbase.engine.service.MutationService
+import com.kakao.actionbase.server.payload.EdgeScanDeleteResponse
+import com.kakao.actionbase.server.util.mapToResponseEntity
+import com.kakao.actionbase.v2.core.metadata.Direction
 
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -43,4 +47,19 @@ class EdgeMutationController(
         mutationService
             .mutate(database, table, request.mutations, lock, syncMode = MutationMode.SYNC, forceSyncMode = force, requestContext = requestContext)
             .map { ResponseEntity.ok(EdgeMutationResponse.from(it)) }
+
+    @DeleteMapping("/graph/v3/databases/{database}/tables/{table}/edges/scan/{index}")
+    fun scanDelete(
+        @PathVariable database: String,
+        @PathVariable table: String,
+        @PathVariable index: String,
+        @RequestParam start: String,
+        @RequestParam direction: Direction,
+        @RequestParam limit: Int,
+        @RequestParam ranges: String? = null,
+    ): Mono<ResponseEntity<EdgeScanDeleteResponse>> =
+        mutationService
+            .scanDelete(database, table, index, start, direction, limit, ranges)
+            .map { EdgeScanDeleteResponse(database, table, index, it) }
+            .mapToResponseEntity()
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/payload/EdgeScanDeleteResponse.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/payload/EdgeScanDeleteResponse.kt
@@ -1,0 +1,8 @@
+package com.kakao.actionbase.server.payload
+
+data class EdgeScanDeleteResponse(
+    val database: String,
+    val table: String,
+    val index: String,
+    val deleted: Int,
+)

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
@@ -105,6 +105,63 @@ class ImmutableEdgeE2ETest : E2ETestBase() {
             .isEqualTo("m3")
     }
 
+    private fun appendPartition2() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables/$table/edges")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "mutations": [
+                    {"type": "INSERT", "edge": {"version": 2000, "source": 2, "target": "d1", "properties": {"seq": 2000, "payload": "x"}}},
+                    {"type": "INSERT", "edge": {"version": 2001, "source": 2, "target": "d2", "properties": {"seq": 2001, "payload": "y"}}},
+                    {"type": "INSERT", "edge": {"version": 2002, "source": 2, "target": "d3", "properties": {"seq": 2002, "payload": "z"}}}
+                  ]
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `scanDelete evicts matching rows and leaves the rest`() {
+        appendPartition2()
+
+        client
+            .delete()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/scan/seq_asc?start=2&direction=OUT&limit=100&ranges=seq:lte:2001")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.deleted")
+            .isEqualTo(2)
+
+        client
+            .get()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/scan/seq_asc?start=2&direction=OUT&limit=10")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.edges.length()")
+            .isEqualTo(1)
+            .jsonPath("$.edges[0].target")
+            .isEqualTo("d3")
+    }
+
+    @Test
+    fun `scanDelete over the max limit is rejected with 400`() {
+        client
+            .delete()
+            .uri("/graph/v3/databases/$db/tables/$table/edges/scan/seq_asc?start=2&direction=OUT&limit=1001")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
     @Test
     fun `creating an immutable table with two indexes is rejected with 400`() {
         client

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -220,6 +220,7 @@ class ReadOnlyRequestFilterTest {
                 "DELETE /graph/v3/databases/{database}",
                 "DELETE /graph/v3/databases/{database}/aliases/{alias}",
                 "DELETE /graph/v3/databases/{database}/tables/{table}",
+                "DELETE /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}",
                 "POST /graph/v3/databases",
                 "POST /graph/v3/databases/{database}/aliases",
                 "POST /graph/v3/databases/{database}/tables",


### PR DESCRIPTION
## Summary

Add a **scan-and-delete** primitive for immutable edge tables and expose it end-to-end — the building block queue/v1 uses to bound its log. Both a consumer **commit** (poll → process → commit, #439) and plain retention reduce to the same thing: delete a processed prefix by scanning an index range and deleting the matched rows.

An immutable edge table persists *only* index rows (no State row, no count), so deleting the scanned index keys is a complete delete. HBase has no native range delete, so this scans the matching index rows and issues per-row point deletes (bounded by `limit`; callers loop to trim a larger range).

Builds on the immutable-edge constraint from #440 (already merged to `main`): one index in one direction is exactly what makes "deleting the scanned index keys is a complete delete" true by construction.

## Changes

Engine primitive:
- `IndexedLabelMixin.scanAndDeleteIndexedEdges(scanFilter)` — scans one page of a range and deletes the matched index rows via the existing `deleteIndexedEdges`, returning the count deleted.
- `TableBinding.scanDelete(index, start, direction, limit, ranges)` — new binding op; `V2BackedTableBinding` implements it **gated to immutable edges** (`require(isImmutable)`), `NilTableBinding` is a no-op.
- `MutationService.scanDelete(...)` exposes it on the write path and **caps `limit` at `MAX_SCAN_DELETE_LIMIT` (1000)** so one call cannot scan-and-delete an unbounded range in a single RPC batch; callers loop to drain a larger range. Enforced at the engine, so every caller is bounded.

User-facing surface:
- `EdgeMutationController`: `DELETE /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}` (`start`, `direction`, `limit`, `ranges`) → `EdgeScanDeleteResponse{database, table, index, deleted}`. `limit` is required (destructive op — force explicit intent). Blocked in read-only mode by the existing `ReadOnlyRequestFilter` (non-GET).

Deliberately immutable-only: for a mutable indexed edge, deleting only index rows would leave the State row and count dangling.

## How to Test

- `./gradlew :engine:test --tests "*ImmutableEdgeSpec"` — includes a case: append 3 rows, `scanDelete` `seq <= 1001`, assert 2 deleted and only the newer row remains.
- `./gradlew :server:test --tests "*ImmutableEdgeE2ETest"` — includes E2Es: append then `scanDelete` deletes the matched page and leaves the rest; an over-cap `limit` is rejected with 400.
- `./gradlew :engine:spotlessCheck :server:spotlessCheck`.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.8)
