### PR TITLE
docs: retire GitHub Discussions links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,11 +105,10 @@ _Inspired by [SlateDB's contribution policy](https://github.com/slatedb/slatedb/
 
 We collaborate through [GitHub](https://github.com/kakao/actionbase):
 
-- **[Discussions](https://github.com/kakao/actionbase/discussions)**: Questions, ideas, and open-ended conversations
 - **[Issues](https://github.com/kakao/actionbase/issues)**: Bug reports, feature requests, and concrete improvements
 - **[Pull Requests](https://github.com/kakao/actionbase/pulls)**: Code and documentation changes
 
-For questions, ideas, or feedback, join us on [Discussions](https://github.com/kakao/actionbase/discussions).
+For questions, ideas, or feedback, open an [issue](https://github.com/kakao/actionbase/issues).
 
 Pull requests are reviewed collaboratively and merged by Maintainers.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,8 +11,8 @@ For practical guidance on how to contribute — see [Contributing](CONTRIBUTING.
   Maintainers have final decision-making authority.
   Under the current governance model, Maintainers are Kakao employees.
 
-- **Contributor**: Participates through code, documentation, issue reporting,
-  or discussions. Welcome from anywhere, regardless of affiliation.
+- **Contributor**: Participates through code, documentation, or issue
+  reporting. Welcome from anywhere, regardless of affiliation.
 
 ## Role Progression and Evolution
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -105,7 +105,6 @@ To participate:
 
 - Test RC versions in non-production environments
 - Report issues on [GitHub Issues](https://github.com/kakao/actionbase/issues)
-- Share feedback on [GitHub Discussions](https://github.com/kakao/actionbase/discussions)
 
 ## Support policy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,4 +41,4 @@ No timeline commitments. Items may shift based on community feedback.
 
 ## Feedback
 
-Have feedback on the roadmap? Join the discussion on [GitHub Discussions](https://github.com/kakao/actionbase/discussions).
+Have feedback on the roadmap? [Open an issue](https://github.com/kakao/actionbase/issues).

--- a/guides/build-your-social-app/src/components/layout/Layout.tsx
+++ b/guides/build-your-social-app/src/components/layout/Layout.tsx
@@ -146,7 +146,7 @@ const Layout: React.FC<SplitLayoutProps> = ({ children }) => {
                 Docs
               </a>
               <a
-                href="https://github.com/kakao/actionbase/discussions/94"
+                href="https://github.com/kakao/actionbase/issues"
                 target="_blank"
                 className="header-action"
                 title="Feedback"
@@ -326,7 +326,7 @@ const Layout: React.FC<SplitLayoutProps> = ({ children }) => {
               <div className="browser-help-notice">
                 <span>Stuck? Try restarting the server</span>
                 <a
-                  href="https://github.com/kakao/actionbase/discussions/94"
+                  href="https://github.com/kakao/actionbase/issues"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/guides/build-your-social-app/src/constants/stepsConfig.ts
+++ b/guides/build-your-social-app/src/constants/stepsConfig.ts
@@ -597,7 +597,7 @@ This is the core pattern behind most social apps.`,
 
 We built this guide to help you get to know Actionbase. We did our best, but it may fall short in places. We appreciate your understanding — and your feedback means a lot.
 
-<a href="https://github.com/kakao/actionbase/discussions/94" target="_blank">Share your thoughts</a>`,
+<a href="https://github.com/kakao/actionbase/issues" target="_blank">Share your thoughts</a>`,
     popover: { side: 'over', align: 'center' },
   },
 ];

--- a/website/src/content/docs/blog/hands-on-guide-story.mdx
+++ b/website/src/content/docs/blog/hands-on-guide-story.mdx
@@ -44,4 +44,4 @@ I believe Actionbase is good technology in its own right. But communicating that
 Good technology needs good communication to shine. I hope this guide is the start of that.
 
 - Try the hands-on guide: https://actionbase.io/guides/build-your-social-media-app/
-- Share your feedback: https://github.com/kakao/actionbase/discussions/94
+- Share your feedback: https://github.com/kakao/actionbase/issues

--- a/website/src/content/docs/guides/build-your-social-media-app.mdx
+++ b/website/src/content/docs/guides/build-your-social-media-app.mdx
@@ -494,7 +494,7 @@ You just built a feed with follows and likes - all powered by Actionbase.
 
 Was this guide helpful? Did Actionbase's concepts make sense? We'd love to hear your thoughts — questions, suggestions, or issues are all welcome.
 
-[Share feedback on GitHub Discussions](https://github.com/kakao/actionbase/discussions/94)
+[Open an issue on GitHub](https://github.com/kakao/actionbase/issues)
 
 ### Behind the Scenes
 

--- a/website/src/content/docs/llms-txt.mdx
+++ b/website/src/content/docs/llms-txt.mdx
@@ -57,4 +57,4 @@ https://actionbase.io/llms-full.txt
 
 ## Feedback
 
-Have tips for better prompts, questions, or suggestions? Share them in our [llms.txt discussion](https://github.com/kakao/actionbase/discussions/61).
+Have tips for better prompts, questions, or suggestions? [Open an issue](https://github.com/kakao/actionbase/issues) to share them.

--- a/website/src/content/docs/project/path-to-open-source.mdx
+++ b/website/src/content/docs/project/path-to-open-source.mdx
@@ -104,7 +104,11 @@ Inside a company, an internal service is just another API to call. Developers de
 
 We understand this. By open-sourcing Actionbase, we hope it can become part of architectures we never imagined.
 
-[More](https://github.com/kakao/actionbase/discussions/32)
+### Was It the Right Call?
+
+Actionbase runs in production at over a million requests per minute—but proving something works is not the same as proving it was the right call. What you see here is what survived: scaling walls, live incidents with users waiting, and fixes shipped while the complaints were still coming in.
+
+We took the consolidation path, and scaling came with it. If you've rebuilt the same interaction features across teams, or scaled a single system until it broke, we'd like to learn from it—whether you faced the same fork, or found a different way entirely.
 
 ### Acknowledgements
 

--- a/website/src/content/docs/stories/how-we-survived/index.mdx
+++ b/website/src/content/docs/stories/how-we-survived/index.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 Actionbase was deployed to production before it was "complete." It had to keep evolving while maintaining production contracts.
 
-Tests passed. But we couldn't confidently answer "is there really no problem?" We walked along [streams in Pangyo](https://github.com/kakao/actionbase/discussions/9) (Tancheon and Unjungcheon) discussing this concern. How could we build a state where even we could trust the system?
+Tests passed. But we couldn't confidently answer "is there really no problem?" We walked along streams in Pangyo (Tancheon and Unjungcheon) discussing this concern. How could we build a state where even we could trust the system?
 
 So we built verification layers.
 


### PR DESCRIPTION
## Summary

GitHub Discussions was removed and key threads were migrated to issues. This removes every remaining `discussions/*` link across the docs site, the repo markdown, and the guide app, following #360 / #364 (which migrated the README and dropped Discussions).

Two migrated threads are inlined rather than linked:

- **Path to Open Source** — folds issue #358 (the migrated "why we built this" thread) into a new "Was It the Right Call?" section, in the page's own voice. The Focus table and operations list from #358 are omitted; they already live in the docs.
- **How We Survived** — unlinks the "streams in Pangyo" mention. Its migrated thread (#359) is actually the logo discussion, so there is nothing verification-related to fold; the anecdote already reads inline.

Everything else points to GitHub Issues (the live channel) or drops the now-defunct Discussions entry.

## Changes

**Docs site (`/website`)**

- `project/path-to-open-source.mdx`: `[More]` link → "Was It the Right Call?" section
- `stories/how-we-survived/index.mdx`: unlink "streams in Pangyo"
- `llms-txt.mdx`, `guides/build-your-social-media-app.mdx`: discussion CTA → Issues

**Repo markdown**

- `CONTRIBUTING.md`: drop the Discussions channel; feedback pointer → Issues
- `RELEASES.md`: drop the "Share feedback on Discussions" bullet (Issues already listed)
- `ROADMAP.md`: roadmap-feedback CTA → Issues
- `GOVERNANCE.md`: drop "or discussions" from contributor channels

**Guide app**

- `build-your-social-app` (`stepsConfig.ts`, `Layout.tsx`): feedback links → Issues

## How to Test

`cd website && CHECK_LINKS=true npm run build` — passes; all internal links valid. `grep -rn "/discussions"` across the repo returns nothing.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code
