### PR TITLE
Support serializable date buckets in codec-java

### DIFF
--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Bucket.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Bucket.java
@@ -1,0 +1,152 @@
+package com.kakao.actionbase.v2.core.metadata;
+
+import com.kakao.actionbase.v2.core.types.DataType;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Ported from V3 {@code com.kakao.actionbase.core.metadata.common.Bucket}. Only the {@code date}
+ * bucket is supported, and only {@link #apply(Object)} (bulk-encoding time bucketing) is ported —
+ * {@code handleQueryValue} is query-time only and unused by bulk encoding.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(value = Bucket.Date.class, name = "date")})
+public abstract class Bucket implements Serializable {
+
+  public abstract String getName();
+
+  public abstract Object apply(Object value);
+
+  public static class Date extends Bucket {
+
+    @JsonProperty("name")
+    private final String name;
+
+    @JsonProperty("unit")
+    private final ValueUnit unit;
+
+    @JsonProperty("timezone")
+    private final String timezone;
+
+    @JsonProperty("format")
+    private final String format;
+
+    @JsonIgnore private final transient ZoneId zoneId;
+    @JsonIgnore private final transient DateTimeFormatter formatter;
+
+    @JsonCreator
+    public Date(
+        @JsonProperty("name") String name,
+        @JsonProperty("unit") ValueUnit unit,
+        @JsonProperty("timezone") String timezone,
+        @JsonProperty("format") String format) {
+      this.name = name;
+      this.unit = unit;
+      this.timezone = timezone;
+      this.format = format;
+      this.zoneId = ZoneId.of(timezone);
+      this.formatter = DateTimeFormatter.ofPattern(format);
+    }
+
+    private Object readResolve() {
+      return new Date(name, unit, timezone, format);
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public ValueUnit getUnit() {
+      return unit;
+    }
+
+    public String getTimezone() {
+      return timezone;
+    }
+
+    public String getFormat() {
+      return format;
+    }
+
+    @Override
+    public Object apply(Object value) {
+      if (value == null) return null;
+
+      try {
+        long longValue = (Long) DataType.LONG.cast(value);
+
+        Instant instant;
+        switch (unit) {
+          case NANOSECOND:
+            instant = Instant.ofEpochSecond(0, longValue);
+            break;
+          case MICROSECOND:
+            instant = Instant.ofEpochSecond(longValue / 1_000_000, (longValue % 1_000_000) * 1000);
+            break;
+          case MILLISECOND:
+            instant = Instant.ofEpochMilli(longValue);
+            break;
+          case SECOND:
+            instant = Instant.ofEpochSecond(longValue);
+            break;
+          default:
+            throw new IllegalArgumentException("Unsupported unit: " + unit);
+        }
+
+        return instant.atZone(zoneId).format(formatter);
+      } catch (Exception e) {
+        return null;
+      }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof Date)) return false;
+      Date other = (Date) obj;
+      return name.equals(other.name)
+          && unit == other.unit
+          && timezone.equals(other.timezone)
+          && format.equals(other.format);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, unit, timezone, format);
+    }
+
+    @Override
+    public String toString() {
+      return "Date{"
+          + "name='"
+          + name
+          + '\''
+          + ", unit="
+          + unit
+          + ", timezone='"
+          + timezone
+          + '\''
+          + ", format='"
+          + format
+          + '\''
+          + '}';
+    }
+  }
+
+  public enum ValueUnit {
+    NANOSECOND,
+    MICROSECOND,
+    MILLISECOND,
+    SECOND,
+  }
+}

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
@@ -95,13 +95,13 @@ public class Group implements Serializable {
     final Bucket bucket;
 
     @JsonCreator
-    public Field(@JsonProperty("name") String name, @JsonProperty("bucket") Bucket bucket) {
-      this.name = name;
-      this.bucket = bucket;
+    public Field(@JsonProperty("name") String name) {
+      this(name, null);
     }
 
-    public Field(String name) {
-      this(name, null);
+    public Field(String name, Bucket bucket) {
+      this.name = name;
+      this.bucket = bucket;
     }
 
     public String getName() {

--- a/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
+++ b/codec-java/src/main/java/com/kakao/actionbase/v2/core/metadata/Group.java
@@ -91,32 +91,49 @@ public class Group implements Serializable {
     @JsonProperty("name")
     final String name;
 
+    @JsonProperty("bucket")
+    final Bucket bucket;
+
     @JsonCreator
-    public Field(@JsonProperty("name") String name) {
+    public Field(@JsonProperty("name") String name, @JsonProperty("bucket") Bucket bucket) {
       this.name = name;
+      this.bucket = bucket;
+    }
+
+    public Field(String name) {
+      this(name, null);
     }
 
     public String getName() {
       return name;
     }
 
+    public Bucket getBucket() {
+      return bucket;
+    }
+
+    /** Applies {@link #bucket} to {@code value} if configured, otherwise returns it unchanged. */
+    public Object applyBucket(Object value) {
+      return bucket == null ? value : bucket.apply(value);
+    }
+
     @Override
     public String toString() {
-      return "Field{" + "name='" + name + '\'' + '}';
+      return "Field{" + "name='" + name + '\'' + ", bucket=" + bucket + '}';
     }
 
     @Override
     public boolean equals(Object obj) {
       if (obj instanceof Field) {
         Field other = (Field) obj;
-        return name.equals(other.name);
+        return name.equals(other.name) && Objects.equals(bucket, other.bucket);
       }
       return false;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name);
+      return Objects.hash(name, bucket);
     }
   }
 

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/BucketTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/BucketTests.java
@@ -1,0 +1,96 @@
+package com.kakao.actionbase.v2.core.metadata;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class BucketTests {
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  // 2026-06-11T00:00:00+09:00, expressed in each ValueUnit's granularity.
+  private static final long EPOCH_SECONDS = 1781103600L;
+  private static final long EPOCH_MILLIS = EPOCH_SECONDS * 1_000L;
+  private static final long EPOCH_MICROS = EPOCH_SECONDS * 1_000_000L;
+  private static final long EPOCH_NANOS = EPOCH_SECONDS * 1_000_000_000L;
+
+  @Test
+  void shouldFormatEpochSecondsAsDateString() {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_day", Bucket.ValueUnit.SECOND, "Asia/Seoul", "yyyy-MM-dd");
+
+    assertEquals("2026-06-11", bucket.apply(EPOCH_SECONDS));
+  }
+
+  @Test
+  void shouldFormatEpochMillisAsDateString() {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_day", Bucket.ValueUnit.MILLISECOND, "Asia/Seoul", "yyyy-MM-dd");
+
+    assertEquals("2026-06-11", bucket.apply(EPOCH_MILLIS));
+  }
+
+  @Test
+  void shouldFormatEpochMicrosAsDateString() {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_day", Bucket.ValueUnit.MICROSECOND, "Asia/Seoul", "yyyy-MM-dd");
+
+    assertEquals("2026-06-11", bucket.apply(EPOCH_MICROS));
+  }
+
+  @Test
+  void shouldFormatEpochNanosAsDateString() {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_day", Bucket.ValueUnit.NANOSECOND, "Asia/Seoul", "yyyy-MM-dd");
+
+    assertEquals("2026-06-11", bucket.apply(EPOCH_NANOS));
+  }
+
+  @Test
+  void shouldReturnNullForNullValue() {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_day", Bucket.ValueUnit.MILLISECOND, "Asia/Seoul", "yyyy-MM-dd");
+
+    assertNull(bucket.apply(null));
+  }
+
+  @Test
+  void shouldDeserializeFromJson() throws Exception {
+    String json =
+        "{\"type\":\"date\",\"name\":\"created_at_day\",\"unit\":\"MILLISECOND\",\"timezone\":\"Asia/Seoul\",\"format\":\"yyyy-MM-dd\"}";
+
+    Bucket bucket = objectMapper.readValue(json, Bucket.class);
+
+    assertTrue(bucket instanceof Bucket.Date);
+    assertEquals("created_at_day", bucket.getName());
+    assertEquals("2026-06-11", bucket.apply(EPOCH_MILLIS));
+  }
+
+  @Test
+  void shouldRemainUsableAfterJavaSerialization() throws Exception {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_hour", Bucket.ValueUnit.NANOSECOND, "+09:00", "yyyyMMdd'T'HH");
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(bucket);
+      serialized = bytes.toByteArray();
+    }
+
+    Bucket.Date restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored = (Bucket.Date) input.readObject();
+    }
+
+    assertEquals(bucket, restored);
+    assertEquals("20260611T00", restored.apply(EPOCH_NANOS));
+  }
+}

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class LabelDTOTests {
@@ -125,6 +126,28 @@ public class LabelDTOTests {
     Group.Field field = label.getGroups().get(0).getFields().get(0);
     assertTrue(field.getBucket() instanceof Bucket.Date);
     assertEquals("20260611T00", field.applyBucket(1_781_103_600_000_000_000L));
+  }
+
+  @Test
+  void shouldDeserializeOptionalGroupFieldBucketsWithStrictNullChecks()
+      throws JsonProcessingException {
+    ObjectMapper strictObjectMapper =
+        new ObjectMapper().enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES);
+    String jsonString =
+        "{\"group\":\"created_at_hour\",\"type\":\"COUNT\","
+            + "\"fields\":[{\"name\":\"eventType\"},{\"name\":\"gender\",\"bucket\":null},"
+            + "{\"name\":\"created_at\",\"bucket\":{\"type\":\"date\","
+            + "\"name\":\"created_at_hour\",\"unit\":\"NANOSECOND\","
+            + "\"timezone\":\"+09:00\",\"format\":\"yyyyMMdd'T'HH\"}}],"
+            + "\"valueField\":\"-\",\"comment\":\"\",\"directionType\":\"OUT\",\"ttl\":-1}";
+
+    Group group = strictObjectMapper.readValue(jsonString, Group.class);
+
+    assertNull(group.getFields().get(0).getBucket());
+    assertNull(group.getFields().get(1).getBucket());
+    Group.Field bucketedField = group.getFields().get(2);
+    assertTrue(bucketedField.getBucket() instanceof Bucket.Date);
+    assertEquals("20260611T00", bucketedField.applyBucket(1_781_103_600_000_000_000L));
   }
 
   @Test

--- a/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
+++ b/codec-java/src/test/java/com/kakao/actionbase/v2/core/metadata/LabelDTOTests.java
@@ -7,6 +7,10 @@ import com.kakao.actionbase.v2.core.code.Index;
 import com.kakao.actionbase.v2.core.code.hbase.Order;
 import com.kakao.actionbase.v2.core.types.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -101,5 +105,73 @@ public class LabelDTOTests {
     assertEquals(1, cache.getFields().size());
     assertEquals("created_at", cache.getFields().get(0).getField());
     assertEquals(Order.DESC, cache.getFields().get(0).getOrder());
+  }
+
+  @Test
+  void testGraphResponseDeserializationWithDateBucket() throws JsonProcessingException {
+    String jsonString =
+        "{\"name\":\"test.events\",\"desc\":\"\",\"type\":\"INDEXED\","
+            + "\"schema\":{\"src\":{\"type\":\"LONG\"},\"tgt\":{\"type\":\"STRING\"},"
+            + "\"fields\":[{\"name\":\"created_at\",\"type\":\"LONG\",\"nullable\":false}]},"
+            + "\"dirType\":\"OUT\",\"storage\":\"test_storage\",\"indices\":[],"
+            + "\"groups\":[{\"group\":\"created_at_hour\",\"type\":\"COUNT\","
+            + "\"fields\":[{\"name\":\"created_at\",\"bucket\":{\"type\":\"date\","
+            + "\"name\":\"created_at_hour\",\"unit\":\"NANOSECOND\",\"timezone\":\"+09:00\","
+            + "\"format\":\"yyyyMMdd'T'HH\"}}],\"directionType\":\"OUT\",\"ttl\":-1}],"
+            + "\"caches\":[],\"event\":false,\"readOnly\":false,\"mode\":\"ASYNC\"}";
+
+    LabelDTO label = objectMapper.readValue(jsonString, LabelDTO.class);
+
+    Group.Field field = label.getGroups().get(0).getFields().get(0);
+    assertTrue(field.getBucket() instanceof Bucket.Date);
+    assertEquals("20260611T00", field.applyBucket(1_781_103_600_000_000_000L));
+  }
+
+  @Test
+  void shouldRemainUsableAfterJavaSerializationWithDateBucket() throws Exception {
+    Bucket.Date bucket =
+        new Bucket.Date("created_at_hour", Bucket.ValueUnit.NANOSECOND, "+09:00", "yyyyMMdd'T'HH");
+    Group group =
+        new Group(
+            "created_at_hour",
+            GroupType.COUNT,
+            Collections.singletonList(new Group.Field("created_at", bucket)),
+            "-",
+            "",
+            DirectionType.OUT,
+            null);
+    LabelDTO label =
+        new LabelDTO(
+            "test.test",
+            "desc",
+            LabelType.INDEXED,
+            new EdgeSchema(
+                new VertexField(VertexType.LONG),
+                new VertexField(VertexType.STRING),
+                Collections.singletonList(new Field("created_at", DataType.LONG, false))),
+            DirectionType.OUT,
+            "test_storage",
+            Collections.emptyList(),
+            Collections.singletonList(group),
+            Collections.emptyList(),
+            false,
+            false,
+            MutationMode.ASYNC);
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(label);
+      serialized = bytes.toByteArray();
+    }
+
+    LabelDTO restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored = (LabelDTO) input.readObject();
+    }
+
+    Group.Field restoredField = restored.getGroups().get(0).getFields().get(0);
+    assertEquals(bucket, restoredField.getBucket());
+    assertEquals("20260611T00", restoredField.applyBucket(1_781_103_600_000_000_000L));
   }
 }


