### PR TITLE
Document immutable edge tables and queue/v1

### DIFF
--- a/website/src/content/docs/api-references/mutation.mdx
+++ b/website/src/content/docs/api-references/mutation.mdx
@@ -318,9 +318,9 @@ curl -X POST \
 
 ## 5. Scan-Delete (Immutable Edge Tables)
 
-Scan an index range on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge) and delete the matched rows, returning the count deleted. Used for eviction / retention: an immutable edge persists only index rows, so deleting the scanned rows is a complete delete.
+Scan an index range on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge) and delete the matched rows, returning the count deleted. Used for eviction and retention.
 
-Rejected with `400` on non-immutable tables. `limit` is required and capped at 1000 — one call deletes at most one page; loop until the returned count is below `limit` to drain a larger range.
+Rejected with `400` on non-immutable tables. `limit` is required and capped at 1000; one call deletes at most one page, so loop until the returned count is below `limit` to drain a larger range.
 
 ### Endpoint
 
@@ -382,7 +382,7 @@ The `type` field in mutation items specifies the operation to perform:
 | `UPDATE` | Update properties of an existing edge                           |
 | `DELETE` | Delete an edge (marks it as deleted)                            |
 
-Immutable edge tables accept `INSERT` only — `UPDATE` and `DELETE` are rejected with `400`. Rows are removed via [scan-delete](#5-scan-delete-immutable-edge-tables) instead.
+Immutable edge tables accept `INSERT` only; `UPDATE` and `DELETE` are rejected with `400`. Rows are removed via [scan-delete](#5-scan-delete-immutable-edge-tables) instead.
 
 ## Lock Parameter
 

--- a/website/src/content/docs/api-references/mutation.mdx
+++ b/website/src/content/docs/api-references/mutation.mdx
@@ -316,6 +316,62 @@ curl -X POST \
 }
 ```
 
+## 5. Scan-Delete (Immutable Edge Tables)
+
+Scan an index range on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge) and delete the matched rows, returning the count deleted. Used for eviction / retention: an immutable edge persists only index rows, so deleting the scanned rows is a complete delete.
+
+Rejected with `400` on non-immutable tables. `limit` is required and capped at 1000 — one call deletes at most one page; loop until the returned count is below `limit` to drain a larger range.
+
+### Endpoint
+
+```
+DELETE /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                            |
+| -------- | ------------- | -------- | ------------------------------------------------------ |
+| Header   | Authorization | Optional | Authentication key (reserved for future use)           |
+| Path     | database      | Required | Target database name                                   |
+| Path     | table         | Required | Target table name (must be an immutable edge table)    |
+| Path     | index         | Required | Index to scan                                          |
+| Query    | start         | Required | Source node to scan from                               |
+| Query    | direction     | Required | Scan direction (OUT, IN)                               |
+| Query    | limit         | Required | Max rows to delete in this call (maximum 1000)         |
+| Query    | ranges        | Optional | Index range predicate (e.g., `seq:lte:1001`)           |
+
+### Response Type
+
+[EdgeScanDeleteResponse](#edgescandeleteresponse) - The count deleted
+
+### Request Example
+
+| Parameter     | Value         |
+| ------------- | ------------- |
+| Authorization | YOUR_API_KEY  |
+| database      | your_database |
+| table         | your_table    |
+| index         | seq_asc       |
+
+```bash
+# DELETE /graph/v3/databases/your_database/tables/your_table/edges/scan/seq_asc
+curl -X DELETE \
+    "http://ab.example.com/graph/v3/databases/your_database/tables/your_table/edges/scan/seq_asc?start=1&direction=OUT&limit=100&ranges=seq:lte:1001" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+```json
+{
+  "database": "your_database",
+  "table": "your_table",
+  "index": "seq_asc",
+  "deleted": 2
+}
+```
+
 ## Event Types
 
 The `type` field in mutation items specifies the operation to perform:
@@ -325,6 +381,8 @@ The `type` field in mutation items specifies the operation to perform:
 | `INSERT` | Create a new edge or update an existing edge with a new version |
 | `UPDATE` | Update properties of an existing edge                           |
 | `DELETE` | Delete an edge (marks it as deleted)                            |
+
+Immutable edge tables accept `INSERT` only — `UPDATE` and `DELETE` are rejected with `400`. Rows are removed via [scan-delete](#5-scan-delete-immutable-edge-tables) instead.
 
 ## Lock Parameter
 
@@ -424,5 +482,18 @@ data class MultiEdge(
   val source: Any? = null,           // Source node ID (optional)
   val target: Any? = null,           // Target node ID (optional)
   val properties: Map<String, Any?>,  // Edge properties
+)
+```
+
+### EdgeScanDeleteResponse
+
+Scan-delete response payload.
+
+```kotlin
+data class EdgeScanDeleteResponse(
+  val database: String,  // Target database name
+  val table: String,     // Target table name
+  val index: String,     // Index that was scanned
+  val deleted: Int,      // Rows deleted by this call (at most `limit`)
 )
 ```

--- a/website/src/content/docs/api-references/mutation.mdx
+++ b/website/src/content/docs/api-references/mutation.mdx
@@ -330,16 +330,16 @@ DELETE /graph/v3/databases/{database}/tables/{table}/edges/scan/{index}
 
 ### Parameters
 
-| Location | Parameter     | Required | Description                                            |
-| -------- | ------------- | -------- | ------------------------------------------------------ |
-| Header   | Authorization | Optional | Authentication key (reserved for future use)           |
-| Path     | database      | Required | Target database name                                   |
-| Path     | table         | Required | Target table name (must be an immutable edge table)    |
-| Path     | index         | Required | Index to scan                                          |
-| Query    | start         | Required | Source node to scan from                               |
-| Query    | direction     | Required | Scan direction (OUT, IN)                               |
-| Query    | limit         | Required | Max rows to delete in this call (maximum 1000)         |
-| Query    | ranges        | Optional | Index range predicate (e.g., `seq:lte:1001`)           |
+| Location | Parameter     | Required | Description                                         |
+| -------- | ------------- | -------- | --------------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use)        |
+| Path     | database      | Required | Target database name                                |
+| Path     | table         | Required | Target table name (must be an immutable edge table) |
+| Path     | index         | Required | Index to scan                                       |
+| Query    | start         | Required | Source node to scan from                            |
+| Query    | direction     | Required | Scan direction (OUT, IN)                            |
+| Query    | limit         | Required | Max rows to delete in this call (maximum 1000)      |
+| Query    | ranges        | Optional | Index range predicate (e.g., `seq:lte:1001`)        |
 
 ### Response Type
 

--- a/website/src/content/docs/api-references/queue.mdx
+++ b/website/src/content/docs/api-references/queue.mdx
@@ -27,13 +27,13 @@ POST /queue/v1/namespaces/{namespace}/queues
 
 ### Parameters
 
-| Location | Parameter  | Required               | Description                                            |
-| -------- | ---------- | ---------------------- | ------------------------------------------------------ |
-| Header   | Authorization | Optional            | Authentication key (reserved for future use)           |
-| Path     | namespace  | Required               | Target namespace                                       |
-| Body     | queue      | Required               | Queue name                                             |
-| Body     | storage    | Required               | Storage URI (e.g., `datastore://<namespace>/<table>`)  |
-| Body     | partitions | Optional (default: 30) | Partition count, fixed at creation (minimum 1)         |
+| Location | Parameter     | Required               | Description                                           |
+| -------- | ------------- | ---------------------- | ----------------------------------------------------- |
+| Header   | Authorization | Optional               | Authentication key (reserved for future use)          |
+| Path     | namespace     | Required               | Target namespace                                      |
+| Body     | queue         | Required               | Queue name                                            |
+| Body     | storage       | Required               | Storage URI (e.g., `datastore://<namespace>/<table>`) |
+| Body     | partitions    | Optional (default: 30) | Partition count, fixed at creation (minimum 1)        |
 
 ### Response Type
 
@@ -226,12 +226,12 @@ POST /queue/v1/namespaces/{namespace}/queues/{queue}/messages
 
 ### Parameters
 
-| Location | Parameter     | Required | Description                                            |
-| -------- | ------------- | -------- | ------------------------------------------------------ |
-| Header   | Authorization | Optional | Authentication key (reserved for future use)           |
-| Path     | namespace     | Required | Target namespace                                       |
-| Path     | queue         | Required | Target queue name                                      |
-| Body     | messages      | Required | List of messages, each with `key`, `seq`, and `value`  |
+| Location | Parameter     | Required | Description                                           |
+| -------- | ------------- | -------- | ----------------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use)          |
+| Path     | namespace     | Required | Target namespace                                      |
+| Path     | queue         | Required | Target queue name                                     |
+| Body     | messages      | Required | List of messages, each with `key`, `seq`, and `value` |
 
 ### Request Body
 
