### PR TITLE
Clarify getTableBinding error message to cover the query path

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/v3/V2BackedEngine.kt
@@ -34,7 +34,8 @@ class V2BackedEngine(
         }
         if (label !is HBaseIndexedLabel) {
             throw UnsupportedOperationException(
-                "This Label (${label.entity.fullName}, ${label.javaClass}) is not indexed or not supported for edge mutation",
+                "This Label (${label.entity.fullName}, ${label.javaClass}) is not backed by an indexed label," +
+                    " so it cannot be bound on the V3 path (both query and edge mutation)",
             )
         }
         return label.tableBinding


### PR DESCRIPTION
## Summary

`V2BackedEngine.getTableBinding` serves both the query and the mutation path, but its `UnsupportedOperationException` said the label `is not indexed or not supported for edge mutation`. When the error fires on a GET request the message points the diagnosis at the wrong path. Reword it to name the V3 table binding and state that both query and edge mutation are affected.

## Changes

- Reword the `getTableBinding` error message in `V2BackedEngine` to cover both the query and the mutation path

## How to Test

```
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.*"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Fable 5)