### PR DESCRIPTION
## Summary

At the time of this change, neither `main` nor `codec-java/0.4.x` defines date bucket metadata, and the published codec-java 0.4.0 artifact has no `Bucket` type or `Group.Field.bucket`. When metadata contains a date bucket, strict deserializers can reject the unknown `bucket` property and fail to load the metadata, while tolerant deserializers can silently discard the bucket definition. In the latter case, downstream bulk-load or distributed processing can group by raw timestamp values instead of the formatted bucket values expected by the metadata.

This PR adds date bucket metadata support to codec-java group fields and preserves compatibility with 0.4.0-shaped metadata where `bucket` is missing or explicitly null. It also keeps derived `ZoneId` and `DateTimeFormatter` state out of Java serialization and reconstructs that state after deserialization so nested `LabelDTO` metadata remains usable.

Closes: N/A

This PR is a prerequisite for #397 and should be merged first.

## Changes

- Add date bucket metadata and application to `Group.Field`.
- Keep optional buckets compatible with metadata where `bucket` is missing or null, including strict creator-null checks.
- Keep derived `ZoneId` and `DateTimeFormatter` state out of Java serialization and reconstruct it after deserialization.
- Cover value-unit conversion, missing/null/date bucket deserialization, and nested `LabelDTO` Java serialization round trips.

## How to Test

- [x] `./gradlew :codec-java:test --tests com.kakao.actionbase.v2.core.metadata.BucketTests --tests com.kakao.actionbase.v2.core.metadata.LabelDTOTests`
- [x] `./gradlew :codec-java:spotlessCheck`

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Codex / GPT-5.6 SOL

---
🤖 Generated with Codex (gpt-5.6-sol)
