### PR TITLE
Auto-create draft release with generated notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    labels:
+      - release
+    authors:
+      - github-actions
+      - dependabot

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -47,6 +47,15 @@ jobs:
           git tag "v${{ env.version }}"
           git push origin "v${{ env.version }}"
 
+      - name: Create draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ env.version }}" \
+            --draft \
+            --generate-notes \
+            --title "v${{ env.version }}"
+
       - name: Create release branch (minor release only)
         if: env.is_patch == 'false'
         run: |


### PR DESCRIPTION
## Summary

Post-release only creates the git tag; the GitHub release object and its notes are written by hand each time. A tag with no release is easy to miss (v0.4.7 was tagged with no release until it was created manually).

## Changes

- `post-release.yml`: after the tag is pushed, run `gh release create --draft --generate-notes` so every release gets a draft with auto-filled notes for a human to review and publish.
- `.github/release.yml`: exclude version-bump PRs (`release` label) and bot authors from the generated notes.

## How to Test

Merge a `release/v*` PR and confirm a **draft** release for the new tag appears under Releases with auto-generated notes (version-bump PR excluded).

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 4.8)