### PR TITLE
Reject datastore table teardown while a URI-bound label references it

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferences.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferences.kt
@@ -1,0 +1,111 @@
+package com.kakao.actionbase.v2.engine.service.ddl
+
+import com.kakao.actionbase.engine.EngineConstants
+import com.kakao.actionbase.engine.storage.DatastoreUri
+import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.entity.StorageEntity
+import com.kakao.actionbase.v2.engine.metadata.StorageType
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+data class DatastoreTableReference(
+    val kind: Kind,
+    val name: EntityName,
+    val active: Boolean,
+) {
+    enum class Kind {
+        STORAGE,
+        LABEL,
+    }
+}
+
+/**
+ * The referential-integrity rule for the last hop of `alias -> label -> storage -> datastore table`.
+ * The hops above it are enforced by [LabelDdlService.canDeactivate] and
+ * [StorageDdlService.canDeactivate].
+ *
+ * @param defaultNamespace fills in for a URI that omits it (`datastore:///{table}`). Null where the
+ *   caller spans clusters; such a URI then matches on table name alone, over-reporting rather than
+ *   letting an irreversible drop through.
+ */
+class DatastoreTableReferences(
+    private val graph: Graph,
+    private val defaultNamespace: String?,
+) {
+    fun findAll(
+        namespace: String,
+        tableName: String,
+    ): Mono<List<DatastoreTableReference>> =
+        Mono
+            .zip(storageRefs(namespace, tableName), labelRefs(namespace, tableName))
+            .map { it.t1 + it.t2 }
+
+    /** The subset that blocks a disable or drop. */
+    fun findActive(
+        namespace: String,
+        tableName: String,
+    ): Mono<List<DatastoreTableReference>> = findAll(namespace, tableName).map { refs -> refs.filter { it.active } }
+
+    private fun storageRefs(
+        namespace: String,
+        tableName: String,
+    ): Mono<List<DatastoreTableReference>> =
+        graph.storageDdl
+            .getAll(EntityName.origin)
+            .map { page ->
+                page
+                    .whole("storages")
+                    .content
+                    .filter { it.type == StorageType.HBASE && it.namesTable(namespace, tableName) }
+                    .map { DatastoreTableReference(DatastoreTableReference.Kind.STORAGE, it.name, it.active) }
+            }
+
+    private fun labelRefs(
+        namespace: String,
+        tableName: String,
+    ): Mono<List<DatastoreTableReference>> =
+        graph.serviceDdl
+            .getAll(EntityName.origin)
+            .flatMapMany { services -> Flux.fromIterable(services.whole("services").content) }
+            .flatMap { service ->
+                val serviceName = service.name.shiftNameToService()
+                graph.labelDdl.getAll(serviceName).map { it.whole("labels of $serviceName") }
+            }.flatMapIterable { page -> page.content }
+            .filter { label -> label.storage.uriNames(namespace, tableName) }
+            .map { label -> DatastoreTableReference(DatastoreTableReference.Kind.LABEL, label.name, label.active) }
+            .collectList()
+
+    /**
+     * A metadata scan stops at `metadataFetchLimit` without saying so, and a truncated page cannot
+     * prove that nothing references the table. Refuse rather than report an absence we can't back -
+     * the caller is deciding whether to drop.
+     */
+    private fun <T> DdlPage<T>.whole(what: String): DdlPage<T> {
+        check(content.size < graph.metadataFetchLimit) {
+            "Cannot resolve datastore table references: the scan of $what hit the " +
+                "metadataFetchLimit of ${graph.metadataFetchLimit}, so the result may be incomplete"
+        }
+        return this
+    }
+
+    // A malformed URI is skipped rather than raised: one label's bad metadata must not make an
+    // unrelated table unlistable.
+    private fun String.uriNames(
+        namespace: String,
+        tableName: String,
+    ): Boolean {
+        if (!EngineConstants.isSchemeUri(this)) return false
+        val (ns, table) = runCatching { DatastoreUri.parse(this) }.getOrNull() ?: return false
+        if (table != tableName) return false
+        if (ns.isNotEmpty()) return ns == namespace
+        // Namespace omitted and no default to resolve it with, so the table name is all we can match on.
+        return defaultNamespace == null || defaultNamespace == namespace
+    }
+
+    private fun StorageEntity.namesTable(
+        namespace: String,
+        tableName: String,
+    ): Boolean = conf.get("namespace")?.asText() == namespace && conf.get("tableName")?.asText() == tableName
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferencesSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferencesSpec.kt
@@ -1,0 +1,206 @@
+package com.kakao.actionbase.v2.engine.service.ddl
+
+import com.kakao.actionbase.v2.core.metadata.DirectionType
+import com.kakao.actionbase.v2.core.metadata.LabelType
+import com.kakao.actionbase.v2.engine.Graph
+import com.kakao.actionbase.v2.engine.GraphConfig
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.metadata.StorageType
+import com.kakao.actionbase.v2.engine.test.GraphFixtures
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import reactor.kotlin.test.test
+
+/**
+ * A datastore table is reachable two ways - through a named storage entity, or straight from a
+ * label carrying a `datastore://` URI. Only the first used to be checked, which left every
+ * v3-created table unguarded: `TableCreateRequest.storage` is always the URI form.
+ */
+class DatastoreTableReferencesSpec :
+    StringSpec({
+        val defaultNamespace = "ab_default"
+
+        lateinit var graph: Graph
+        lateinit var references: DatastoreTableReferences
+
+        beforeTest {
+            graph = GraphFixtures.create()
+            references = DatastoreTableReferences(graph, defaultNamespace)
+        }
+
+        afterTest { graph.close() }
+
+        fun createLabel(
+            name: String,
+            storage: String,
+        ) {
+            graph.labelDdl
+                .create(
+                    EntityName(GraphFixtures.serviceName, name),
+                    LabelCreateRequest(
+                        desc = "reference fixture",
+                        type = LabelType.HASH,
+                        schema = GraphFixtures.sampleSchema,
+                        dirType = DirectionType.OUT,
+                        storage = storage,
+                    ),
+                ).test()
+                .assertNext { it.status shouldBe DdlStatus.Status.CREATED }
+                .verifyComplete()
+        }
+
+        fun deactivate() =
+            LabelUpdateRequest(
+                active = false,
+                desc = null,
+                type = null,
+                schema = null,
+                groups = null,
+                indices = null,
+                readOnly = null,
+                mode = null,
+                caches = null,
+            )
+
+        fun createHbaseStorage(
+            name: String,
+            namespace: String,
+            tableName: String,
+        ) {
+            val conf =
+                jacksonObjectMapper().createObjectNode().apply {
+                    put("namespace", namespace)
+                    put("tableName", tableName)
+                }
+            GraphFixtures.createStorage(graph, name, StorageType.HBASE, conf)
+        }
+
+        "a named storage binding is reported" {
+            createHbaseStorage("named_storage", "ab_test", "named_bound")
+
+            references
+                .findActive("ab_test", "named_bound")
+                .test()
+                .assertNext { refs ->
+                    refs.size shouldBe 1
+                    refs.single().kind shouldBe DatastoreTableReference.Kind.STORAGE
+                    refs.single().name shouldBe EntityName.fromOrigin("named_storage")
+                }.verifyComplete()
+        }
+
+        "a datastore URI binding is reported" {
+            createLabel("uri_label", "datastore://ab_test/uri_bound")
+
+            references
+                .findActive("ab_test", "uri_bound")
+                .test()
+                .assertNext { refs ->
+                    refs.size shouldBe 1
+                    refs.single().kind shouldBe DatastoreTableReference.Kind.LABEL
+                    refs.single().name shouldBe EntityName(GraphFixtures.serviceName, "uri_label")
+                }.verifyComplete()
+        }
+
+        "a URI omitting the namespace resolves to the default namespace" {
+            createLabel("short_uri_label", "datastore:///short_bound")
+
+            references
+                .findActive(defaultNamespace, "short_bound")
+                .test()
+                .assertNext { refs -> refs.size shouldBe 1 }
+                .verifyComplete()
+        }
+
+        "without a default namespace, a namespace-less URI matches on table name alone" {
+            createLabel("roaming_label", "datastore:///roaming_bound")
+            val clusterBlind = DatastoreTableReferences(graph, defaultNamespace = null)
+
+            clusterBlind
+                .findActive("some_other_namespace", "roaming_bound")
+                .test()
+                .assertNext { refs -> refs.size shouldBe 1 }
+                .verifyComplete()
+
+            clusterBlind
+                .findActive("some_other_namespace", "unrelated_table")
+                .test()
+                .assertNext { refs -> refs.isEmpty() shouldBe true }
+                .verifyComplete()
+        }
+
+        "refuses to answer when the metadata scan is truncated" {
+            // A page filled to metadataFetchLimit can't prove the table is unreferenced, and the
+            // caller is deciding whether to drop it.
+            val truncating =
+                GraphFixtures.create(GraphConfig.Builder().withMetadataFetchLimit(1), withTestData = false)
+            try {
+                GraphFixtures.createStorage(
+                    truncating,
+                    "only_storage",
+                    StorageType.HBASE,
+                    jacksonObjectMapper().createObjectNode().apply {
+                        put("namespace", "ab_test")
+                        put("tableName", "filler")
+                    },
+                )
+
+                shouldThrow<IllegalStateException> {
+                    DatastoreTableReferences(truncating, defaultNamespace)
+                        .findActive("ab_test", "anything")
+                        .block()
+                }
+            } finally {
+                truncating.close()
+            }
+        }
+
+        "a URI naming another table is not reported" {
+            createLabel("other_label", "datastore://ab_test/other_bound")
+
+            references
+                .findActive("ab_test", "uri_bound")
+                .test()
+                .assertNext { refs -> refs.isEmpty() shouldBe true }
+                .verifyComplete()
+        }
+
+        "a deactivated label no longer blocks, but is still listed" {
+            createLabel("stale_label", "datastore://ab_test/stale_bound")
+            graph.labelDdl
+                .update(EntityName(GraphFixtures.serviceName, "stale_label"), deactivate())
+                .test()
+                .assertNext { it.status shouldBe DdlStatus.Status.UPDATED }
+                .verifyComplete()
+
+            references
+                .findActive("ab_test", "stale_bound")
+                .test()
+                .assertNext { refs -> refs.isEmpty() shouldBe true }
+                .verifyComplete()
+
+            references
+                .findAll("ab_test", "stale_bound")
+                .test()
+                .assertNext { refs ->
+                    refs.size shouldBe 1
+                    refs.single().active shouldBe false
+                }.verifyComplete()
+        }
+
+        "both binding forms on one table are reported together" {
+            createHbaseStorage("shared_storage", "ab_test", "shared_bound")
+            createLabel("shared_uri_label", "datastore://ab_test/shared_bound")
+
+            references
+                .findActive("ab_test", "shared_bound")
+                .test()
+                .assertNext { refs ->
+                    refs.map { it.kind }.toSet() shouldBe
+                        setOf(DatastoreTableReference.Kind.STORAGE, DatastoreTableReference.Kind.LABEL)
+                }.verifyComplete()
+        }
+    })

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/admin/HBaseController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v2/admin/HBaseController.kt
@@ -5,8 +5,7 @@ import com.kakao.actionbase.server.service.devtools.HBaseMetric
 import com.kakao.actionbase.server.service.devtools.HBaseTableSchema
 import com.kakao.actionbase.server.service.devtools.models.GraphHBaseTable
 import com.kakao.actionbase.v2.engine.Graph
-import com.kakao.actionbase.v2.engine.entity.EntityName
-import com.kakao.actionbase.v2.engine.metadata.StorageType
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReferences
 
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,6 +23,8 @@ class HBaseController(
     private val graph: Graph,
     private val hBaseAdminService: HBaseAdminService,
 ) {
+    private val references = DatastoreTableReferences(graph, defaultNamespace = null)
+
     @GetMapping("/graph/v2/admin/hbase/cluster")
     fun listClusters(): Mono<Map<String, List<Map<String, String>>>> =
         hBaseAdminService
@@ -60,35 +61,16 @@ class HBaseController(
         @PathVariable cluster: String,
         @PathVariable tableFullName: String,
     ): Mono<Map<String, String>> =
-        graph.storageDdl
-            .getAll(EntityName.origin)
-            .map { page ->
-                page.content
-                    // TODO: Need to actually check deleted metadata, but additional debugging is needed to understand why this is necessary.
-                    .filter { it.active }
-                    .filter { it.type == StorageType.HBASE }
-                    .filter {
-                        val namespace = it.conf.get("namespace").asText()
-                        val tableName = it.conf.get("tableName").asText()
-                        "$namespace:$tableName" == tableFullName
-                    }
-            }.flatMap {
-                if (it.isNotEmpty()) {
-                    val storageNames = it.joinToString(",") { entity -> entity.fullName }
-                    Mono.error(IllegalArgumentException("Table $tableFullName is used by storages ($storageNames)"))
-                } else {
-                    hBaseAdminService
-                        .getTable(cluster, tableFullName)
-                        .map { table ->
-                            require(!table.isEnabled) {
-                                "Table $tableFullName is enabled, delete after disable it."
-                            }
-                        }.flatMap {
-                            hBaseAdminService
-                                .deleteTable(cluster, tableFullName)
-                                .then(Mono.just(mapOf("result" to "deleted")))
-                        }
+        throwErrorIfTableInUse(tableFullName)
+            .then(Mono.defer { hBaseAdminService.getTable(cluster, tableFullName) })
+            .map { table ->
+                require(!table.isEnabled) {
+                    "Table $tableFullName is enabled, delete after disable it."
                 }
+            }.flatMap {
+                hBaseAdminService
+                    .deleteTable(cluster, tableFullName)
+                    .then(Mono.just(mapOf("result" to "deleted")))
             }
 
     @PutMapping("/graph/v2/admin/hbase/cluster/{cluster}/table/{tableFullName}")
@@ -99,25 +81,8 @@ class HBaseController(
     ): Mono<Map<String, String>> {
         val result =
             if (request.enable == false) {
-                graph.storageDdl
-                    .getAll(EntityName.origin)
-                    .map { page ->
-                        page.content
-                            .filter { it.active }
-                            .filter { it.type == StorageType.HBASE }
-                            .filter {
-                                val namespace = it.conf.get("namespace").asText()
-                                val tableName = it.conf.get("tableName").asText()
-                                "$namespace:$tableName" == tableFullName
-                            }
-                    }.flatMap {
-                        if (it.isNotEmpty()) {
-                            val storageNames = it.joinToString(",") { entity -> entity.fullName }
-                            Mono.error(IllegalArgumentException("Table $tableFullName is used by storages ($storageNames)"))
-                        } else {
-                            hBaseAdminService.disableTable(cluster, tableFullName)
-                        }
-                    }
+                throwErrorIfTableInUse(tableFullName)
+                    .then(Mono.defer { hBaseAdminService.disableTable(cluster, tableFullName) })
             } else {
                 hBaseAdminService.enableTable(cluster, tableFullName)
             }
@@ -162,6 +127,30 @@ class HBaseController(
         hBaseAdminService
             .getReplicationPeer(cluster)
             .map { mapOf("replication" to it) }
+
+    // Cluster-blind, as this check has always been: it matches against this server's own metadata
+    // whatever `cluster` names. For a remote cluster that errs toward refusing.
+    //
+    // Callers wrap the admin call in Mono.defer so nothing runs before this answers - building it
+    // eagerly would open a connection, or throw on an unknown cluster, ahead of the guard.
+    private fun throwErrorIfTableInUse(tableFullName: String): Mono<Void> {
+        val parts = tableFullName.trim().split(":")
+        require(parts.size == 2) { "Table name must be in namespace:tableName format, got $tableFullName" }
+        val (namespace, tableName) = parts
+        return references
+            .findActive(namespace, tableName)
+            .flatMap { refs ->
+                if (refs.isEmpty()) {
+                    Mono.empty()
+                } else {
+                    Mono.error(
+                        IllegalArgumentException(
+                            "Table $tableFullName is used by ${refs.joinToString(",") { "${it.kind}:${it.name}" }}",
+                        ),
+                    )
+                }
+            }
+    }
 
     data class GraphHBaseTableUpdateRequest(
         val enable: Boolean?,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
@@ -7,8 +7,8 @@ import com.kakao.actionbase.server.configuration.ConditionalOnHBaseDatastore
 import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
-import com.kakao.actionbase.v2.engine.entity.StorageEntity
 import com.kakao.actionbase.v2.engine.metadata.StorageType
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReferences
 
 import org.apache.hadoop.hbase.NamespaceDescriptor
 import org.apache.hadoop.hbase.TableName
@@ -39,6 +39,8 @@ class DatastoreHBaseService(
             .get()
 
     private val namespaces = legacyNamespaces + tenantNamespace
+
+    private val references = DatastoreTableReferences(graph, tenantNamespace)
 
     fun getNamespaces(): List<String> = namespaces
 
@@ -72,25 +74,27 @@ class DatastoreHBaseService(
         request: HBaseTableUpdateRequest,
     ): Mono<Void> =
         withValidatedTableName(optionalFullQualifierTableName) { tableName ->
-            val updateStream =
-                if (request.enable == true) {
-                    hBaseAdmin.enableTable(tableName.namespaceAsString, tableName.qualifierAsString)
-                } else {
-                    hBaseAdmin.disableTable(tableName.namespaceAsString, tableName.qualifierAsString)
-                }
-            throwErrorIfStorageInUse(tableName).then(updateStream)
+            throwErrorIfStorageInUse(tableName).then(
+                Mono.defer {
+                    if (request.enable == true) {
+                        hBaseAdmin.enableTable(tableName.namespaceAsString, tableName.qualifierAsString)
+                    } else {
+                        hBaseAdmin.disableTable(tableName.namespaceAsString, tableName.qualifierAsString)
+                    }
+                },
+            )
         }
 
     fun enableTable(optionalFullQualifierTableName: String): Mono<Void> =
         withValidatedTableName(optionalFullQualifierTableName) { tableName ->
             throwErrorIfStorageInUse(tableName)
-                .then(hBaseAdmin.enableTable(tableName.namespaceAsString, tableName.qualifierAsString))
+                .then(Mono.defer { hBaseAdmin.enableTable(tableName.namespaceAsString, tableName.qualifierAsString) })
         }
 
     fun disableTable(optionalFullQualifierTableName: String): Mono<Void> =
         withValidatedTableName(optionalFullQualifierTableName) { tableName ->
             throwErrorIfStorageInUse(tableName)
-                .then(hBaseAdmin.disableTable(tableName.namespaceAsString, tableName.qualifierAsString))
+                .then(Mono.defer { hBaseAdmin.disableTable(tableName.namespaceAsString, tableName.qualifierAsString) })
         }
 
     // Replication toggle is allowed on in-use tables. The operator runbook for safe table cleanup
@@ -109,7 +113,7 @@ class DatastoreHBaseService(
     fun deleteTable(optionalFullQualifierTableName: String): Mono<Void> =
         withValidatedTableName(optionalFullQualifierTableName) { tableName ->
             throwErrorIfStorageInUse(tableName)
-                .then(hBaseAdmin.deleteTable(tableName.namespaceAsString, tableName.qualifierAsString))
+                .then(Mono.defer { hBaseAdmin.deleteTable(tableName.namespaceAsString, tableName.qualifierAsString) })
         }
 
     fun getTableMetricSummary(optionalFullQualifierTableName: String): Mono<Map<String, Any>> =
@@ -118,30 +122,20 @@ class DatastoreHBaseService(
                 .getTableMetricSummary(tableName.namespaceAsString, tableName.qualifierAsString)
         }
 
+    // Callers wrap the admin call in Mono.defer so nothing is built before this answers - an
+    // argument to `then` is evaluated eagerly, which would put admin work ahead of the guard.
     private fun throwErrorIfStorageInUse(tableName: TableName): Mono<Void> =
-        getStorageInUse(tableName.namespaceAsString, tableName.qualifierAsString)
-            .flatMap { storages ->
-                if (storages.isNotEmpty()) {
-                    Mono.error(IllegalArgumentException("Table ${tableName.namespaceAsString}:$tableName is used by storages (${storages.joinToString(",") { it.fullName }})"))
-                } else {
+        references
+            .findActive(tableName.namespaceAsString, tableName.qualifierAsString)
+            .flatMap { refs ->
+                if (refs.isEmpty()) {
                     Mono.empty()
-                }
-            }
-
-    private fun getStorageInUse(
-        namespace: String,
-        tableName: String,
-    ): Mono<List<StorageEntity>> =
-        graph.storageDdl
-            .getAll(EntityName.origin)
-            .map { page ->
-                page.content.filter { storage ->
-                    storage.active &&
-                        storage.type == StorageType.HBASE &&
-                        (
-                            storage.conf.get("namespace").asText() == namespace &&
-                                storage.conf.get("tableName").asText() == tableName
-                        )
+                } else {
+                    Mono.error(
+                        IllegalArgumentException(
+                            "Table $tableName is used by ${refs.joinToString(",") { "${it.kind}:${it.name}" }}",
+                        ),
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary

Disabling or dropping an HBase table only checked for a `StorageEntity` naming it. A label can bind straight to the table with a `datastore://{namespace}/{table}` URI and no storage entity at all, and every table the v3 API creates takes that form. So a table serving live reads and writes could be disabled or dropped.

Relates to #370

## Changes

- Add `DatastoreTableReferences`, resolving both binding forms
- Use it in `DatastoreHBaseService` and `HBaseController`, replacing three copies of the inline storage scan
- Refuse to answer when a metadata scan hits `metadataFetchLimit` — a truncated page can't prove a table is unreferenced
- Wrap the admin call in `Mono.defer` so the guard runs first. An argument to `then` is evaluated eagerly, which put connection setup ahead of the check

## How to Test

```
./gradlew :engine:test :server:test
```

## Behavior change

Teardown that used to succeed is now rejected — a table bound by an active label has to be deactivated first. `/graph/v2/admin/hbase` stays cluster-blind as before, so for a remote cluster it errs toward refusing.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
