### PR TITLE
docs: raise generalization to U2U/U2I/I2I

### DIFF
--- a/website/src/content/docs/design/concepts.mdx
+++ b/website/src/content/docs/design/concepts.mdx
@@ -12,22 +12,22 @@ Actionbase is a database for serving user interactions—not a general-purpose g
 - **Write-Time Optimization** — Pre-compute read structures at write time. Reads become simple lookups.
 - **Leverage Proven Storage** — Build on HBase for durability and scale. Don't reinvent storage.
 
-## User Interactions
+## Interaction Axes
 
-Actionbase handles:
+Every interaction is expressed in the same model — **who** did **what** to which **target** (_source → action → target_). The combination of source and target yields three axes:
 
-- Recent views (products, content)
-- Likes and reactions
-- Follows
+- **User–User (U2U)** — follow/unfollow, follower/following counts, timeline scans
+- **User–Item (U2I)** — likes/bookmarks, view history, bidirectional counters
+- **Item–Item (I2I)** — related products, similar-content graphs, and other precomputed item-to-item relations
 
-These share common characteristics: **who** did **what** to which **target**, real-time access, predictable query patterns.
+They look different on the surface, but share the same structure: real-time access with predictable query patterns.
 
 ## Property Graph Model
 
 Actionbase models interactions as edges:
 
-- **Source**: who (e.g., user_id)
-- **Target**: what (e.g., product_id, content_id, user_id)
+- **Source**: who or what acts (e.g., user_id, product_id)
+- **Target**: what is acted on (e.g., product_id, content_id, user_id)
 - **Properties**: schema-defined attributes (e.g., `created_at`, `reaction_type`)
 
 ```
@@ -44,6 +44,13 @@ User --[follows]--> User (edge)
   ├─ target: "user789"
   └─ properties: {
       created_at: 1234567891
+    }
+
+Product --[related]--> Product (edge)
+  ├─ source: "product456"
+  ├─ target: "product789"
+  └─ properties: {
+      score: 0.87
     }
 ```
 

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -7,9 +7,9 @@ description: Frequently asked questions about Actionbase
 
 ### What is Actionbase?
 
-Actionbase is a database for serving user interactions—likes, recent views, follows, reactions.
+Actionbase is a database for serving user interactions at scale, spanning three axes — user–user (U2U), user–item (U2I), and item–item (I2I).
 
-It models interactions as **who** did **what** to which **target**, and materializes read-optimized structures at write time. Reads use bounded access patterns (GET, SCAN, COUNT).
+It models every interaction the same way — **who** did **what** to which **target** — and materializes read-optimized structures at write time. Reads use bounded access patterns (GET, SCAN, COUNT).
 
 Actionbase is not a general-purpose graph database. It focuses on serving user interactions with predictable read patterns.
 
@@ -25,9 +25,9 @@ Internally, interactions are represented as edges in a graph. The terms "interac
 
 ### What problems does Actionbase solve?
 
-- Storing and querying recent views
-- Managing likes, reactions, and their counts
-- Handling follow relationships
+- **U2U** — follow relationships, follower/following counts, timelines
+- **U2I** — likes, reactions, view history, and their counts
+- **I2I** — related products and similar-content relations
 
 Instead of reimplementing indexing, ordering, and counting logic per service, Actionbase pre-computes these at write time.
 
@@ -191,7 +191,8 @@ For most teams, a well-tuned RDBMS handles this fine. Actionbase exists for case
 
 - Like buttons and reaction counts
 - "Recently viewed" lists
-- Follow/following feeds
+- Follow/following feeds and follower counts
+- Related products and similar-content lists
 - Per-user interaction histories
 
 When these outgrow your RDBMS—sharding gets painful, caches drift—Actionbase can take over.

--- a/website/src/content/docs/for-rdb-users.mdx
+++ b/website/src/content/docs/for-rdb-users.mdx
@@ -7,7 +7,7 @@ For users familiar with relational databases who want to understand how Actionba
 
 ## Why Consider Actionbase?
 
-As services grow, tables storing user interactions—likes, recent views, follows—often hit scaling walls:
+As services grow, tables storing user interactions—likes, recent views, follows, related items—often hit scaling walls:
 
 - Shard key management and hot entities
 - Cross-shard queries
@@ -22,11 +22,12 @@ In an RDB, interaction data often lives in tables like:
 - `user_follows` (user–user)
 - `user_likes` (user–item)
 - `user_views` (user–item)
+- `product_related` (item–item)
 
 In Actionbase, these become edges:
 
