### PR TITLE
Immutable edge tables do not emit CDC

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/service/MutationService.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.core.edge.MutationEvent
 import com.kakao.actionbase.core.edge.MutationKey
 import com.kakao.actionbase.core.edge.UnresolvedEvent
 import com.kakao.actionbase.core.edge.payload.MutationResult
+import com.kakao.actionbase.core.metadata.common.ModelSchema
 import com.kakao.actionbase.core.metadata.features.FeatureFlags
 import com.kakao.actionbase.core.metadata.features.MutationFeature
 import com.kakao.actionbase.core.state.EventType
@@ -69,7 +70,10 @@ class MutationService(
                                 val sorted = group.sortedBy { it.event.version }
                                 readModifyWrite(tb, key, sorted, acquireLock, requestContext.newCollector(), insertMerge)
                                     .doOnNext { result ->
-                                        engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
+                                        // Immutable edge tables are append-only logs consumed by scan, not a CDC stream.
+                                        if (tb.schema !is ModelSchema.ImmutableEdge) {
+                                            engine.writeCdc(ctx, sorted, result.status, result.before, result.after, result.acc)
+                                        }
                                     }.onErrorResume { error ->
                                         tb.handleMutationError(error)
                                         // Permanent (bad input) vs transient (retryable).

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/edge/ImmutableEdgeSpec.kt
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import reactor.kotlin.test.test
 
@@ -142,6 +143,17 @@ class ImmutableEdgeSpec :
                 .test()
                 .assertNext { result -> result.count shouldBe 0L }
                 .verifyComplete()
+        }
+
+        "immutable edge emits no CDC on append" {
+            val request = mapper.readValue<EdgeBulkMutationRequest>(appendRequest)
+            val results =
+                mutationService
+                    .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
+                    .block()!!
+            results.all { it.status == "CREATED" } shouldBe true
+
+            (graph.cdc as InMemoryCdc).readCdc().filter { it.label == labelName }.shouldBeEmpty()
         }
     }) {
     companion object {


### PR DESCRIPTION
## Summary

Immutable edge tables no longer emit CDC. An immutable edge is an append-only log consumed by scan/poll (it backs queue/v1), not a CDC stream — the log itself *is* the change history, so streaming a parallel CDC event per append is redundant.

This also removes an asymmetry surfaced while adding scan-and-delete (#438): appends emitted CDC while evictions — which delete storage directly — did not. Now neither does, so an immutable table is consistently CDC-free.

WAL is unaffected: `writeWal` runs before the CDC step, so durability and async consumption are unchanged. Only the downstream CDC stream is skipped, and only for immutable edges.

## Changes

- `MutationService.mutate` — skip `engine.writeCdc(...)` when the table's schema is `ModelSchema.ImmutableEdge`. Mutable edge / multi-edge / vertex paths are untouched.

## How to Test

- `./gradlew :engine:test --tests "*ImmutableEdgeSpec"` — includes a case: append succeeds (CREATED) yet emits no CDC for the table.
- `./gradlew :engine:test --tests "*GraphSystemAsyncSpec" --tests "*CdcSpec"` — non-immutable mutations still emit CDC (regression guard).
- `./gradlew :engine:spotlessCheck`.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code (opus 4.8)
