### PR TITLE
docs: align landing hero tagline with the GitHub description

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ editUrl: false
 lastUpdated: false
 hero:
   title: Actionbase
-  tagline: One database for user–user, user–item, and item–item interactions — precomputed at write time, served as simple lookups
+  tagline: One database for user-user (follows), user-item (likes), and item-item (related items) interactions — precomputed at write time, served as simple lookups
   image:
     file: ~/assets/hero.webp
   actions:


### PR DESCRIPTION
## Summary

Unify the product one-liner across the GitHub repo description and the docs-site landing hero. Keep the per-axis examples and use the "served as simple lookups" wording, which states Actionbase's actual read model (reads are bounded lookups with no read-time computation) rather than the generic "real-time".

- Before: `... interactions — precomputed, served in real-time`
- After: `One database for user-user (follows), user-item (likes), and item-item (related items) interactions — precomputed at write time, served as simple lookups`

The GitHub repo description was updated to the same string.

## Changes

- `index.mdx`: hero `tagline`

## How to Test

`cd website && CHECK_LINKS=true npm run build` — passes.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: claude code
