### PR TITLE
Resolve an omitted datastore:// namespace to the backend default

### DIFF
--- a/cli/internal/command/migrate.go
+++ b/cli/internal/command/migrate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/kakao/actionbase/internal/client"
@@ -73,15 +74,20 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 	// with the reason if a label actually references one.
 	storageURIByName := map[string]string{}
 	storageErrByName := map[string]error{}
+	droppedNamespaces := map[string]struct{}{}
 	if resp := m.client.GetStorages(); !resp.IsError() {
 		for _, s := range resp.Body.Content {
 			if uri, err := storageToDatastoreURI(s); err != nil {
 				storageErrByName[s.Name] = err
 			} else {
 				storageURIByName[s.Name] = uri
+				if ns := confString(s.Conf, "namespace"); ns != "" {
+					droppedNamespaces[ns] = struct{}{}
+				}
 			}
 		}
 	}
+	reportDroppedNamespaces(droppedNamespaces)
 
 	var plan []migrationEntry
 	add := func(path string, body map[string]any, label string) {
@@ -241,6 +247,27 @@ func storageToDatastoreURI(s clientModel.StorageEntity) (string, error) {
 		return "", fmt.Errorf("HBASE storage %q conf is missing tableName", s.Name)
 	}
 	return fmt.Sprintf("%s/%s", datastoreURIPrefix, tableName), nil
+}
+
+// reportDroppedNamespaces surfaces the source namespaces the rewrite drops.
+// The rewritten refs omit the namespace, so the server resolves them to the
+// target deployment's configured namespace. If more than one source namespace
+// appears, tables that were not in the target's default namespace would be
+// silently repointed — the operator must verify before applying.
+func reportDroppedNamespaces(namespaces map[string]struct{}) {
+	if len(namespaces) == 0 {
+		return
+	}
+	names := make([]string, 0, len(namespaces))
+	for ns := range namespaces {
+		names = append(names, ns)
+	}
+	sort.Strings(names)
+	util.Print("Note: rewritten refs omit the source namespace and resolve to the target deployment's configured namespace.\n")
+	util.Print("      Source namespaces seen: %s\n", strings.Join(names, ", "))
+	if len(names) > 1 {
+		util.Print("      WARNING: multiple source namespaces — tables not in the target's default namespace will be repointed. Verify before apply.\n")
+	}
 }
 
 func confString(conf map[string]any, key string) string {

--- a/cli/internal/command/migrate.go
+++ b/cli/internal/command/migrate.go
@@ -228,16 +228,19 @@ func tableBody(t clientModel.TableEntity, uriByName map[string]string, errByName
 // URI. The engine resolves every datastore:// URI except the reserved
 // __sys__ metastore as an HBase namespace/table, so non-HBASE storages have
 // no URI to mint — they return an error instead.
+//
+// The namespace is omitted (datastore:///<table>) so the rewritten reference
+// stays portable across environments; the server resolves it to the namespace
+// configured for the target deployment.
 func storageToDatastoreURI(s clientModel.StorageEntity) (string, error) {
 	if s.Type != "HBASE" {
 		return "", fmt.Errorf("storage type %s has no datastore:// equivalent", s.Type)
 	}
-	namespace := confString(s.Conf, "namespace")
 	tableName := confString(s.Conf, "tableName")
-	if namespace == "" || tableName == "" {
-		return "", fmt.Errorf("HBASE storage %q conf is missing namespace/tableName", s.Name)
+	if tableName == "" {
+		return "", fmt.Errorf("HBASE storage %q conf is missing tableName", s.Name)
 	}
-	return fmt.Sprintf("%s%s/%s", datastoreURIPrefix, namespace, tableName), nil
+	return fmt.Sprintf("%s/%s", datastoreURIPrefix, tableName), nil
 }
 
 func confString(conf map[string]any, key string) string {

--- a/cli/internal/command/migrate.go
+++ b/cli/internal/command/migrate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -17,6 +18,12 @@ const (
 	defaultPlanFile    = "migration-run.json"
 	datastoreURIPrefix = "datastore://"
 )
+
+// A datastore:// segment starts with a lowercase letter, then lowercase
+// alphanumeric/underscore. Legacy HBASE conf.tableName was never held to that
+// rule, so a name the server would reject has to fail in the plan rather than
+// halfway through apply.
+var datastoreSegment = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // migrationEntry is one POST the apply phase will replay. It mirrors the JSON
 // shape of the previous dev/migration-run.py plan: a path, a request body, and
@@ -74,20 +81,18 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 	// with the reason if a label actually references one.
 	storageURIByName := map[string]string{}
 	storageErrByName := map[string]error{}
-	droppedNamespaces := map[string]struct{}{}
+	namespaceByStorageName := map[string]string{}
 	if resp := m.client.GetStorages(); !resp.IsError() {
 		for _, s := range resp.Body.Content {
 			if uri, err := storageToDatastoreURI(s); err != nil {
 				storageErrByName[s.Name] = err
 			} else {
 				storageURIByName[s.Name] = uri
-				if ns := confString(s.Conf, "namespace"); ns != "" {
-					droppedNamespaces[ns] = struct{}{}
-				}
+				namespaceByStorageName[s.Name] = confString(s.Conf, "namespace")
 			}
 		}
 	}
-	reportDroppedNamespaces(droppedNamespaces)
+	referencedStorages := map[string]struct{}{}
 
 	var plan []migrationEntry
 	add := func(path string, body map[string]any, label string) {
@@ -118,6 +123,7 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 				if err != nil {
 					return model.Fail(fmt.Sprintf("Cannot plan label %s.%s: %v", db.Name, short, err))
 				}
+				referencedStorages[detail.Body.Storage] = struct{}{}
 				tables++
 				add(fmt.Sprintf("/graph/v2/service/%s/label/%s", db.Name, short),
 					body,
@@ -138,6 +144,8 @@ func (m *Migrate) plan(outputPath string) *model.Response {
 			}
 		}
 	}
+
+	reportDroppedNamespaces(droppedNamespaces(referencedStorages, namespaceByStorageName))
 
 	data, err := json.MarshalIndent(plan, "", "  ")
 	if err != nil {
@@ -246,7 +254,25 @@ func storageToDatastoreURI(s clientModel.StorageEntity) (string, error) {
 	if tableName == "" {
 		return "", fmt.Errorf("HBASE storage %q conf is missing tableName", s.Name)
 	}
+	if !datastoreSegment.MatchString(tableName) {
+		return "", fmt.Errorf(
+			"HBASE storage %q table name %q is not a legal datastore:// segment (lowercase letter first, then lowercase alphanumeric/underscore)",
+			s.Name, tableName)
+	}
 	return fmt.Sprintf("%s/%s", datastoreURIPrefix, tableName), nil
+}
+
+// droppedNamespaces returns the source namespaces of the storages a label
+// actually references. Unreferenced storages are excluded: counting them would
+// warn about namespaces no rewritten ref ever pointed at.
+func droppedNamespaces(referenced map[string]struct{}, namespaceByStorageName map[string]string) map[string]struct{} {
+	dropped := map[string]struct{}{}
+	for name := range referenced {
+		if ns := namespaceByStorageName[name]; ns != "" {
+			dropped[ns] = struct{}{}
+		}
+	}
+	return dropped
 }
 
 // reportDroppedNamespaces surfaces the source namespaces the rewrite drops.

--- a/cli/internal/command/migrate_test.go
+++ b/cli/internal/command/migrate_test.go
@@ -15,13 +15,22 @@ func TestStorageToDatastoreURI(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "HBASE uses namespace and tableName from conf",
+			name: "HBASE omits the namespace, keeping only the table",
 			storage: clientModel.StorageEntity{
 				Name: "default_hbase_storage",
 				Type: "HBASE",
 				Conf: map[string]any{"namespace": "kc_graph", "tableName": "edges"},
 			},
-			expected: "datastore://kc_graph/edges",
+			expected: "datastore:///edges",
+		},
+		{
+			name: "HBASE without a namespace still converts",
+			storage: clientModel.StorageEntity{
+				Name: "no_ns",
+				Type: "HBASE",
+				Conf: map[string]any{"tableName": "edges"},
+			},
+			expected: "datastore:///edges",
 		},
 		{
 			name:    "JDBC has no datastore equivalent",
@@ -70,7 +79,7 @@ func TestStorageToDatastoreURI(t *testing.T) {
 }
 
 func TestTableBody(t *testing.T) {
-	uriByName := map[string]string{"default_hbase_storage": "datastore://kc_graph/edges"}
+	uriByName := map[string]string{"default_hbase_storage": "datastore:///edges"}
 	errByName := map[string]error{"metastore": errors.New("storage type JDBC has no datastore:// equivalent")}
 
 	t.Run("legacy storage name is rewritten to its URI", func(t *testing.T) {
@@ -78,8 +87,8 @@ func TestTableBody(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if body["storage"] != "datastore://kc_graph/edges" {
-			t.Errorf("storage = %q, want datastore://kc_graph/edges", body["storage"])
+		if body["storage"] != "datastore:///edges" {
+			t.Errorf("storage = %q, want datastore:///edges", body["storage"])
 		}
 	})
 

--- a/cli/internal/command/migrate_test.go
+++ b/cli/internal/command/migrate_test.go
@@ -56,6 +56,24 @@ func TestStorageToDatastoreURI(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "a table name the server would reject fails in the plan",
+			storage: clientModel.StorageEntity{
+				Name: "legacy_mixed_case",
+				Type: "HBASE",
+				Conf: map[string]any{"namespace": "kc_graph", "tableName": "Edges"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "a hyphenated table name fails in the plan",
+			storage: clientModel.StorageEntity{
+				Name: "legacy_hyphen",
+				Type: "HBASE",
+				Conf: map[string]any{"namespace": "kc_graph", "tableName": "edge-cache"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -76,6 +94,41 @@ func TestStorageToDatastoreURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDroppedNamespaces(t *testing.T) {
+	namespaceByStorageName := map[string]string{
+		"referenced":   "kc_graph",
+		"unreferenced": "other_ns",
+		"no_namespace": "",
+	}
+
+	t.Run("only referenced storages contribute a namespace", func(t *testing.T) {
+		got := droppedNamespaces(map[string]struct{}{"referenced": {}}, namespaceByStorageName)
+
+		if len(got) != 1 {
+			t.Fatalf("droppedNamespaces = %v, want exactly kc_graph", got)
+		}
+		if _, ok := got["kc_graph"]; !ok {
+			t.Errorf("droppedNamespaces = %v, want kc_graph", got)
+		}
+	})
+
+	t.Run("a storage without a namespace contributes nothing", func(t *testing.T) {
+		got := droppedNamespaces(map[string]struct{}{"no_namespace": {}}, namespaceByStorageName)
+
+		if len(got) != 0 {
+			t.Errorf("droppedNamespaces = %v, want empty", got)
+		}
+	})
+
+	t.Run("a ref that is already a URI contributes nothing", func(t *testing.T) {
+		got := droppedNamespaces(map[string]struct{}{"datastore:///edges": {}}, namespaceByStorageName)
+
+		if len(got) != 0 {
+			t.Errorf("droppedNamespaces = %v, want empty", got)
+		}
+	})
 }
 
 func TestTableBody(t *testing.T) {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -46,8 +46,11 @@ object Constants {
         const val COMMENT_MAX_LENGTH = 1000
         const val COMMENT_SIZE_MESSAGE = "comment must be at most $COMMENT_MAX_LENGTH characters"
 
-        const val STORAGE_URI_PATTERN = "^datastore://([a-z][a-z0-9_]*)?/[a-z][a-z0-9_]*$"
-        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table>, with the namespace optional (datastore:///<table> resolves to the configured default). Each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table or datastore:///my_table)"
+        // Namespace optional (datastore:///<table> resolves to the configured default).
+        // Segments are lowercase alphanumeric/underscore; a `__` prefix is reserved for
+        // system names (e.g. datastore://__sys__/metastore) and rejected on user input.
+        const val STORAGE_URI_PATTERN = "^datastore://((?!__)[a-z0-9_]+)?/(?!__)[a-z0-9_]+$"
+        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table>, with the namespace optional (datastore:///<table> resolves to the configured default). Each segment contains only lowercase alphanumeric/underscore and must not start with '__', which is reserved for system names (e.g., datastore://my_namespace/my_table or datastore:///my_table)"
     }
 
     object Group {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -46,8 +46,8 @@ object Constants {
         const val COMMENT_MAX_LENGTH = 1000
         const val COMMENT_SIZE_MESSAGE = "comment must be at most $COMMENT_MAX_LENGTH characters"
 
-        const val STORAGE_URI_PATTERN = "^datastore://[a-z][a-z0-9_]*/[a-z][a-z0-9_]*$"
-        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table> where each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table)"
+        const val STORAGE_URI_PATTERN = "^datastore://([a-z][a-z0-9_]*)?/[a-z][a-z0-9_]*$"
+        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table>, with the namespace optional (datastore:///<table> resolves to the configured default). Each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore (e.g., datastore://my_namespace/my_table or datastore:///my_table)"
     }
 
     object Group {

--- a/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
+++ b/core/src/main/kotlin/com/kakao/actionbase/core/Constants.kt
@@ -47,10 +47,11 @@ object Constants {
         const val COMMENT_SIZE_MESSAGE = "comment must be at most $COMMENT_MAX_LENGTH characters"
 
         // Namespace optional (datastore:///<table> resolves to the configured default).
-        // Segments are lowercase alphanumeric/underscore; a `__` prefix is reserved for
-        // system names (e.g. datastore://__sys__/metastore) and rejected on user input.
-        const val STORAGE_URI_PATTERN = "^datastore://((?!__)[a-z0-9_]+)?/(?!__)[a-z0-9_]+$"
-        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table>, with the namespace optional (datastore:///<table> resolves to the configured default). Each segment contains only lowercase alphanumeric/underscore and must not start with '__', which is reserved for system names (e.g., datastore://my_namespace/my_table or datastore:///my_table)"
+        // Segments start with a lowercase letter, as every other name does, which leaves
+        // the fully delimited __x__ form to system names (e.g. datastore://__sys__/metastore)
+        // and out of reach of user input.
+        const val STORAGE_URI_PATTERN = "^datastore://([a-z][a-z0-9_]*)?/[a-z][a-z0-9_]*$"
+        const val STORAGE_URI_MESSAGE = "storage must be in format datastore://<namespace>/<table>, with the namespace optional (datastore:///<table> resolves to the configured default). Each segment starts with a lowercase letter and contains only lowercase alphanumeric/underscore, which reserves the __x__ form for system names (e.g., datastore://my_namespace/my_table or datastore:///my_table)"
     }
 
     object Group {

--- a/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
@@ -18,12 +18,12 @@ class StorageUriPatternTest {
             """
             - uri: datastore://my_namespace/my_table
             - uri: datastore://ns/t
+            - uri: datastore://ns1/table1
             # namespace omitted, resolved to the configured default
             - uri: datastore:///my_table
             - uri: datastore:///t
-            # a single leading underscore is allowed
-            - uri: datastore://_ns/t
-            - uri: datastore:///_expire
+            # a trailing double underscore is an ordinary name
+            - uri: datastore://sys__/t
             """,
         )
         fun `valid storage URIs`(uri: String) {
@@ -39,10 +39,15 @@ class StorageUriPatternTest {
             # table segment is always required
             - uri: datastore://ns/
             - uri: datastore:///
-            # a `__` prefix is reserved for system names
+            # the reserved __x__ form is out of reach of user input
             - uri: datastore://__sys__/metastore
             - uri: datastore://ns/__count__
             - uri: datastore:///__reserved
+            # segments start with a lowercase letter, as every other name does
+            - uri: datastore://_ns/t
+            - uri: datastore:///_expire
+            - uri: datastore://1ns/t
+            - uri: datastore:///9t
             # single segment (no ///) is not the omitted form
             - uri: datastore://t
             # uppercase and hyphen are not allowed

--- a/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
@@ -1,0 +1,53 @@
+package com.kakao.actionbase.core
+
+import com.kakao.actionbase.test.documentations.params.ObjectSource
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+import org.junit.jupiter.api.Nested
+
+class StorageUriPatternTest {
+    private val regex = Regex(Constants.Name.STORAGE_URI_PATTERN)
+
+    @Nested
+    inner class Accepts {
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            - uri: datastore://my_namespace/my_table
+            - uri: datastore://ns/t
+            # namespace omitted, resolved to the configured default
+            - uri: datastore:///my_table
+            - uri: datastore:///t
+            """,
+        )
+        fun `valid storage URIs`(uri: String) {
+            assertTrue(regex.matches(uri), "expected $uri to match")
+        }
+    }
+
+    @Nested
+    inner class Rejects {
+        @ObjectSourceParameterizedTest
+        @ObjectSource(
+            """
+            # table segment is always required
+            - uri: datastore://ns/
+            - uri: datastore:///
+            # namespace, when present, must start with a lowercase letter
+            - uri: datastore://1ns/t
+            - uri: datastore://_ns/t
+            # single segment (no ///) is not the omitted form
+            - uri: datastore://t
+            # uppercase and hyphen are not allowed
+            - uri: datastore://Ns/t
+            - uri: datastore:///my-table
+            """,
+        )
+        fun `invalid storage URIs`(uri: String) {
+            assertFalse(regex.matches(uri), "expected $uri not to match")
+        }
+    }
+}

--- a/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
+++ b/core/src/test/kotlin/com/kakao/actionbase/core/StorageUriPatternTest.kt
@@ -21,6 +21,9 @@ class StorageUriPatternTest {
             # namespace omitted, resolved to the configured default
             - uri: datastore:///my_table
             - uri: datastore:///t
+            # a single leading underscore is allowed
+            - uri: datastore://_ns/t
+            - uri: datastore:///_expire
             """,
         )
         fun `valid storage URIs`(uri: String) {
@@ -36,9 +39,10 @@ class StorageUriPatternTest {
             # table segment is always required
             - uri: datastore://ns/
             - uri: datastore:///
-            # namespace, when present, must start with a lowercase letter
-            - uri: datastore://1ns/t
-            - uri: datastore://_ns/t
+            # a `__` prefix is reserved for system names
+            - uri: datastore://__sys__/metastore
+            - uri: datastore://ns/__count__
+            - uri: datastore:///__reserved
             # single segment (no ///) is not the omitted form
             - uri: datastore://t
             # uppercase and hyphen are not allowed

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/EngineConstants.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/EngineConstants.kt
@@ -5,6 +5,8 @@ object EngineConstants {
     // backend, so the string is self-describing — no Storage entity lookup:
     //   datastore://__sys__/metastore  -> system metastore (RDB-backed) labels
     //   datastore://<namespace>/<table> -> HBase datastore
+    //   datastore:///<table>            -> HBase datastore, namespace resolved
+    //                                      to the backend's configured default
     // A bare string is a legacy reference to a metastore-stored Storage entity,
     // kept until migration retires it.
     const val DATASTORE_URI_PREFIX = "datastore://"

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/DatastoreUri.kt
@@ -3,7 +3,9 @@ package com.kakao.actionbase.engine.storage
 /**
  * Utility for parsing datastore URIs.
  *
- * Format: datastore://{namespace}/{tableName}
+ * Format: datastore://{namespace}/{tableName}. The namespace may be omitted
+ * (datastore:///{tableName}), leaving it empty for the backend to fill with its
+ * configured default namespace at acquisition time.
  */
 object DatastoreUri {
     private const val PREFIX = "datastore://"

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageBackend.kt
@@ -15,4 +15,9 @@ interface StorageBackend : AutoCloseable {
         val (ns, name) = DatastoreUri.parse(uri)
         return getStorageTable(ns.ifEmpty { defaultNamespace }, name)
     }
+
+    companion object {
+        /** Default for backends that serve one unnamed space, matching HBase's own default namespace. */
+        const val DEFAULT_NAMESPACE = "default"
+    }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/StorageBackend.kt
@@ -3,6 +3,9 @@ package com.kakao.actionbase.engine.storage
 import reactor.core.publisher.Mono
 
 interface StorageBackend : AutoCloseable {
+    /** Namespace substituted when a datastore:// URI omits it (`datastore:///<table>`). */
+    val defaultNamespace: String
+
     fun getStorageTable(
         namespace: String,
         name: String,
@@ -10,6 +13,6 @@ interface StorageBackend : AutoCloseable {
 
     fun getStorageTable(uri: String): Mono<StorageTable> {
         val (ns, name) = DatastoreUri.parse(uri)
-        return getStorageTable(ns, name)
+        return getStorageTable(ns.ifEmpty { defaultNamespace }, name)
     }
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/HBaseStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/HBaseStorageBackend.kt
@@ -17,6 +17,7 @@ import reactor.core.scheduler.Schedulers
 
 class HBaseStorageBackend private constructor(
     private val connectionMono: Mono<AsyncConnection>,
+    override val defaultNamespace: String,
 ) : StorageBackend {
     override fun getStorageTable(
         namespace: String,
@@ -65,7 +66,7 @@ class HBaseStorageBackend private constructor(
 
             val isSecure = properties["secure"]?.toBoolean() ?: false
             val version = properties["version"] ?: "2.4"
-            requireNotNull(properties["namespace"]) { "HBase namespace is not set" }
+            val namespace = requireNotNull(properties["namespace"]) { "HBase namespace is not set" }
 
             require(version.startsWith("2.4") || version.startsWith("2.5")) {
                 "Unsupported HBase version: $version. Supported versions are 2.4.x and 2.5.x."
@@ -139,7 +140,7 @@ class HBaseStorageBackend private constructor(
                         Mono.fromFuture(ConnectionFactory.createAsyncConnection(config))
                     }.cache()
 
-            return HBaseStorageBackend(connectionMono)
+            return HBaseStorageBackend(connectionMono, namespace)
         }
 
         internal fun resolveKerberosRealm(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/HBaseStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/HBaseStorageBackend.kt
@@ -66,7 +66,10 @@ class HBaseStorageBackend private constructor(
 
             val isSecure = properties["secure"]?.toBoolean() ?: false
             val version = properties["version"] ?: "2.4"
-            val namespace = requireNotNull(properties["namespace"]) { "HBase namespace is not set" }
+            // Blank would leave an omitted-namespace ref unresolved, and TableName.valueOf
+            // would silently place it in HBase's own default namespace instead.
+            val namespace = properties["namespace"]
+            require(!namespace.isNullOrBlank()) { "HBase namespace is not set" }
 
             require(version.startsWith("2.4") || version.startsWith("2.5")) {
                 "Unsupported HBase version: $version. Supported versions are 2.4.x and 2.5.x."

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/MockHBaseStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/MockHBaseStorageBackend.kt
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono
  * Each namespace + name combination gets its own isolated table.
  */
 class MockHBaseStorageBackend : StorageBackend {
-    override val defaultNamespace: String = "default"
+    override val defaultNamespace: String = StorageBackend.DEFAULT_NAMESPACE
 
     override fun getStorageTable(
         namespace: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/MockHBaseStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/hbase/MockHBaseStorageBackend.kt
@@ -18,6 +18,8 @@ import reactor.core.publisher.Mono
  * Each namespace + name combination gets its own isolated table.
  */
 class MockHBaseStorageBackend : StorageBackend {
+    override val defaultNamespace: String = "default"
+
     override fun getStorageTable(
         namespace: String,
         name: String,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/memory/MemoryStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/memory/MemoryStorageBackend.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap
 import reactor.core.publisher.Mono
 
 class MemoryStorageBackend : StorageBackend {
+    override val defaultNamespace: String = "default"
+
     private val stores = ConcurrentHashMap<String, ByteArrayStore>()
 
     private fun getOrCreateStore(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/memory/MemoryStorageBackend.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/storage/memory/MemoryStorageBackend.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
 import reactor.core.publisher.Mono
 
 class MemoryStorageBackend : StorageBackend {
-    override val defaultNamespace: String = "default"
+    override val defaultNamespace: String = StorageBackend.DEFAULT_NAMESPACE
 
     private val stores = ConcurrentHashMap<String, ByteArrayStore>()
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
@@ -57,7 +57,7 @@ class DefaultHBaseCluster private constructor(
         return getTable(namespace, tableName)
     }
 
-    private fun parseDatastoreUri(uri: String): Pair<String, String> {
+    internal fun parseDatastoreUri(uri: String): Pair<String, String> {
         val (ns, tableName) = DatastoreUri.parse(uri)
         return ns.ifEmpty { namespace } to tableName
     }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.v2.engine.compat
 
+import com.kakao.actionbase.engine.storage.DatastoreUri
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseConnections
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTable
 import com.kakao.actionbase.v2.engine.storage.hbase.HBaseTables
@@ -57,9 +58,7 @@ class DefaultHBaseCluster private constructor(
     }
 
     private fun parseDatastoreUri(uri: String): Pair<String, String> {
-        val parts = uri.removePrefix("datastore://").split("/")
-        require(parts.size == 2) { "Invalid datastore URI: $uri. Expected format: datastore://{namespace}/{tableName}" }
-        val (ns, tableName) = parts[0] to parts[1]
+        val (ns, tableName) = DatastoreUri.parse(uri)
         return ns.ifEmpty { namespace } to tableName
     }
 

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseCluster.kt
@@ -49,7 +49,8 @@ class DefaultHBaseCluster private constructor(
             }
         }
 
-    // URI format: datastore://{namespace}/{tableName}
+    // URI format: datastore://{namespace}/{tableName}; an omitted namespace
+    // (datastore:///{tableName}) resolves to this cluster's configured namespace.
     fun getTable(uri: String): Mono<HBaseTables> {
         val (namespace, tableName) = parseDatastoreUri(uri)
         return getTable(namespace, tableName)
@@ -58,7 +59,8 @@ class DefaultHBaseCluster private constructor(
     private fun parseDatastoreUri(uri: String): Pair<String, String> {
         val parts = uri.removePrefix("datastore://").split("/")
         require(parts.size == 2) { "Invalid datastore URI: $uri. Expected format: datastore://{namespace}/{tableName}" }
-        return parts[0] to parts[1]
+        val (ns, tableName) = parts[0] to parts[1]
+        return ns.ifEmpty { namespace } to tableName
     }
 
     override fun close() {

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/HBaseStorageBackendTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/HBaseStorageBackendTest.kt
@@ -4,8 +4,11 @@ import com.kakao.actionbase.engine.storage.hbase.HBaseStorageBackend
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 
+import kotlin.test.assertEquals
+
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class HBaseStorageBackendTest {
@@ -17,6 +20,12 @@ class HBaseStorageBackendTest {
             """
             # namespace missing
             - version: "2.4"
+              quorum: localhost:2181
+              error: IllegalArgumentException
+
+            # namespace blank — an omitted-namespace ref would resolve to nothing
+            - namespace: ""
+              version: "2.4"
               quorum: localhost:2181
               error: IllegalArgumentException
 
@@ -68,6 +77,20 @@ class HBaseStorageBackendTest {
                         HBaseStorageBackend.create(props)
                     }
             }
+        }
+
+        @Test
+        fun `the configured namespace becomes the default for omitted-namespace refs`() {
+            val backend =
+                HBaseStorageBackend.create(
+                    mapOf(
+                        "namespace" to "ab_test",
+                        "version" to "2.4",
+                        "hbase.zookeeper.quorum" to "localhost:2181",
+                    ),
+                )
+
+            assertEquals("ab_test", backend.defaultNamespace)
         }
     }
 }

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/MemoryStorageBackendTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/MemoryStorageBackendTest.kt
@@ -52,11 +52,24 @@ class MemoryStorageBackendTest {
             """
             - uri: datastore://test_ns/test_table
             - uri: datastore://ns1/table1
+            - uri: datastore:///table1
             """,
         )
         fun `returns StorageTable with uri`(uri: String) {
             val table = backend.getStorageTable(uri).block()!!
             assertNotNull(table)
+        }
+
+        @Test
+        fun `omitted namespace resolves to the default namespace`() {
+            val omitted = backend.getStorageTable("datastore:///table").block()!!
+            val explicit = backend.getStorageTable(backend.defaultNamespace, "table").block()!!
+
+            omitted.put("key".toByteArray(), "value".toByteArray()).block()
+
+            assert(String(explicit.get("key".toByteArray()).block()!!) == "value") {
+                "datastore:///table should resolve to the '${backend.defaultNamespace}' namespace store"
+            }
         }
 
         @Test

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/MemoryStorageBackendTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/storage/MemoryStorageBackendTest.kt
@@ -4,6 +4,7 @@ import com.kakao.actionbase.engine.storage.memory.MemoryStorageBackend
 import com.kakao.actionbase.test.documentations.params.ObjectSource
 import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
 
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 import org.junit.jupiter.api.AfterEach
@@ -67,9 +68,11 @@ class MemoryStorageBackendTest {
 
             omitted.put("key".toByteArray(), "value".toByteArray()).block()
 
-            assert(String(explicit.get("key".toByteArray()).block()!!) == "value") {
-                "datastore:///table should resolve to the '${backend.defaultNamespace}' namespace store"
-            }
+            assertEquals(
+                "value",
+                String(explicit.get("key".toByteArray()).block()!!),
+                "datastore:///table should resolve to the '${backend.defaultNamespace}' namespace store",
+            )
         }
 
         @Test

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseClusterTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/compat/DefaultHBaseClusterTest.kt
@@ -75,4 +75,22 @@ class DefaultHBaseClusterTest {
         DefaultHBaseCluster.initialize(properties)
         assertTrue(DefaultHBaseCluster.INSTANCE.mock)
     }
+
+    @Test
+    fun `omitted namespace resolves to the configured namespace`() {
+        DefaultHBaseCluster.initialize(mapOf("version" to "embedded"))
+        val cluster = DefaultHBaseCluster.INSTANCE
+
+        assertEquals(cluster.namespace to "t", cluster.parseDatastoreUri("datastore:///t"))
+        assertEquals("other_ns" to "t", cluster.parseDatastoreUri("datastore://other_ns/t"))
+    }
+
+    @Test
+    fun `a malformed datastore uri is rejected before it reaches TableName`() {
+        DefaultHBaseCluster.initialize(mapOf("version" to "embedded"))
+        val cluster = DefaultHBaseCluster.INSTANCE
+
+        assertThrows<IllegalArgumentException> { cluster.parseDatastoreUri("datastore://ns/my-table") }
+        assertThrows<IllegalArgumentException> { cluster.parseDatastoreUri("datastore://ns/t/extra") }
+    }
 }

--- a/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/HBaseTestingStorageBackend.kt
+++ b/engine/src/testFixtures/kotlin/com/kakao/actionbase/test/hbase/HBaseTestingStorageBackend.kt
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono
  */
 class HBaseTestingStorageBackend(
     private val connectionMono: Mono<AsyncConnection>,
-    private val defaultNamespace: String,
+    override val defaultNamespace: String,
 ) : StorageBackend {
     override fun getStorageTable(
         namespace: String,


### PR DESCRIPTION
## Summary

The namespace in a `datastore://` ref is a per-deployment config value (`actionbase.hbase.namespace` → `ab_local`, `ab_prod`), but acquisition passed the URI's namespace straight to `TableName.valueOf`. So the migrate CLI baked a concrete namespace into every rewritten ref and pinned the metadata to one environment, and the `defaultNamespace` the factory already captured was never read.

This implements the `datastore://` scheme decision from #468: adopt Hadoop's `fs.defaultFS` model, where an omitted namespace (`datastore:///<table>`) resolves to the backend's configured default at acquisition. An explicit namespace still resolves exactly as before, so existing refs are untouched.

I amended the naming rules in #468 while writing this. Segments start with a lowercase letter like every other name, and the reserved form is the fully delimited `__x__`.

Closes #468

## Changes

- `StorageBackend` carries a `defaultNamespace`; `getStorageTable(uri)` substitutes it for an empty parsed namespace.
- `HBaseStorageBackend` supplies the namespace it previously only `requireNotNull`d, and now rejects a blank one — blank would leave an omitted-namespace ref resolving to HBase's own `default` rather than the deployment's. Backends that serve one unnamed space share `StorageBackend.DEFAULT_NAMESPACE`.
- `DefaultHBaseCluster` fills an empty namespace with its configured namespace on the data-table resolution path. Its parsing now delegates to `DatastoreUri.parse` — the data-table path had a private copy of the split-and-require logic, so the scheme's rules now live in one parser.
- `STORAGE_URI_PATTERN` accepts the omitted form (`datastore:///<table>`) and holds each segment to the letter-start rule, which leaves the reserved `__x__` form out of reach of user input so it can't target `datastore://__sys__/metastore`.
- The migrate CLI rewrite emits the omitted form instead of baking the namespace. `migrate plan` reports the source namespaces it drops — counting only the storages a planned label references — and rejects a `conf.tableName` the scheme disallows, since legacy storage entities were never held to the name rule.
- Tests: omitted-namespace resolution on all three backends and on `DefaultHBaseCluster`, a blank namespace rejected at `create`, the pattern's accept/reject set (including the `__x__` reservation and the letter-start rule), and the migrate URI shape.

One behavior change rides along. `DefaultHBaseCluster.getTable(uri)` validated nothing before, so a ref with characters the scheme disallows reached `TableName.valueOf`; it now fails at resolution. Nothing creatable through DDL is affected, and the migrate rewrite rejects such a name in the plan phase rather than emitting it.

## How to Test

```
./gradlew :core:test :engine:test
cd cli && go test ./internal/command/
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Opus 4.8