@@ -263,8 +263,8 @@ curl -X POST \
 {
   "accepted": 2,
   "results": [
-    {"partition": 7, "id": "01JT7Q0Z8B3N5Y6W9XKQRVMH2D", "status": "CREATED"},
-    {"partition": 7, "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F", "status": "CREATED"}
+    { "partition": 7, "id": "01JT7Q0Z8B3N5Y6W9XKQRVMH2D", "status": "CREATED" },
+    { "partition": 7, "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F", "status": "CREATED" }
   ]
 }
 ```
@@ -281,15 +281,15 @@ GET /queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/poll
 
 ### Parameters
 
-| Location | Parameter     | Required                | Description                                       |
-| -------- | ------------- | ----------------------- | ------------------------------------------------- |
-| Header   | Authorization | Optional                | Authentication key (reserved for future use)      |
-| Path     | namespace     | Required                | Target namespace                                  |
-| Path     | queue         | Required                | Target queue name                                 |
-| Path     | partition     | Required                | Partition to read (`0 .. partitions-1`)           |
-| Query    | limit         | Optional (default: 100) | Max messages per page (maximum 1000)              |
-| Query    | offset        | Optional                | Read messages with `seq > offset` (exclusive)     |
-| Query    | until         | Optional                | Read messages with `seq <= until` (inclusive)     |
+| Location | Parameter     | Required                | Description                                   |
+| -------- | ------------- | ----------------------- | --------------------------------------------- |
+| Header   | Authorization | Optional                | Authentication key (reserved for future use)  |
+| Path     | namespace     | Required                | Target namespace                              |
+| Path     | queue         | Required                | Target queue name                             |
+| Path     | partition     | Required                | Partition to read (`0 .. partitions-1`)       |
+| Query    | limit         | Optional (default: 100) | Max messages per page (maximum 1000)          |
+| Query    | offset        | Optional                | Read messages with `seq > offset` (exclusive) |
+| Query    | until         | Optional                | Read messages with `seq <= until` (inclusive) |
 
 ### Response Type
 
@@ -308,7 +308,12 @@ curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue
 ```json
 {
   "messages": [
-    {"partition": 7, "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F", "seq": 1001, "value": {"body": "world"}}
+    {
+      "partition": 7,
+      "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F",
+      "seq": 1001,
+      "value": { "body": "world" }
+    }
   ],
   "offset": 1001,
   "hasNext": false
@@ -327,13 +332,13 @@ DELETE /queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/me
 
 ### Parameters
 
-| Location | Parameter     | Required | Description                                       |
-| -------- | ------------- | -------- | ------------------------------------------------- |
-| Header   | Authorization | Optional | Authentication key (reserved for future use)      |
-| Path     | namespace     | Required | Target namespace                                  |
-| Path     | queue         | Required | Target queue name                                 |
-| Path     | partition     | Required | Partition to commit (`0 .. partitions-1`)         |
-| Query    | offset        | Required | Delete every message with `seq <= offset`         |
+| Location | Parameter     | Required | Description                                  |
+| -------- | ------------- | -------- | -------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use) |
+| Path     | namespace     | Required | Target namespace                             |
+| Path     | queue         | Required | Target queue name                            |
+| Path     | partition     | Required | Partition to commit (`0 .. partitions-1`)    |
+| Query    | offset        | Required | Delete every message with `seq <= offset`    |
 
 ### Response Type
 

--- a/website/src/content/docs/api-references/queue.mdx
+++ b/website/src/content/docs/api-references/queue.mdx
@@ -17,7 +17,7 @@ queue/v1 API. See [Queue](/design/queue/) for conceptual background.
 
 ## 1. Create Queue
 
-Create a queue. This provisions the backing immutable edge table with the fixed queue schema (`seq`, `value`, and the server-assigned ULID message id).
+Create a queue, provisioning the backing immutable edge table with the fixed queue schema (`seq`, `value`, and a server-assigned ULID message id).
 
 ### Endpoint
 
@@ -145,7 +145,7 @@ curl -X PUT \
 
 ## 4. Delete Queue
 
-Delete a queue. Guarded: the queue must be disabled first — deleting an active queue returns `409 Conflict`.
+Delete a queue. The queue must be disabled first; deleting an active queue returns `409 Conflict`.
 
 ### Endpoint
 
@@ -216,7 +216,7 @@ curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue
 
 ## 6. Enqueue
 