-- **Source**: who (e.g., user_id)
-- **Target**: what (e.g., product_id, user_id)
+- **Source**: who or what acts (e.g., user_id, product_id)
+- **Target**: what is acted on (e.g., product_id, user_id)
 - **Properties**: schema-defined (e.g., `created_at`)
 
 Read-optimized structures (indexes, counts) are pre-computed at write time.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ editUrl: false
 lastUpdated: false
 hero:
   title: Actionbase
-  tagline: One database for likes, views, and follows — pre-computed, served in real-time
+  tagline: One database for user–user, user–item, and item–item interactions — precomputed at write time, served as simple lookups
   image:
     file: ~/assets/hero.webp
   actions:
@@ -31,8 +31,8 @@ import { CardGrid, Card } from '@astrojs/starlight/components';
   <Card title="Pre-computed Reads" icon="star">
     Writes do the work. Reads return what's already computed.
   </Card>
-  <Card title="Likes · Views · Follows" icon="heart">
-    One model for common user interactions.
+  <Card title="U2U · U2I · I2I" icon="heart">
+    One model for user–user, user–item, and item–item interactions.
   </Card>
   <Card title="REST API" icon="forward-slash">
     Simple writes, fast reads — all via HTTP.

--- a/website/src/content/docs/introduction.mdx
+++ b/website/src/content/docs/introduction.mdx
@@ -3,13 +3,13 @@ title: Introduction
 description: Introduction to Actionbase
 ---
 
-Actionbase is a database for serving user interactions.
-It is designed to serve interaction-driven data in real time and is
-production-proven across Kakao services.
+Actionbase is a database for serving user interactions in real time, production-proven across Kakao services.
 
-Actionbase serves interaction-derived data—**likes**, **recent views**, **follows**, **reactions**—in real time.
+Follows, likes, recent views, related content — they are all **interaction data**. Every interaction is expressed in the same model — **who** did **what** to which **target** (_source → action → target_) — and the combination of source and target yields three axes:
 
-An interaction is modeled as: **who** did **what** to which **target**.
+- **User–User (U2U)** — follow/unfollow, follower/following counts, timeline scans
+- **User–Item (U2I)** — likes/bookmarks, view history, bidirectional counters
+- **Item–Item (I2I)** — related products, similar-content graphs, and other precomputed item-to-item relations
 
 Actionbase materializes read-optimized structures at write time. Reads use bounded access patterns (GET, COUNT, SCAN) without expensive computation.
 
@@ -17,13 +17,13 @@ When backed by HBase, Actionbase inherits durability and horizontal scalability.
 
 ## Focus
 
-| Focuses on                                          | Explicitly avoids                    |
-| --------------------------------------------------- | ------------------------------------ |
-| Real-time user interactions (likes, views, follows) | General-purpose graph queries        |
-| Bounded access patterns (GET, COUNT, SCAN)          | Unbounded traversal or analytics     |
-| Continuous writes, immediate reads                  | Batch ingestion or deferred indexing |
-| WAL/CDC to Kafka (yours or ours)                    | Owning downstream processing         |
-| Pluggable storage (HBase now, others planned)       | Building yet another storage engine  |
+| Focuses on                                    | Explicitly avoids                    |
+| --------------------------------------------- | ------------------------------------ |
+| Real-time interactions across U2U / U2I / I2I | General-purpose graph queries        |
+| Bounded access patterns (GET, COUNT, SCAN)    | Unbounded traversal or analytics     |
+| Continuous writes, immediate reads            | Batch ingestion or deferred indexing |
+| WAL/CDC to Kafka (yours or ours)              | Owning downstream processing         |
+| Pluggable storage (HBase now, others planned) | Building yet another storage engine  |
 
 ## Storage Backend
 


### PR DESCRIPTION
## Summary

The README was reframed around the U2U / U2I / I2I axes (#363), but the site docs still described Actionbase as likes/views/follows only, missing the item–item axis. This raises the conceptual/positioning docs to match.

## Changes

- `design/concepts.mdx` — "Interaction Axes" (U2U/U2I/I2I) + an I2I edge example
- `introduction.mdx` — three-axis framing + Focus table row
- `index.mdx` — hero tagline and card aligned with the README headline
- `faq.mdx` — definition, problems, and use cases cover all three axes
- `for-rdb-users.mdx` — add an item–item table mapping

Concrete walkthroughs (quick-start, guides, stories) keep their concrete examples, matching how the README keeps Quick Start concrete.

## How to Test

`cd website && CHECK_LINKS=true npm run build` — no new links introduced.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code
