### PR TITLE
Constrain immutable edge tables to one index and one direction

### DIFF
--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -46,7 +46,17 @@ sealed class ModelSchema : AbstractSchema {
         val indexes: List<Index> = emptyList(),
         val groups: List<Group> = emptyList(),
     ) : ModelSchema(),
-        AbstractSchema by Schema(properties.associate { it.name to it.nullable })
+        AbstractSchema by Schema(properties.associate { it.name to it.nullable }) {
+        init {
+            // An append writes one index row per index, and those rows are the whole record (no State
+            // row). Eviction scans a single index and deletes only its rows, so a second index's rows
+            // would be orphaned — unreachable to trim, yet still returned by scans on that index.
+            // Restricting to one index keeps "the index rows are the record" true by construction.
+            require(indexes.size <= 1) {
+                "an immutable edge table supports at most one index, but got ${indexes.size}: ${indexes.map { it.index }}"
+            }
+        }
+    }
 
     @JsonTypeName("multiEdge")
     data class MultiEdge(

--- a/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/metadata/common/ModelSchema.kt
@@ -48,12 +48,11 @@ sealed class ModelSchema : AbstractSchema {
     ) : ModelSchema(),
         AbstractSchema by Schema(properties.associate { it.name to it.nullable }) {
         init {
-            // An append writes one index row per index, and those rows are the whole record (no State
-            // row). Eviction scans a single index and deletes only its rows, so a second index's rows
-            // would be orphaned — unreachable to trim, yet still returned by scans on that index.
-            // Restricting to one index keeps "the index rows are the record" true by construction.
             require(indexes.size <= 1) {
-                "an immutable edge table supports at most one index, but got ${indexes.size}: ${indexes.map { it.index }}"
+                "immutable edge allows at most one index (scan-and-delete evicts by scanning one), got ${indexes.map { it.index }}"
+            }
+            require(direction != DirectionType.BOTH) {
+                "immutable edge must be single-direction OUT or IN (scan-and-delete evicts one direction), got BOTH"
             }
         }
     }

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -6,6 +6,7 @@ import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterized
 import com.kakao.actionbase.test.json.PrettyObjectWriter
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 import org.junit.jupiter.api.Test
@@ -16,6 +17,26 @@ class EdgeSchemaSerializationTest {
     val prettyWriter = PrettyObjectWriter.DEFAULT
 
     val objectMapper = prettyWriter.objectMapper
+
+    @Test
+    fun `immutable edge rejects more than one index`() {
+        val twoIndexes =
+            listOf(
+                Index(index = "by_ts", fields = listOf(IndexField(field = "ts", order = Order.ASC))),
+                Index(index = "by_ts_desc", fields = listOf(IndexField(field = "ts", order = Order.DESC))),
+            )
+        val e =
+            assertFailsWith<IllegalArgumentException> {
+                ModelSchema.ImmutableEdge(
+                    source = Field(type = com.kakao.actionbase.core.types.PrimitiveType.INT, comment = "partition"),
+                    target = Field(type = com.kakao.actionbase.core.types.PrimitiveType.STRING, comment = "message id"),
+                    properties = listOf(StructField(name = "ts", type = com.kakao.actionbase.core.types.PrimitiveType.LONG, comment = "ts", nullable = false)),
+                    direction = DirectionType.OUT,
+                    indexes = twoIndexes,
+                )
+            }
+        assertTrue(e.message!!.contains("at most one index"), "message should explain the single-index rule, was: ${e.message}")
+    }
 
     @Test
     fun `immutable edge schema round-trips under the immutableEdge discriminator`() {

--- a/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/metadata/common/EdgeSchemaSerializationTest.kt
@@ -39,6 +39,21 @@ class EdgeSchemaSerializationTest {
     }
 
     @Test
+    fun `immutable edge rejects BOTH direction`() {
+        val e =
+            assertFailsWith<IllegalArgumentException> {
+                ModelSchema.ImmutableEdge(
+                    source = Field(type = com.kakao.actionbase.core.types.PrimitiveType.INT, comment = "partition"),
+                    target = Field(type = com.kakao.actionbase.core.types.PrimitiveType.STRING, comment = "message id"),
+                    properties = listOf(StructField(name = "ts", type = com.kakao.actionbase.core.types.PrimitiveType.LONG, comment = "ts", nullable = false)),
+                    direction = DirectionType.BOTH,
+                    indexes = listOf(Index(index = "by_ts", fields = listOf(IndexField(field = "ts", order = Order.ASC)))),
+                )
+            }
+        assertTrue(e.message!!.contains("single-direction"), "message should explain the single-direction rule, was: ${e.message}")
+    }
+
+    @Test
     fun `immutable edge schema round-trips under the immutableEdge discriminator`() {
         val schema =
             ModelSchema.ImmutableEdge(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
@@ -106,6 +106,40 @@ class ImmutableEdgeE2ETest : E2ETestBase() {
     }
 
     @Test
+    fun `creating an immutable table with two indexes is rejected with 400`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "two_index_log",
+                  "schema": {
+                    "type": "IMMUTABLE_EDGE",
+                    "source": {"type": "long", "comment": "partition"},
+                    "target": {"type": "string", "comment": "message id"},
+                    "properties": [
+                      {"name": "seq", "type": "long", "comment": "sequence", "nullable": false}
+                    ],
+                    "direction": "OUT",
+                    "indexes": [
+                      {"index": "seq_asc", "fields": [{"field": "seq", "order": "ASC"}]},
+                      {"index": "seq_desc", "fields": [{"field": "seq", "order": "DESC"}]}
+                    ],
+                    "groups": []
+                  },
+                  "storage": "datastore://immutable_ns/two_index_log",
+                  "mode": "SYNC",
+                  "comment": "two indexes should be rejected"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
     fun `point get is rejected with 400`() {
         append()
 

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/ImmutableEdgeE2ETest.kt
@@ -140,6 +140,37 @@ class ImmutableEdgeE2ETest : E2ETestBase() {
     }
 
     @Test
+    fun `creating an immutable table with BOTH direction is rejected with 400`() {
+        client
+            .post()
+            .uri("/graph/v3/databases/$db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "both_dir_log",
+                  "schema": {
+                    "type": "IMMUTABLE_EDGE",
+                    "source": {"type": "long", "comment": "partition"},
+                    "target": {"type": "string", "comment": "message id"},
+                    "properties": [
+                      {"name": "seq", "type": "long", "comment": "sequence", "nullable": false}
+                    ],
+                    "direction": "BOTH",
+                    "indexes": [{"index": "seq_asc", "fields": [{"field": "seq", "order": "ASC"}]}],
+                    "groups": []
+                  },
+                  "storage": "datastore://immutable_ns/both_dir_log",
+                  "mode": "SYNC",
+                  "comment": "BOTH direction should be rejected"
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
     fun `point get is rejected with 400`() {
         append()
 


### PR DESCRIPTION
## Summary

Establish the **constraints for an immutable edge table**: exactly **one index** in **one direction** (OUT or IN, not BOTH).

Surfaced while implementing scan-and-delete. An immutable edge persists *only* index rows (no State row, no count), so the index rows **are** the record — and an append writes one row per `(index x direction)`. Eviction scans a **single** index in a **single** direction and deletes only those rows. Any row keyed by another index, or by the opposite direction, would be orphaned: unreachable to trim via the scanned path, yet still returned by scans that reach it.

Constraining an immutable edge to one index and one direction keeps "the index rows are the record" true by construction, so eviction stays a complete delete. This is a prerequisite for the immutable-edge scan-delete work.

## Changes

- `ModelSchema.ImmutableEdge` — `init` block enforces two invariants:
  - `indexes.size <= 1` (message names the offending indexes)
  - `direction != BOTH`

  Enforced at the model boundary, so it holds for every entry point (table create/update, deserialization, direct construction) and yields a 400 on the create/update path.

## Compatibility

The check runs on every construction, including reads (`toV3ModelSchemaImmutableEdge` reconstructs the schema from stored metadata). Immutable edge is a new table type and queue/v1 (single `seq_asc` index, OUT) is compliant, so no existing table is affected; a pre-existing table that violated the rule would now fail to read back.

## How to Test

- `./gradlew :core:test --tests "*EdgeSchemaSerializationTest"` — includes cases asserting a two-index and a BOTH-direction `ImmutableEdge` construction each throw.
- `./gradlew :server:test --tests "*ImmutableEdgeE2ETest"` — includes E2Es: creating an immutable table with two indexes, or with BOTH direction, returns 400.
- `./gradlew :core:spotlessCheck :server:spotlessCheck`.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.8)