-Append messages to the queue. Each message is routed to a partition by `xxhash32(key) mod partitions`; the server assigns a ULID message id. `seq` orders messages within a partition and may encode a due time for delayed consumption.
+Append messages to the queue. Each message is routed to a partition by its `key`; the server assigns a ULID id, and `seq` orders it within the partition.
 
 ### Endpoint
 
@@ -271,7 +271,7 @@ curl -X POST \
 
 ## 7. Poll
 
-Read one partition forward in `seq` order. `offset` is exclusive (`seq > offset`); `until` is inclusive (`seq <= until`) and bounds a poll to due messages when `seq` encodes a due time. The response's `offset` is the cursor to pass back to the next poll — and the value to [commit](#8-commit) once the batch is processed.
+Read one partition forward in `seq` order. The response's `offset` is the cursor for the next poll, and the value to [commit](#8-commit) once the batch is processed.
 
 ### Endpoint
 
@@ -317,7 +317,7 @@ curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue
 
 ## 8. Commit
 
-Commit a partition up to an offset: the consumer has processed every message with `seq <= offset`, so they are **deleted**. This completes the poll → process → commit lifecycle and doubles as retention. Assumes one logical consumer per partition — see [Queue](/design/queue/#consumer-lifecycle).
+Commit a partition up to an offset: every message with `seq <= offset` is deleted. Assumes one logical consumer per partition; see [Queue](/design/queue/#consumer-lifecycle).
 
 ### Endpoint
 

--- a/website/src/content/docs/api-references/queue.mdx
+++ b/website/src/content/docs/api-references/queue.mdx
@@ -1,0 +1,450 @@
+---
+title: Queue API Reference
+description: queue/v1 API reference
+sidebar:
+  order: 4
+tableOfContents:
+  maxHeadingLevel: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution">
+  Authentication is not enforced. See [API References](/api-references/#authentication).
+</Aside>
+
+queue/v1 API. See [Queue](/design/queue/) for conceptual background.
+
+## 1. Create Queue
+
+Create a queue. This provisions the backing immutable edge table with the fixed queue schema (`seq`, `value`, and the server-assigned ULID message id).
+
+### Endpoint
+
+```
+POST /queue/v1/namespaces/{namespace}/queues
+```
+
+### Parameters
+
+| Location | Parameter  | Required               | Description                                            |
+| -------- | ---------- | ---------------------- | ------------------------------------------------------ |
+| Header   | Authorization | Optional            | Authentication key (reserved for future use)           |
+| Path     | namespace  | Required               | Target namespace                                       |
+| Body     | queue      | Required               | Queue name                                             |
+| Body     | storage    | Required               | Storage URI (e.g., `datastore://<namespace>/<table>`)  |
+| Body     | partitions | Optional (default: 30) | Partition count, fixed at creation (minimum 1)         |
+
+### Response Type
+
+[QueueDescriptorResponse](#queuedescriptorresponse) - Queue metadata
+
+### Request Example
+
+| Parameter     | Value          |
+| ------------- | -------------- |
+| Authorization | YOUR_API_KEY   |
+| namespace     | your_namespace |
+
+```bash
+# POST /queue/v1/namespaces/your_namespace/queues
+curl -X POST \
+    "http://ab.example.com/queue/v1/namespaces/your_namespace/queues" \
+    -H "Authorization: YOUR_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "queue": "your_queue",
+      "storage": "datastore://your_namespace/your_queue",
+      "partitions": 30
+    }'
+```
+
+### Response Example
+
+```json
+{
+  "namespace": "your_namespace",
+  "queue": "your_queue",
+  "partitions": 30,
+  "storage": "datastore://your_namespace/your_queue"
+}
+```
+
+## 2. Get Queue
+
+Get a queue's metadata.
+
+### Endpoint
+
+```
+GET /queue/v1/namespaces/{namespace}/queues/{queue}
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                  |
+| -------- | ------------- | -------- | -------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use) |
+| Path     | namespace     | Required | Target namespace                             |
+| Path     | queue         | Required | Target queue name                            |
+
+### Response Type
+
+[QueueDescriptorResponse](#queuedescriptorresponse) - Queue metadata
+
+### Request Example
+
+```bash
+# GET /queue/v1/namespaces/your_namespace/queues/your_queue
+curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+```json
+{
+  "namespace": "your_namespace",
+  "queue": "your_queue",
+  "partitions": 30,
+  "storage": "datastore://your_namespace/your_queue"
+}
+```
+
+## 3. Enable / Disable Queue
+
+Activate or deactivate a queue. A queue must be disabled before it can be deleted.
+
+### Endpoint
+
+```
+PUT /queue/v1/namespaces/{namespace}/queues/{queue}/enable
+PUT /queue/v1/namespaces/{namespace}/queues/{queue}/disable
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                  |
+| -------- | ------------- | -------- | -------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use) |
+| Path     | namespace     | Required | Target namespace                             |
+| Path     | queue         | Required | Target queue name                            |
+
+### Response Type
+
+[QueueDescriptorResponse](#queuedescriptorresponse) - Queue metadata
+
+### Request Example
+
+```bash
+# PUT /queue/v1/namespaces/your_namespace/queues/your_queue/disable
+curl -X PUT \
+    "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue/disable" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+## 4. Delete Queue
+
+Delete a queue. Guarded: the queue must be disabled first — deleting an active queue returns `409 Conflict`.
+
+### Endpoint
+
+```
+DELETE /queue/v1/namespaces/{namespace}/queues/{queue}
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                  |
+| -------- | ------------- | -------- | -------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use) |
+| Path     | namespace     | Required | Target namespace                             |
+| Path     | queue         | Required | Target queue name                            |
+
+### Request Example
+
+```bash
+# DELETE /queue/v1/namespaces/your_namespace/queues/your_queue
+curl -X DELETE \
+    "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+`204 No Content` on success; `409 Conflict` if the queue is still enabled.
+
+## 5. Get Partitions
+
+Get a queue's partition count, for consumers that fan a poll loop across `0 .. partitions-1`.
+
+### Endpoint
+
+```
+GET /queue/v1/namespaces/{namespace}/queues/{queue}/partitions
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                  |
+| -------- | ------------- | -------- | -------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use) |
+| Path     | namespace     | Required | Target namespace                             |
+| Path     | queue         | Required | Target queue name                            |
+
+### Response Type
+
+[QueuePartitionsResponse](#queuepartitionsresponse) - The partition count
+
+### Request Example
+
+```bash
+# GET /queue/v1/namespaces/your_namespace/queues/your_queue/partitions
+curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue/partitions" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+```json
+{
+  "namespace": "your_namespace",
+  "queue": "your_queue",
+  "partitions": 30
+}
+```
+
+## 6. Enqueue
+
+Append messages to the queue. Each message is routed to a partition by `xxhash32(key) mod partitions`; the server assigns a ULID message id. `seq` orders messages within a partition and may encode a due time for delayed consumption.
+
+### Endpoint
+
+```
+POST /queue/v1/namespaces/{namespace}/queues/{queue}/messages
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                            |
+| -------- | ------------- | -------- | ------------------------------------------------------ |
+| Header   | Authorization | Optional | Authentication key (reserved for future use)           |
+| Path     | namespace     | Required | Target namespace                                       |
+| Path     | queue         | Required | Target queue name                                      |
+| Body     | messages      | Required | List of messages, each with `key`, `seq`, and `value`  |
+
+### Request Body
+
+[EnqueueRequest](#enqueuerequest) - Payload containing messages
+
+### Response Type
+
+[EnqueueResponse](#enqueueresponse) - Per-message results
+
+### Request Example
+
+```bash
+# POST /queue/v1/namespaces/your_namespace/queues/your_queue/messages
+curl -X POST \
+    "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue/messages" \
+    -H "Authorization: YOUR_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "messages": [
+        {"key": "user1", "seq": 1000, "value": {"body": "hello"}},
+        {"key": "user1", "seq": 1001, "value": {"body": "world"}}
+      ]
+    }'
+```
+
+### Response Example
+
+```json
+{
+  "accepted": 2,
+  "results": [
+    {"partition": 7, "id": "01JT7Q0Z8B3N5Y6W9XKQRVMH2D", "status": "CREATED"},
+    {"partition": 7, "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F", "status": "CREATED"}
+  ]
+}
+```
+
+## 7. Poll
+
+Read one partition forward in `seq` order. `offset` is exclusive (`seq > offset`); `until` is inclusive (`seq <= until`) and bounds a poll to due messages when `seq` encodes a due time. The response's `offset` is the cursor to pass back to the next poll — and the value to [commit](#8-commit) once the batch is processed.
+
+### Endpoint
+
+```
+GET /queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/poll
+```
+
+### Parameters
+
+| Location | Parameter     | Required                | Description                                       |
+| -------- | ------------- | ----------------------- | ------------------------------------------------- |
+| Header   | Authorization | Optional                | Authentication key (reserved for future use)      |
+| Path     | namespace     | Required                | Target namespace                                  |
+| Path     | queue         | Required                | Target queue name                                 |
+| Path     | partition     | Required                | Partition to read (`0 .. partitions-1`)           |
+| Query    | limit         | Optional (default: 100) | Max messages per page (maximum 1000)              |
+| Query    | offset        | Optional                | Read messages with `seq > offset` (exclusive)     |
+| Query    | until         | Optional                | Read messages with `seq <= until` (inclusive)     |
+
+### Response Type
+
+[PollResponse](#pollresponse) - One partition's page
+
+### Request Example
+
+```bash
+# GET /queue/v1/namespaces/your_namespace/queues/your_queue/partitions/7/poll
+curl "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue/partitions/7/poll?limit=100&offset=1000" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+```json
+{
+  "messages": [
+    {"partition": 7, "id": "01JT7Q0Z8CM4A1E8ZPXW3G5T7F", "seq": 1001, "value": {"body": "world"}}
+  ],
+  "offset": 1001,
+  "hasNext": false
+}
+```
+
+## 8. Commit
+
+Commit a partition up to an offset: the consumer has processed every message with `seq <= offset`, so they are **deleted**. This completes the poll → process → commit lifecycle and doubles as retention. Assumes one logical consumer per partition — see [Queue](/design/queue/#consumer-lifecycle).
+
+### Endpoint
+
+```
+DELETE /queue/v1/namespaces/{namespace}/queues/{queue}/partitions/{partition}/messages
+```
+
+### Parameters
+
+| Location | Parameter     | Required | Description                                       |
+| -------- | ------------- | -------- | ------------------------------------------------- |
+| Header   | Authorization | Optional | Authentication key (reserved for future use)      |
+| Path     | namespace     | Required | Target namespace                                  |
+| Path     | queue         | Required | Target queue name                                 |
+| Path     | partition     | Required | Partition to commit (`0 .. partitions-1`)         |
+| Query    | offset        | Required | Delete every message with `seq <= offset`         |
+
+### Response Type
+
+[QueueCommitResponse](#queuecommitresponse) - How many messages were deleted
+
+### Request Example
+
+```bash
+# DELETE /queue/v1/namespaces/your_namespace/queues/your_queue/partitions/7/messages
+curl -X DELETE \
+    "http://ab.example.com/queue/v1/namespaces/your_namespace/queues/your_queue/partitions/7/messages?offset=1001" \
+    -H "Authorization: YOUR_API_KEY"
+```
+
+### Response Example
+
+```json
+{
+  "namespace": "your_namespace",
+  "queue": "your_queue",
+  "partition": 7,
+  "committed": 2
+}
+```
+
+## Data Model
+
+### QueueCreateRequest
+
+```kotlin
+data class QueueCreateRequest(
+    val queue: String,        // Queue name
+    val storage: String,      // Storage URI
+    val partitions: Int = 30, // Partition count, fixed at creation (minimum 1)
+)
+```
+
+### QueueDescriptorResponse
+
+```kotlin
+data class QueueDescriptorResponse(
+    val namespace: String,
+    val queue: String,
+    val partitions: Int,
+    val storage: String,
+)
+```
+
+### QueuePartitionsResponse
+
+```kotlin
+data class QueuePartitionsResponse(
+    val namespace: String,
+    val queue: String,
+    val partitions: Int,
+)
+```
+
+### EnqueueRequest
+
+```kotlin
+data class EnqueueRequest(
+    val messages: List<EnqueueMessage>,
+)
+
+data class EnqueueMessage(
+    val key: String,       // Routes to a partition
+    val seq: Long,         // Orders within the partition; may encode a due time
+    val value: Any? = null // Opaque payload (JSON)
+)
+```
+
+### EnqueueResponse
+
+```kotlin
+data class EnqueueResponse(
+    val accepted: Int,                 // Count of messages with status CREATED
+    val results: List<EnqueueResult>,
+)
+
+data class EnqueueResult(
+    val partition: Int,   // Partition the message was routed to
+    val id: String,       // Server-assigned ULID
+    val status: String,   // CREATED on success
+)
+```
+
+### PollResponse
+
+```kotlin
+data class PollResponse(
+    val messages: List<PolledMessage>, // In seq order
+    val offset: Long?,                 // Cursor for the next poll (highest seq seen)
+    val hasNext: Boolean,              // Whether more messages remain in the range
+)
+
+data class PolledMessage(
+    val partition: Int,
+    val id: String,       // ULID message id
+    val seq: Long,
+    val value: Any?,
+)
+```
+
+### QueueCommitResponse
+
+```kotlin
+data class QueueCommitResponse(
+    val namespace: String,
+    val queue: String,
+    val partition: Int,
+    val committed: Int,   // Messages deleted by this commit
+)
+```

--- a/website/src/content/docs/design/glossary.mdx
+++ b/website/src/content/docs/design/glossary.mdx
@@ -2,7 +2,7 @@
 title: Glossary
 description: Key terminology used in Actionbase documentation
 sidebar:
-  order: 6
+  order: 7
 ---
 
 Key terms used in Actionbase documentation.

--- a/website/src/content/docs/design/queue.mdx
+++ b/website/src/content/docs/design/queue.mdx
@@ -1,0 +1,68 @@
+---
+title: Queue
+description: A partitioned message queue built on immutable edge tables
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+queue/v1 is a partitioned message queue built on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge). It provides ordered, partition-parallel delivery with an explicit consumer lifecycle: **poll → process → commit**.
+
+See the [Queue API Reference](/api-references/queue/) for endpoints.
+
+## Architecture
+
+A queue is an immutable edge table with a fixed schema. Each queue concept maps directly onto an edge concept:
+
+| Queue concept | Edge concept                                  |
+| ------------- | --------------------------------------------- |
+| namespace     | Service (v3: database)                        |
+| queue         | Label (v3: table), type IMMUTABLE_INDEXED     |
+| partition     | src (LONG)                                    |
+| message id    | tgt (STRING) — a server-assigned ULID         |
+| seq           | field (LONG) — ordering key, also the index   |
+| value         | field (STRING) — opaque JSON payload          |
+
+Because the backing table is append-only and index-only, an enqueue is a single index-row write and a poll is a single bounded index scan. There is no per-message state — no ack flags, no consumer registry.
+
+## Partitioning
+
+A message is routed by its `key`:
+
+```
+partition = xxhash32(key) mod partitions
+```
+
+- Messages with the same key land in the same partition and are read back in `seq` order.
+- `partitions` is fixed at queue creation (default 30 = 2·3·5, whose divisors allow many balanced consumer-shard splits).
+- Consumers fan out by polling partitions `0 .. partitions-1` independently.
+
+## Consumer Lifecycle
+
+```
+poll(partition, offset) → process the batch → commit(partition, offset = batch offset)
+```
+
+1. **Poll** scans one partition forward by `seq`. `offset` is exclusive (`seq > offset`); the response returns the batch and its next `offset` (the highest `seq` seen). An optional `until` bound (inclusive) restricts a poll to due messages when `seq` encodes a due time.
+2. **Process** the batch.
+3. **Commit** up to the batch's offset: every message with `seq <= offset` is **deleted**. There is no separate ack state — the delete *is* the committed position, and the same operation serves retention.
+
+<Aside type="caution">
+  Commit deletes a prefix of the partition, so it assumes **one logical consumer per partition**
+  (Kafka-style). Independent consumers sharing a partition would delete each other's unprocessed
+  messages.
+</Aside>
+
+## Delivery Semantics
+
+- **At-least-once**: commit only after processing. If a consumer crashes between poll and commit, the next poll re-reads the uncommitted messages.
+- **Ordered within a partition**: polls return messages in `seq` order; there is no ordering across partitions.
+- **Commit is a real delete**: after a commit, re-polling from the start of the partition does not return the committed prefix.
+- **No CDC**: immutable edge tables do not emit CDC — the queue itself is the log.
+
+## Next Steps
+
+- [Queue API Reference](/api-references/queue/): Endpoints
+- [Schema](/design/schema/): Immutable edge tables
+- [Mutation API Reference](/api-references/mutation/): The underlying scan-delete primitive

--- a/website/src/content/docs/design/queue.mdx
+++ b/website/src/content/docs/design/queue.mdx
@@ -15,14 +15,14 @@ See the [Queue API Reference](/api-references/queue/) for endpoints.
 
 A queue is an immutable edge table with a fixed schema. Each queue concept maps directly onto an edge concept:
 
-| Queue concept | Edge concept                                  |
-| ------------- | --------------------------------------------- |
-| namespace     | Service (v3: database)                        |
-| queue         | Label (v3: table), type IMMUTABLE_INDEXED     |
-| partition     | src (LONG)                                    |
-| message id    | tgt (STRING) — a server-assigned ULID         |
-| seq           | field (LONG) — ordering key, also the index   |
-| value         | field (STRING) — opaque JSON payload          |
+| Queue concept | Edge concept                                    |
+| ------------- | ----------------------------------------------- |
+| namespace     | database                                        |
+| queue         | table, type IMMUTABLE_EDGE                       |
+| partition     | source (LONG)                                   |
+| message id    | target (STRING) — a server-assigned ULID        |
+| seq           | property (LONG) — ordering key, also the index  |
+| value         | property (STRING) — opaque JSON payload         |
 
 Because the backing table is append-only and index-only, an enqueue is a single index-row write and a poll is a single bounded index scan. There is no per-message state — no ack flags, no consumer registry.
 

--- a/website/src/content/docs/design/queue.mdx
+++ b/website/src/content/docs/design/queue.mdx
@@ -15,17 +15,17 @@ See the [Queue API Reference](/api-references/queue/) for endpoints.
 
 A queue is an immutable edge table with a fixed schema and a fixed access pattern. Define a queue, and each part is exactly one thing on the underlying [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge):
 
-| queue/v1                                   | Immutable edge table                          |
-| ------------------------------------------ | --------------------------------------------- |
-| namespace                                  | database                                      |
-| queue                                      | table, type IMMUTABLE_EDGE                     |
-| partition = `xxhash32(key) mod partitions` | source (LONG)                                 |
-| message id                                 | target (STRING) — a server-assigned ULID      |
-| seq (order / due time)                     | property (LONG) — the single `seq ASC` index  |
-| value                                      | property (STRING) — opaque JSON payload       |
-| enqueue                                    | INSERT one index row (append, lock-free)      |
-| poll (`seq > offset`, optional `until`)    | bounded scan of the `seq ASC` index (OUT)     |
-| commit (`seq <= offset`)                   | scan-delete over that index range             |
+| queue/v1                                   | Immutable edge table                         |
+| ------------------------------------------ | -------------------------------------------- |
+| namespace                                  | database                                     |
+| queue                                      | table, type IMMUTABLE_EDGE                   |
+| partition = `xxhash32(key) mod partitions` | source (LONG)                                |
+| message id                                 | target (STRING) — a server-assigned ULID     |
+| seq (order / due time)                     | property (LONG) — the single `seq ASC` index |
+| value                                      | property (STRING) — opaque JSON payload      |
+| enqueue                                    | INSERT one index row (append, lock-free)     |
+| poll (`seq > offset`, optional `until`)    | bounded scan of the `seq ASC` index (OUT)    |
+| commit (`seq <= offset`)                   | scan-delete over that index range            |
 
 The backing table is append-only and index-only: an enqueue is a single index-row write, and a poll is a single bounded index scan. There is no per-message state, no ack flags, and no consumer registry.
 
@@ -69,11 +69,11 @@ poll(partition, offset) → process the batch → commit(partition, offset = bat
 
 A durable, partitioned, append-only log with a due-time filter — a log primitive, not a full message broker.
 
-| Use case                  | Fit     | Notes                                                            |
-| ------------------------- | ------- | ---------------------------------------------------------------- |
-| Refresh / delay scheduler | Good    | `until` withholds not-yet-due messages; commit clears fired ones |
+| Use case                  | Fit     | Notes                                                                                     |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| Refresh / delay scheduler | Good    | `until` withholds not-yet-due messages; commit clears fired ones                          |
 | Durable per-partition log | Partial | Replay by `offset`; retention is manual via commit (a delete), one consumer per partition |
-| Ack-based work queue      | No      | No per-message ack, visibility timeout, redelivery, or dead-letter |
+| Ack-based work queue      | No      | No per-message ack, visibility timeout, redelivery, or dead-letter                        |
 
 Not provided: message ack / redelivery, deduplication, independent consumer groups on one partition, and server-side long-poll or streaming.
 

--- a/website/src/content/docs/design/queue.mdx
+++ b/website/src/content/docs/design/queue.mdx
@@ -13,16 +13,19 @@ See the [Queue API Reference](/api-references/queue/) for endpoints.
 
 ## Architecture
 
-A queue is an immutable edge table with a fixed schema. Each queue concept maps directly onto an edge concept:
+A queue is an immutable edge table with a fixed schema and a fixed access pattern. Define a queue, and each part is exactly one thing on the underlying [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge):
 
-| Queue concept | Edge concept                                    |
-| ------------- | ----------------------------------------------- |
-| namespace     | database                                        |
-| queue         | table, type IMMUTABLE_EDGE                       |
-| partition     | source (LONG)                                   |
-| message id    | target (STRING) — a server-assigned ULID        |
-| seq           | property (LONG) — ordering key, also the index  |
-| value         | property (STRING) — opaque JSON payload         |
+| queue/v1                                   | Immutable edge table                          |
+| ------------------------------------------ | --------------------------------------------- |
+| namespace                                  | database                                      |
+| queue                                      | table, type IMMUTABLE_EDGE                     |
+| partition = `xxhash32(key) mod partitions` | source (LONG)                                 |
+| message id                                 | target (STRING) — a server-assigned ULID      |
+| seq (order / due time)                     | property (LONG) — the single `seq ASC` index  |
+| value                                      | property (STRING) — opaque JSON payload       |
+| enqueue                                    | INSERT one index row (append, lock-free)      |
+| poll (`seq > offset`, optional `until`)    | bounded scan of the `seq ASC` index (OUT)     |
+| commit (`seq <= offset`)                   | scan-delete over that index range             |
 
 The backing table is append-only and index-only: an enqueue is a single index-row write, and a poll is a single bounded index scan. There is no per-message state, no ack flags, and no consumer registry.
 
@@ -58,8 +61,21 @@ poll(partition, offset) → process the batch → commit(partition, offset = bat
 
 - **At-least-once**: commit only after processing. If a consumer crashes between poll and commit, the next poll re-reads the uncommitted messages.
 - **Ordered within a partition**: polls return messages in `seq` order; there is no ordering across partitions.
+- **Ordering key**: `seq` is a client-supplied, increasing key (a timestamp, LSN, or sequence number). Uniqueness is not required; the server-assigned ULID `id` keeps same-`seq` messages distinct.
 - **Commit is a real delete**: after a commit, re-polling from the start of the partition does not return the committed prefix.
 - **No CDC**: immutable edge tables do not emit CDC; the queue itself is the log.
+
+## Use Cases
+
+A durable, partitioned, append-only log with a due-time filter — a log primitive, not a full message broker.
+
+| Use case                  | Fit     | Notes                                                            |
+| ------------------------- | ------- | ---------------------------------------------------------------- |
+| Refresh / delay scheduler | Good    | `until` withholds not-yet-due messages; commit clears fired ones |
+| Durable per-partition log | Partial | Replay by `offset`; retention is manual via commit (a delete), one consumer per partition |
+| Ack-based work queue      | No      | No per-message ack, visibility timeout, redelivery, or dead-letter |
+
+Not provided: message ack / redelivery, deduplication, independent consumer groups on one partition, and server-side long-poll or streaming.
 
 ## Next Steps
 

--- a/website/src/content/docs/design/queue.mdx
+++ b/website/src/content/docs/design/queue.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-queue/v1 is a partitioned message queue built on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge). It provides ordered, partition-parallel delivery with an explicit consumer lifecycle: **poll → process → commit**.
+queue/v1 is a partitioned message queue built on an [immutable edge table](/design/schema/#immutable-edge-tables-type-immutable_indexed-v3-immutable_edge). Messages are ordered within a partition and parallel across partitions, with an explicit lifecycle: **poll → process → commit**.
 
 See the [Queue API Reference](/api-references/queue/) for endpoints.
 
@@ -24,7 +24,7 @@ A queue is an immutable edge table with a fixed schema. Each queue concept maps 
 | seq           | property (LONG) — ordering key, also the index  |
 | value         | property (STRING) — opaque JSON payload         |
 
-Because the backing table is append-only and index-only, an enqueue is a single index-row write and a poll is a single bounded index scan. There is no per-message state — no ack flags, no consumer registry.
+The backing table is append-only and index-only: an enqueue is a single index-row write, and a poll is a single bounded index scan. There is no per-message state, no ack flags, and no consumer registry.
 
 ## Partitioning
 
@@ -46,7 +46,7 @@ poll(partition, offset) → process the batch → commit(partition, offset = bat
 
 1. **Poll** scans one partition forward by `seq`. `offset` is exclusive (`seq > offset`); the response returns the batch and its next `offset` (the highest `seq` seen). An optional `until` bound (inclusive) restricts a poll to due messages when `seq` encodes a due time.
 2. **Process** the batch.
-3. **Commit** up to the batch's offset: every message with `seq <= offset` is **deleted**. There is no separate ack state — the delete *is* the committed position, and the same operation serves retention.
+3. **Commit** up to the batch's offset: every message with `seq <= offset` is deleted. There is no separate ack state; the delete is the committed position, and the same operation serves retention.
 
 <Aside type="caution">
   Commit deletes a prefix of the partition, so it assumes **one logical consumer per partition**
@@ -59,7 +59,7 @@ poll(partition, offset) → process the batch → commit(partition, offset = bat
 - **At-least-once**: commit only after processing. If a consumer crashes between poll and commit, the next poll re-reads the uncommitted messages.
 - **Ordered within a partition**: polls return messages in `seq` order; there is no ordering across partitions.
 - **Commit is a real delete**: after a commit, re-polling from the start of the partition does not return the committed prefix.
-- **No CDC**: immutable edge tables do not emit CDC — the queue itself is the log.
+- **No CDC**: immutable edge tables do not emit CDC; the queue itself is the log.
 
 ## Next Steps
 

--- a/website/src/content/docs/design/schema.mdx
+++ b/website/src/content/docs/design/schema.mdx
@@ -161,18 +161,17 @@ Useful for gradual migrations or domain-specific naming.
 
 v2 and v3 map almost 1:1.
 
-| v2 (Current)      | v3 (Future)    |
-| ----------------- | -------------- |
-| service           | database       |
-| label             | table          |
-| src               | source         |
-| tgt               | target         |
-| ts                | version        |
-| fields            | properties     |
-| dirType           | direction      |
-| indices           | indexes        |
-| desc              | comment        |
-| IMMUTABLE_INDEXED | IMMUTABLE_EDGE |
+| v2 (Current) | v3 (Future) |
+| ------------ | ----------- |
+| service      | database    |
+| label        | table       |
+| src          | source      |
+| tgt          | target      |
+| ts           | version     |
+| fields       | properties  |
+| dirType      | direction   |
+| indices      | indexes     |
+| desc         | comment     |
 
 ## Next Steps
 

--- a/website/src/content/docs/design/schema.mdx
+++ b/website/src/content/docs/design/schema.mdx
@@ -101,7 +101,7 @@ Indices are pre-computed at write time. See [Query](/design/query/).
 
 ### Immutable Edge Tables (type: IMMUTABLE_INDEXED, v3: IMMUTABLE_EDGE)
 
-An append-only variant of the indexed label. A regular edge tracks mutable state (a like can be un-liked); an immutable edge records facts that never change (an event log, a message queue). Only index rows are persisted — there is no state row, no count records, and no caches. The index rows *are* the record.
+An append-only variant of the indexed label. A regular edge tracks mutable state (a like can be un-liked); an immutable edge records facts that never change, such as an event log or a message queue. Only index rows are persisted: there is no state row, no count records, and no caches. The index rows are the record.
 
 | Property  | Constraint                                                          |
 | --------- | ------------------------------------------------------------------- |
@@ -109,15 +109,15 @@ An append-only variant of the indexed label. A regular edge tracks mutable state
 | dirType   | Single direction (OUT or IN) — BOTH is rejected                     |
 | mutations | INSERT only — UPDATE and DELETE are rejected                        |
 
-The constraints exist so that every persisted row is reachable by a single index scan: deleting the scanned rows is then a complete delete, which is what makes eviction (scan-delete) safe.
+These constraints ensure every persisted row is reachable by a single index scan, so deleting the scanned rows is a complete delete. That is what makes eviction (scan-delete) safe.
 
 Behavioral differences from a regular indexed label:
 
 | Operation           | Behavior                                                                 |
 | ------------------- | ------------------------------------------------------------------------ |
-| Point get           | Rejected — read with an index scan                                       |
-| Count / `total`     | Not supported — no count records are written                             |
-| CDC                 | Not emitted — the log itself is the change history                       |
+| Point get           | Rejected; read with an index scan                                        |
+| Count / `total`     | Not supported; no count records are written                              |
+| CDC                 | Not emitted; the log itself is the change history                        |
 | Eviction            | [Scan-delete](/api-references/mutation/#5-scan-delete-immutable-edge-tables) removes a scanned index range |
 
 **Example: Event Log**

--- a/website/src/content/docs/design/schema.mdx
+++ b/website/src/content/docs/design/schema.mdx
@@ -47,16 +47,16 @@ Example: an e-commerce service might contain labels for `likes`, `recent_views`,
 
 Defines the schema for edges—src, tgt, fields, and indices.
 
-| Property | Description                                           |
-| -------- | ----------------------------------------------------- |
-| name     | Format: `service.label`                               |
-| desc     | Description (v3: comment)                             |
+| Property | Description                                               |
+| -------- | --------------------------------------------------------- |
+| name     | Format: `service.label`                                   |
+| desc     | Description (v3: comment)                                 |
 | type     | Label type (INDEXED, HASH, MULTI_EDGE, IMMUTABLE_INDEXED) |
-| schema   | Edge structure (src, tgt, fields)                     |
-| dirType  | Direction type (v3: direction)                        |
-| storage  | Storage URI (e.g., `datastore://<namespace>/<table>`) |
-| indices  | Indices for querying (v3: indexes)                    |
-| active   | Whether active                                        |
+| schema   | Edge structure (src, tgt, fields)                         |
+| dirType  | Direction type (v3: direction)                            |
+| storage  | Storage URI (e.g., `datastore://<namespace>/<table>`)     |
+| indices  | Indices for querying (v3: indexes)                        |
+| active   | Whether active                                            |
 
 ### Schema Definition
 
@@ -103,22 +103,22 @@ Indices are pre-computed at write time. See [Query](/design/query/).
 
 An append-only variant of the indexed label. A regular edge tracks mutable state (a like can be un-liked); an immutable edge records facts that never change, such as an event log or a message queue. Only index rows are persisted: there is no state row, no count records, and no caches. The index rows are the record.
 
-| Property  | Constraint                                                          |
-| --------- | ------------------------------------------------------------------- |
-| indices   | At most one index                                                   |
-| dirType   | Single direction (OUT or IN) — BOTH is rejected                     |
-| mutations | INSERT only — UPDATE and DELETE are rejected                        |
+| Property  | Constraint                                      |
+| --------- | ----------------------------------------------- |
+| indices   | At most one index                               |
+| dirType   | Single direction (OUT or IN) — BOTH is rejected |
+| mutations | INSERT only — UPDATE and DELETE are rejected    |
 
 These constraints ensure every persisted row is reachable by a single index scan, so deleting the scanned rows is a complete delete. That is what makes eviction (scan-delete) safe.
 
 Behavioral differences from a regular indexed label:
 
-| Operation           | Behavior                                                                 |
-| ------------------- | ------------------------------------------------------------------------ |
-| Point get           | Rejected; read with an index scan                                        |
-| Count / `total`     | Not supported; no count records are written                              |
-| CDC                 | Not emitted; the log itself is the change history                        |
-| Eviction            | [Scan-delete](/api-references/mutation/#5-scan-delete-immutable-edge-tables) removes a scanned index range |
+| Operation       | Behavior                                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| Point get       | Rejected; read with an index scan                                                                          |
+| Count / `total` | Not supported; no count records are written                                                                |
+| CDC             | Not emitted; the log itself is the change history                                                          |
+| Eviction        | [Scan-delete](/api-references/mutation/#5-scan-delete-immutable-edge-tables) removes a scanned index range |
 
 **Example: Event Log**
 

--- a/website/src/content/docs/design/schema.mdx
+++ b/website/src/content/docs/design/schema.mdx
@@ -51,7 +51,7 @@ Defines the schema for edges—src, tgt, fields, and indices.
 | -------- | ----------------------------------------------------- |
 | name     | Format: `service.label`                               |
 | desc     | Description (v3: comment)                             |
-| type     | Label type (INDEXED, HASH, MULTI_EDGE)                |
+| type     | Label type (INDEXED, HASH, MULTI_EDGE, IMMUTABLE_INDEXED) |
 | schema   | Edge structure (src, tgt, fields)                     |
 | dirType  | Direction type (v3: direction)                        |
 | storage  | Storage URI (e.g., `datastore://<namespace>/<table>`) |
@@ -99,6 +99,43 @@ indices:
 
 Indices are pre-computed at write time. See [Query](/design/query/).
 
+### Immutable Edge Tables (type: IMMUTABLE_INDEXED, v3: IMMUTABLE_EDGE)
+
+An append-only variant of the indexed label. A regular edge tracks mutable state (a like can be un-liked); an immutable edge records facts that never change (an event log, a message queue). Only index rows are persisted — there is no state row, no count records, and no caches. The index rows *are* the record.
+
+| Property  | Constraint                                                          |
+| --------- | ------------------------------------------------------------------- |
+| indices   | At most one index                                                   |
+| dirType   | Single direction (OUT or IN) — BOTH is rejected                     |
+| mutations | INSERT only — UPDATE and DELETE are rejected                        |
+
+The constraints exist so that every persisted row is reachable by a single index scan: deleting the scanned rows is then a complete delete, which is what makes eviction (scan-delete) safe.
+
+Behavioral differences from a regular indexed label:
+
+| Operation           | Behavior                                                                 |
+| ------------------- | ------------------------------------------------------------------------ |
+| Point get           | Rejected — read with an index scan                                       |
+| Count / `total`     | Not supported — no count records are written                             |
+| CDC                 | Not emitted — the log itself is the change history                       |
+| Eviction            | [Scan-delete](/api-references/mutation/#5-scan-delete-immutable-edge-tables) removes a scanned index range |
+
+**Example: Event Log**
+
+```
+src: partition (LONG)
+tgt: event_id (STRING)
+fields:
+  - seq (LONG)
+  - payload (STRING)
+dirType: OUT
+indices:
+  - name: seq_asc
+    fields: [seq ASC]
+```
+
+Immutable edge tables back the [queue/v1 API](/design/queue/).
+
 ## Alias
 
 An alternative name for a label.
@@ -124,17 +161,18 @@ Useful for gradual migrations or domain-specific naming.
 
 v2 and v3 map almost 1:1.
 
-| v2 (Current) | v3 (Future) |
-| ------------ | ----------- |
-| service      | database    |
-| label        | table       |
-| src          | source      |
-| tgt          | target      |
-| ts           | version     |
-| fields       | properties  |
-| dirType      | direction   |
-| indices      | indexes     |
-| desc         | comment     |
+| v2 (Current)      | v3 (Future)    |
+| ----------------- | -------------- |
+| service           | database       |
+| label             | table          |
+| src               | source         |
+| tgt               | target         |
+| ts                | version        |
+| fields            | properties     |
+| dirType           | direction      |
+| indices           | indexes        |
+| desc              | comment        |
+| IMMUTABLE_INDEXED | IMMUTABLE_EDGE |
 
 ## Next Steps
 

--- a/website/src/content/docs/design/storage-backends.mdx
+++ b/website/src/content/docs/design/storage-backends.mdx
@@ -2,7 +2,7 @@
 title: Storage Backends
 description: Understanding storage backends in Actionbase
 sidebar:
-  order: 5
+  order: 6
 ---
 
 Actionbase abstracts storage through a minimal interface called `Datastore`. Different backends can be integrated.

--- a/website/src/content/docs/internals/encoding.mdx
+++ b/website/src/content/docs/internals/encoding.mdx
@@ -19,6 +19,8 @@ Actionbase stores edge data using multiple row types in the storage backend. Eac
 | Edge Index | -4        | Index entries      | Scan       |
 | Edge Count | -2        | Edge counts        | Count      |
 
+Immutable edge tables (`IMMUTABLE_INDEXED`) persist Edge Index rows only — no Edge State and no Edge Count. The index rows are the whole record, which is why point gets and counts are not supported on them and why deleting a scanned index range is a complete delete.
+
 ## Edge State (Type Code: -3)
 
 Stores the current state of edges for Get queries.

--- a/website/src/content/docs/internals/encoding.mdx
+++ b/website/src/content/docs/internals/encoding.mdx
@@ -19,7 +19,7 @@ Actionbase stores edge data using multiple row types in the storage backend. Eac
 | Edge Index | -4        | Index entries      | Scan       |
 | Edge Count | -2        | Edge counts        | Count      |
 
-Immutable edge tables (`IMMUTABLE_INDEXED`) persist Edge Index rows only — no Edge State and no Edge Count. The index rows are the whole record, which is why point gets and counts are not supported on them and why deleting a scanned index range is a complete delete.
+Immutable edge tables (`IMMUTABLE_INDEXED`) persist Edge Index rows only, with no Edge State and no Edge Count. The index rows are the whole record, so point gets and counts are not supported and deleting a scanned index range is a complete delete.
 
 ## Edge State (Type Code: -3)
 


### PR DESCRIPTION
## Summary

Document immutable edge tables and queue/v1 (shipped across #434 and #436–#441) on the docs site. English-only; the site falls back to English for untranslated pages.

## Changes

- New: `design/queue.mdx`, `api-references/queue.mdx`
- Updated: `design/schema.mdx`, `api-references/mutation.mdx`, `internals/encoding.mdx`

## How to Test

`cd website && CHECK_LINKS=true npm run build` — passes; all internal links valid.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code
