### PR TITLE
docs: remove the open-source announcement banner

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -20,9 +20,6 @@ hero:
       icon: external
       variant: minimal
       link: https://github.com/kakao/actionbase
-
-banner:
-  content: '🚀 Open-sourced — <a href="/blog/open-source-announcement/">Learn more</a>'
 ---
 
 import { CardGrid, Card } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary

Remove the persistent "🚀 Open-sourced — Learn more" announcement banner from the landing page.

## Background

Actionbase was open-sourced on **2026-01-05 — more than six months ago**. A launch banner pinned to every page fits the first weeks after release, but six-plus months on it no longer reflects current news and adds permanent chrome to the landing page. The announcement post itself remains available under the blog for anyone who wants the backstory.

## Changes

- `index.mdx`: drop the `banner` frontmatter block

## How to Test

`cd website && CHECK_LINKS=true npm run build` — passes; all internal links valid.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code
