### PR TITLE
Add a Decision issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/decision.md
+++ b/.github/ISSUE_TEMPLATE/decision.md
@@ -1,0 +1,19 @@
+---
+name: Decision
+about: Record an architecture or product decision (Maintainers only)
+title: ''
+labels: decision
+assignees: ''
+---
+
+## Context
+
+What is the situation, and what forces are at play?
+
+## Decision
+
+What are we doing, and why this over the alternatives?
+
+## Consequences
+
+What becomes easier, what breaks, and what follows from this?


### PR DESCRIPTION
## Summary

Add a `Decision` issue template to record architecture and product decisions in Context / Decision / Consequences form, labeled `decision`.

## Changes

- Add `.github/ISSUE_TEMPLATE/decision.md`

## How to Test

Front matter follows the existing templates; the template appears in the new-issue chooser once merged. The `decision` label must exist for auto-labeling.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Fable 5)
