### PR TITLE
Add commit (poll -> process -> commit) to queue/v1

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/queue/QueuePayloads.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/queue/QueuePayloads.kt
@@ -42,3 +42,10 @@ data class QueuePartitionsResponse(
     val queue: String,
     val partitions: Int,
 )
+
+data class QueueCommitResponse(
+    val namespace: String,
+    val queue: String,
+    val partition: Int,
+    val committed: Int,
+)

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/queue/QueueService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/queue/QueueService.kt
@@ -96,6 +96,34 @@ class QueueService(
         }
     }
 
+    fun commit(
+        namespace: String,
+        queue: String,
+        partition: Int,
+        offset: Long,
+    ): Mono<Int> =
+        getNumPartitions(namespace, queue).flatMap { numPartitions ->
+            require(partition in 0 until numPartitions) { "partition must be in 0..${numPartitions - 1}, got $partition" }
+            commitPage(namespace, queue, partition, offset, 0)
+        }
+
+    private fun commitPage(
+        namespace: String,
+        queue: String,
+        partition: Int,
+        offset: Long,
+        deletedSoFar: Int,
+    ): Mono<Int> =
+        mutationService
+            .scanDelete(namespace, queue, QueueSchema.SEQ, partition.toLong(), Direction.OUT, COMMIT_BATCH, "${QueueSchema.SEQ}:lte:$offset")
+            .flatMap { deleted ->
+                if (deleted < COMMIT_BATCH) {
+                    Mono.just(deletedSoFar + deleted)
+                } else {
+                    commitPage(namespace, queue, partition, offset, deletedSoFar + deleted)
+                }
+            }
+
     /** Partition count; a cache miss reads Graph's in-memory registry and decodes the comment marker. */
     fun getNumPartitions(
         namespace: String,
@@ -166,6 +194,7 @@ class QueueService(
 
     private companion object {
         const val MAX_POLL_LIMIT = 1000
+        const val COMMIT_BATCH = 1000
         const val NUM_PARTITIONS_CACHE_SIZE = 100_000L
     }
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/queue/v1/MessageController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/queue/v1/MessageController.kt
@@ -3,11 +3,13 @@ package com.kakao.actionbase.server.api.queue.v1
 import com.kakao.actionbase.engine.queue.EnqueueRequest
 import com.kakao.actionbase.engine.queue.EnqueueResponse
 import com.kakao.actionbase.engine.queue.PollResponse
+import com.kakao.actionbase.engine.queue.QueueCommitResponse
 import com.kakao.actionbase.engine.queue.QueuePartitionsResponse
 import com.kakao.actionbase.engine.queue.QueueService
 import com.kakao.actionbase.server.util.mapToResponseEntity
 
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -48,4 +50,16 @@ class MessageController(
         @RequestParam(required = false) offset: Long? = null,
         @RequestParam(required = false) until: Long? = null,
     ): Mono<ResponseEntity<PollResponse>> = queueService.poll(namespace, queue, partition, limit, offset, until).mapToResponseEntity()
+
+    @DeleteMapping("/queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/messages")
+    fun commit(
+        @PathVariable namespace: String,
+        @PathVariable queue: String,
+        @PathVariable partition: Int,
+        @RequestParam offset: Long,
+    ): Mono<ResponseEntity<QueueCommitResponse>> =
+        queueService
+            .commit(namespace, queue, partition, offset)
+            .map { QueueCommitResponse(namespace, queue, partition, it) }
+            .mapToResponseEntity()
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/queue/v1/QueuePollE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/queue/v1/QueuePollE2ETest.kt
@@ -2,6 +2,7 @@ package com.kakao.actionbase.server.api.queue.v1
 
 import com.kakao.actionbase.engine.queue.PartitionHasher
 import com.kakao.actionbase.engine.queue.PollResponse
+import com.kakao.actionbase.engine.queue.QueueCommitResponse
 
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -146,6 +147,54 @@ class QueuePollE2ETest : QueueE2ESupport() {
             .jsonPath("$.queue")
             .isEqualTo(queue)
     }
+
+    @Test
+    fun `poll then commit deletes the processed prefix and a re-poll reflects it`() {
+        val queue = "committed"
+        createNamespace(ns)
+        createQueue(ns, queue, numPartitions)
+        enqueue(
+            ns,
+            queue,
+            """
+            [
+              {"key": "u", "seq": 1, "value": "a"},
+              {"key": "u", "seq": 2, "value": "b"},
+              {"key": "u", "seq": 3, "value": "c"},
+              {"key": "u", "seq": 4, "value": "d"},
+              {"key": "u", "seq": 5, "value": "e"}
+            ]
+            """.trimIndent(),
+        )
+        val p = PartitionHasher.partition("u", numPartitions)
+
+        val batch = poll(queue, p, limit = 3)
+        assertEquals(listOf(1L, 2L, 3L), batch.messages.map { it.seq })
+        assertEquals(3L, batch.offset)
+        assertEquals(3, commit(queue, p, offset = batch.offset!!))
+
+        val afterCommit = poll(queue, p, limit = 10)
+        assertEquals(listOf(4L, 5L), afterCommit.messages.map { it.seq })
+
+        assertEquals(2, commit(queue, p, offset = afterCommit.offset!!))
+        assertTrue(poll(queue, p, limit = 10).messages.isEmpty(), "a fully committed partition is empty")
+    }
+
+    private fun commit(
+        queue: String,
+        partition: Int,
+        offset: Long,
+    ): Int =
+        client
+            .delete()
+            .uri("/queue/v1/namespaces/$ns/queues/$queue/partitions/$partition/messages?offset=$offset")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody(QueueCommitResponse::class.java)
+            .returnResult()
+            .responseBody!!
+            .committed
 
     private fun poll(
         queue: String,

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -239,6 +239,7 @@ class ReadOnlyRequestFilterTest {
                 "PUT /queue/v1/namespaces/{namespace}/queues/{queue}/enable",
                 "PUT /queue/v1/namespaces/{namespace}/queues/{queue}/disable",
                 "DELETE /queue/v1/namespaces/{namespace}/queues/{queue}",
+                "DELETE /queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/messages",
             )
 
         val NON_GRAPH_ENDPOINTS =


### PR DESCRIPTION
## Summary

Add **commit** to queue/v1: a consumer polls a partition, processes the batch, then commits up to that batch's offset — every message with `seq <= offset` is deleted. `DELETE /queue/v1/namespaces/{ns}/queues/{queue}/partitions/{partition}/messages?offset=X`.

This completes the **poll → process → commit** lifecycle and doubles as retention/eviction. An immutable edge keeps no per-message ack state, so there is a single operation: the delete *is* the committed position. `offset` mirrors poll's forward cursor, so `commit(offset = polledPage.offset)` deletes exactly the prefix just polled.

Stacked on #438 — base is `feat/immutable-edge-scan-delete`; review/merge that first. `commit` is the queue-level use of #438's scan-and-delete primitive. (The immutable-edge constraint from #440 is already in `main`.)

Single consumer per partition: committing deletes the prefix, so it assumes one logical consumer advancing a partition (Kafka-style), not independent consumers sharing one.

## Changes

- `QueueService.commit(namespace, queue, partition, offset)` — loops `MutationService.scanDelete` in pages of `COMMIT_BATCH` until the `seq <= offset` range is drained, returning the total deleted; validates the partition is in range.
- `MessageController`: `DELETE .../partitions/{partition}/messages?offset=X` → `QueueCommitResponse{namespace, queue, partition, committed}`.
- `ReadOnlyRequestFilter` classifies the endpoint as a write (blocked in read-only mode).

## How to Test

- `./gradlew :server:test --tests "*queue.v1.*"` — includes a lifecycle E2E: enqueue seq 1..5, poll a batch of 3, `commit(offset = page.offset)`, assert 3 deleted and a re-poll from the start returns only 4/5, then commit the rest and the partition drains.
- `./gradlew :engine:spotlessCheck :server:spotlessCheck`.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.8)
