### PR TITLE
Add backward-compat test for HASH label table binding

### DIFF
--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/label/LabelSpec.kt
@@ -149,7 +149,7 @@ class LabelSpec :
         }
 
         fun testEmptySrcGet(label: Label) {
-            val dfMono = label.get(999, 10000, Direction.OUT, emptySet())
+            val dfMono = label.get(src = 999, tgt = 10000, dir = Direction.OUT, stats = emptySet())
             dfMono
                 .test()
                 .assertNext { it.rows.isEmpty() }

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/DatastoreHashLabelSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/DatastoreHashLabelSpec.kt
@@ -94,7 +94,7 @@ class DatastoreHashLabelSpec :
                 }.verifyComplete()
 
             label
-                .get(100, 1000, Direction.OUT, emptySet())
+                .get(src = 100, tgt = 1000, dir = Direction.OUT, stats = emptySet())
                 .test()
                 .assertNext { it.rows.size shouldBe 1 }
                 .verifyComplete()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
@@ -51,12 +51,12 @@ class HashLabelTableBindingTest {
     @ObjectSourceParameterizedTest
     @ObjectSource(
         """
-        - storage: hbase
-        - storage: datastore
+        - storage: storage_metadata
+        - storage: datastore_uri
         """,
     )
     fun `HASH label on storage resolves a V3 table binding`(storage: String) {
-        val storageUri = if (storage == "hbase") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
+        val storageUri = if (storage == "storage_metadata") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
         val labelName = EntityName(GraphFixtures.serviceName, "matrix_hash_$storage")
         val request =
             LabelCreateRequest(

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
@@ -144,7 +144,7 @@ class HashLabelTableBindingTest {
             .verifyComplete()
 
         label
-            .get(200L, 2000L, Direction.OUT, emptySet())
+            .get(src = 200L, tgt = 2000L, dir = Direction.OUT, stats = emptySet())
             .test()
             .assertNext { it.rows.size shouldBe 1 }
             .verifyComplete()

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.Direction
 import com.kakao.actionbase.v2.core.metadata.DirectionType
 import com.kakao.actionbase.v2.core.metadata.EdgeOperation
 import com.kakao.actionbase.v2.core.metadata.LabelType
@@ -38,12 +39,13 @@ import reactor.kotlin.test.test
  * Storage metadata removal in favor of `datastore://` URIs (#410), and HashLabel
  * removal in favor of IndexedLabel (#296 for HBase, #459 for datastore).
  *
- * | step                   | what it proves                                                |
- * |------------------------|---------------------------------------------------------------|
- * | create                 | bare-name resolves via storages map; `datastore://` needs no Storage metadata |
- * | instanceof check       | materializes as the IndexedLabel, not old HashLabel           |
- * | V3 mutate + gets       | V3 API resolves the table binding and round-trips             |
- * | legacy write → V3 read | rows written by the removed DatastoreHashLabel stay readable  |
+ * | step                | what it proves                                                |
+ * |---------------------|---------------------------------------------------------------|
+ * | create              | bare-name resolves via storages map; `datastore://` needs no Storage metadata |
+ * | instanceof check    | materializes as the IndexedLabel, not old HashLabel           |
+ * | V3 write / V3 read  | V3 API resolves the table binding and round-trips             |
+ * | V2 write / V2 read  | V2 engine path still round-trips on the same label            |
+ * | legacy rows → read  | rows written by the removed DatastoreHashLabel stay readable  |
  */
 @DisplayName("V2BackedEngine — HASH label table binding")
 class HashLabelTableBindingTest {
@@ -114,13 +116,15 @@ class HashLabelTableBindingTest {
         - storage: datastore_uri
         """,
     )
-    fun `HASH label mutates and queries through the V3 API`(storage: String) {
+    fun `HASH label round-trips on both the V3 and the V2 path`(storage: String) {
         val storageUri = if (storage == "storage_metadata") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
         val labelName = EntityName(database, "matrix_hash_$storage")
         createHashLabel(labelName, storageUri)
 
-        graph.getLabel(labelName).shouldBeInstanceOf<HBaseIndexedLabel>()
+        val label = graph.getLabel(labelName)
+        label.shouldBeInstanceOf<HBaseIndexedLabel>()
 
+        // V3 write / V3 read
         mutateV3(labelName.nameNotNull)
 
         queryService
@@ -130,6 +134,20 @@ class HashLabelTableBindingTest {
                 result.count shouldBe 2
                 result.edges.map { it.target } shouldBe listOf(1000L, 1001L)
             }.verifyComplete()
+
+        // V2 write / V2 read, on separate keys
+        val v2Edge = Edge(20L, 200L, 2000L, mapOf("createdAt" to 20L, "permission" to "me"))
+        graph
+            .mutate(labelName, label, listOf(v2Edge.toTraceEdge()), EdgeOperation.INSERT)
+            .test()
+            .assertNext { it.result.single().status shouldBe EdgeOperationStatus.CREATED }
+            .verifyComplete()
+
+        label
+            .get(200L, 2000L, Direction.OUT, emptySet())
+            .test()
+            .assertNext { it.rows.size shouldBe 1 }
+            .verifyComplete()
     }
 
     @Test

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
@@ -1,0 +1,95 @@
+package com.kakao.actionbase.v2.engine.v3
+
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.EdgeOperation
+import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
+import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
+import com.kakao.actionbase.v2.engine.service.ddl.DdlStatus
+import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
+import com.kakao.actionbase.v2.engine.test.GraphFixtures
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import reactor.kotlin.test.test
+
+/**
+ * Backward-compatibility guard for the two intertwined transitions on HASH labels:
+ * Storage metadata removal in favor of `datastore://` URIs (#410), and HashLabel
+ * removal in favor of IndexedLabel (#296 for HBase, #459 for datastore).
+ *
+ * | step             | what it proves                                               |
+ * |------------------|--------------------------------------------------------------|
+ * | create           | bare-name resolves via storages map; `datastore://` needs no Storage metadata |
+ * | instanceof check | materializes as the IndexedLabel, not old HashLabel          |
+ * | getTableBinding  | V3 binding gate accepts it                                   |
+ * | mutate + get     | HASH label is actually usable, not just structurally routed  |
+ */
+@DisplayName("V2BackedEngine — HASH label table binding")
+class HashLabelTableBindingTest {
+    private lateinit var graph: Graph
+
+    @BeforeEach
+    fun setUp() {
+        graph = GraphFixtures.create()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        graph.close()
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - storage: hbase
+        - storage: datastore
+        """,
+    )
+    fun `HASH label on storage resolves a V3 table binding`(storage: String) {
+        val storageUri = if (storage == "hbase") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
+        val labelName = EntityName(GraphFixtures.serviceName, "matrix_hash_$storage")
+        val request =
+            LabelCreateRequest(
+                desc = "HASH table binding regression coverage",
+                type = LabelType.HASH,
+                schema = GraphFixtures.sampleSchema,
+                dirType = DirectionType.OUT,
+                storage = storageUri,
+            )
+
+        graph.labelDdl
+            .create(labelName, request)
+            .test()
+            .assertNext { it.status shouldBe DdlStatus.Status.CREATED }
+            .verifyComplete()
+
+        val label = graph.getLabel(labelName)
+        label.shouldBeInstanceOf<HBaseIndexedLabel>()
+
+        val engine = V2BackedEngine(graph)
+        engine.getTableBinding(GraphFixtures.serviceName, labelName.nameNotNull)
+
+        graph
+            .mutate(label.name, label, GraphFixtures.sampleEdges.map { it.toTraceEdge() }, EdgeOperation.INSERT)
+            .test()
+            .assertNext {
+                it.result.count { r -> r.status == EdgeOperationStatus.CREATED } shouldBe GraphFixtures.sampleEdges.size
+            }.verifyComplete()
+
+        label
+            .get(100, 1000, Direction.OUT, emptySet())
+            .test()
+            .assertNext { it.rows.size shouldBe 1 }
+            .verifyComplete()
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/HashLabelTableBindingTest.kt
@@ -1,14 +1,21 @@
 package com.kakao.actionbase.v2.engine.v3
 
+import com.kakao.actionbase.engine.metadata.MutationMode as EngineMutationMode
+
+import com.kakao.actionbase.core.edge.payload.EdgeBulkMutationRequest
+import com.kakao.actionbase.engine.service.MutationService
+import com.kakao.actionbase.engine.service.QueryService
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
-import com.kakao.actionbase.v2.core.metadata.Direction
+import com.kakao.actionbase.v2.core.edge.Edge
 import com.kakao.actionbase.v2.core.metadata.DirectionType
 import com.kakao.actionbase.v2.core.metadata.EdgeOperation
 import com.kakao.actionbase.v2.core.metadata.LabelType
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.entity.LabelEntity
 import com.kakao.actionbase.v2.engine.label.EdgeOperationStatus
+import com.kakao.actionbase.v2.engine.label.hbase.HBaseHashLabel
 import com.kakao.actionbase.v2.engine.label.hbase.HBaseIndexedLabel
 import com.kakao.actionbase.v2.engine.service.ddl.DdlStatus
 import com.kakao.actionbase.v2.engine.service.ddl.LabelCreateRequest
@@ -17,6 +24,10 @@ import com.kakao.actionbase.v2.engine.test.GraphFixtures
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -27,20 +38,25 @@ import reactor.kotlin.test.test
  * Storage metadata removal in favor of `datastore://` URIs (#410), and HashLabel
  * removal in favor of IndexedLabel (#296 for HBase, #459 for datastore).
  *
- * | step             | what it proves                                               |
- * |------------------|--------------------------------------------------------------|
- * | create           | bare-name resolves via storages map; `datastore://` needs no Storage metadata |
- * | instanceof check | materializes as the IndexedLabel, not old HashLabel          |
- * | getTableBinding  | V3 binding gate accepts it                                   |
- * | mutate + get     | HASH label is actually usable, not just structurally routed  |
+ * | step                   | what it proves                                                |
+ * |------------------------|---------------------------------------------------------------|
+ * | create                 | bare-name resolves via storages map; `datastore://` needs no Storage metadata |
+ * | instanceof check       | materializes as the IndexedLabel, not old HashLabel           |
+ * | V3 mutate + gets       | V3 API resolves the table binding and round-trips             |
+ * | legacy write → V3 read | rows written by the removed DatastoreHashLabel stay readable  |
  */
 @DisplayName("V2BackedEngine — HASH label table binding")
 class HashLabelTableBindingTest {
     private lateinit var graph: Graph
+    private lateinit var mutationService: MutationService
+    private lateinit var queryService: QueryService
 
     @BeforeEach
     fun setUp() {
         graph = GraphFixtures.create()
+        val engine = V2BackedEngine(graph)
+        mutationService = MutationService(engine)
+        queryService = QueryService(engine)
     }
 
     @AfterEach
@@ -48,19 +64,25 @@ class HashLabelTableBindingTest {
         graph.close()
     }
 
-    @ObjectSourceParameterizedTest
-    @ObjectSource(
+    private val database = GraphFixtures.serviceName
+
+    private val mutationRequest =
         """
-        - storage: storage_metadata
-        - storage: datastore_uri
-        """,
-    )
-    fun `HASH label on storage resolves a V3 table binding`(storage: String) {
-        val storageUri = if (storage == "storage_metadata") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
-        val labelName = EntityName(GraphFixtures.serviceName, "matrix_hash_$storage")
+        {
+          "mutations": [
+            {"type": "INSERT", "edge": {"version": 10, "source": 100, "target": 1000, "properties": {"createdAt": 10, "permission": "na"}}},
+            {"type": "INSERT", "edge": {"version": 11, "source": 100, "target": 1001, "properties": {"createdAt": 11, "permission": "others"}}}
+          ]
+        }
+        """.trimIndent()
+
+    private fun createHashLabel(
+        labelName: EntityName,
+        storageUri: String,
+    ) {
         val request =
             LabelCreateRequest(
-                desc = "HASH table binding regression coverage",
+                desc = "HASH table binding compatibility coverage",
                 type = LabelType.HASH,
                 schema = GraphFixtures.sampleSchema,
                 dirType = DirectionType.OUT,
@@ -72,24 +94,94 @@ class HashLabelTableBindingTest {
             .test()
             .assertNext { it.status shouldBe DdlStatus.Status.CREATED }
             .verifyComplete()
+    }
 
-        val label = graph.getLabel(labelName)
-        label.shouldBeInstanceOf<HBaseIndexedLabel>()
-
-        val engine = V2BackedEngine(graph)
-        engine.getTableBinding(GraphFixtures.serviceName, labelName.nameNotNull)
-
-        graph
-            .mutate(label.name, label, GraphFixtures.sampleEdges.map { it.toTraceEdge() }, EdgeOperation.INSERT)
+    private fun mutateV3(table: String) {
+        val request = mapper.readValue<EdgeBulkMutationRequest>(mutationRequest)
+        mutationService
+            .mutate(database, table, request.mutations, syncMode = EngineMutationMode.SYNC)
             .test()
-            .assertNext {
-                it.result.count { r -> r.status == EdgeOperationStatus.CREATED } shouldBe GraphFixtures.sampleEdges.size
+            .assertNext { results ->
+                results.size shouldBe 2
+                results.all { it.status == "CREATED" } shouldBe true
+            }.verifyComplete()
+    }
+
+    @ObjectSourceParameterizedTest
+    @ObjectSource(
+        """
+        - storage: storage_metadata
+        - storage: datastore_uri
+        """,
+    )
+    fun `HASH label mutates and queries through the V3 API`(storage: String) {
+        val storageUri = if (storage == "storage_metadata") GraphFixtures.hbaseStorage else GraphFixtures.datastoreStorage
+        val labelName = EntityName(database, "matrix_hash_$storage")
+        createHashLabel(labelName, storageUri)
+
+        graph.getLabel(labelName).shouldBeInstanceOf<HBaseIndexedLabel>()
+
+        mutateV3(labelName.nameNotNull)
+
+        queryService
+            .gets(database, labelName.nameNotNull, listOf(100L), listOf(1000L, 1001L))
+            .test()
+            .assertNext { result ->
+                result.count shouldBe 2
+                result.edges.map { it.target } shouldBe listOf(1000L, 1001L)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `V3 API reads and extends rows written by the removed DatastoreHashLabel`() {
+        val storageUri = GraphFixtures.datastoreStorage
+        val labelName = EntityName(database, "legacy_hash_datastore")
+        createHashLabel(labelName, storageUri)
+
+        // Same shape as the removed DatastoreHashLabel: HBaseHashLabel base, byte-array
+        // key-value coder, table resolved from the datastore URI.
+        val legacyEntity =
+            LabelEntity(
+                active = true,
+                name = labelName,
+                desc = "legacy writer",
+                type = LabelType.HASH,
+                schema = GraphFixtures.sampleSchema,
+                dirType = DirectionType.OUT,
+                storage = storageUri,
+            )
+        val legacyLabel =
+            HBaseHashLabel(
+                entity = legacyEntity,
+                coder = graph.edgeEncoderFactory.bytesKeyValueEncoder,
+                tables = graph.datastore.getTable(storageUri).cache(),
+            )
+
+        val legacyEdge = Edge(12L, 100L, 1002L, mapOf("createdAt" to 12L, "permission" to "me"))
+        graph
+            .mutate(labelName, legacyLabel, listOf(legacyEdge.toTraceEdge()), EdgeOperation.INSERT)
+            .test()
+            .assertNext { it.result.single().status shouldBe EdgeOperationStatus.CREATED }
+            .verifyComplete()
+
+        queryService
+            .gets(database, labelName.nameNotNull, listOf(legacyEdge.src), listOf(legacyEdge.tgt))
+            .test()
+            .assertNext { result ->
+                result.count shouldBe 1
+                result.edges.single().properties["permission"] shouldBe legacyEdge.props["permission"]
             }.verifyComplete()
 
-        label
-            .get(100, 1000, Direction.OUT, emptySet())
+        mutateV3(labelName.nameNotNull)
+
+        queryService
+            .gets(database, labelName.nameNotNull, listOf(100L), listOf(1000L, 1001L, 1002L))
             .test()
-            .assertNext { it.rows.size shouldBe 1 }
+            .assertNext { result -> result.count shouldBe 3 }
             .verifyComplete()
+    }
+
+    companion object {
+        private val mapper = jacksonObjectMapper()
     }
 }


### PR DESCRIPTION
## Summary

#459 shipped without a test that would have caught it: no unit test covered a HASH label on datastore storage reaching the V3 table binding. This adds a backward-compatibility guard for the two intertwined transitions on HASH labels — Storage metadata removal in favor of `datastore://` URIs (#410) and HashLabel removal in favor of IndexedLabel (#296 for HBase, #459 for datastore).

Per resolution path (bare-name Storage metadata, unregistered `datastore://` URI), the test verifies: create resolves, the label materializes as an IndexedLabel (not the old HashLabel), and both production paths round-trip within themselves on separate keys — V3 write/read through `MutationService`/`QueryService` (the path the original incident hit) and V2 write/read through `graph.mutate`/`label.get`. A third case writes rows through an `HBaseHashLabel` writer (the shape of the removed `DatastoreHashLabel`) and verifies the current read path serves them and new writes extend the same table — backing the no-data-migration claim of #459. Reverting the #459 fix locally makes exactly the datastore case fail, so the test reproduces the original bug.

## Changes

- Add `HashLabelTableBindingTest` (JUnit 5 + `@ObjectSource`): storage_metadata/datastore_uri parameterized V3+V2 round-trips, plus legacy-written-rows compatibility case
- Use named arguments at `Label.get` call sites in `DatastoreHashLabelSpec` and `LabelSpec` — `get(100, 1000, ...)` reads as (source, limit) but the second argument is the target

## How to Test

```
./gradlew :engine:test --tests "com.kakao.actionbase.v2.engine.v3.HashLabelTableBindingTest"
```

Full `:engine:test` passes locally.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Fable 5)
