### PR TITLE
Expose what references a datastore table

### DIFF
--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferences.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferences.kt
@@ -34,13 +34,22 @@ class DatastoreTableReferences(
     private val graph: Graph,
     private val defaultNamespace: String?,
 ) {
+    /** A binding whose namespace is null could not be resolved, so it matches any namespace. */
+    private data class Binding(
+        val namespace: String?,
+        val tableName: String,
+        val ref: DatastoreTableReference,
+    )
+
     fun findAll(
         namespace: String,
         tableName: String,
     ): Mono<List<DatastoreTableReference>> =
-        Mono
-            .zip(storageRefs(namespace, tableName), labelRefs(namespace, tableName))
-            .map { it.t1 + it.t2 }
+        bindings().map { all ->
+            all
+                .filter { it.tableName == tableName && (it.namespace == null || it.namespace == namespace) }
+                .map { it.ref }
+        }
 
     /** The subset that blocks a disable or drop. */
     fun findActive(
@@ -48,24 +57,41 @@ class DatastoreTableReferences(
         tableName: String,
     ): Mono<List<DatastoreTableReference>> = findAll(namespace, tableName).map { refs -> refs.filter { it.active } }
 
-    private fun storageRefs(
-        namespace: String,
-        tableName: String,
-    ): Mono<List<DatastoreTableReference>> =
+    /**
+     * Every binding at once, keyed by `namespace:tableName`. A single-table lookup costs the same
+     * scan as this does, so anything walking a cluster should ask once here instead of per table.
+     *
+     * @param namespace keeps only bindings in that namespace. Unresolved bindings match any
+     *   namespace, as they do in [findAll], so they survive the filter.
+     */
+    fun findAllByTable(namespace: String? = null): Mono<Map<String, List<DatastoreTableReference>>> =
+        bindings().map { all ->
+            all
+                .filter { namespace == null || it.namespace == null || it.namespace == namespace }
+                .groupBy({ "${it.namespace ?: defaultNamespace.orEmpty()}:${it.tableName}" }, { it.ref })
+        }
+
+    private fun bindings(): Mono<List<Binding>> =
+        Mono
+            .zip(storageBindings(), labelBindings())
+            .map { it.t1 + it.t2 }
+
+    private fun storageBindings(): Mono<List<Binding>> =
         graph.storageDdl
             .getAll(EntityName.origin)
             .map { page ->
                 page
                     .whole("storages")
                     .content
-                    .filter { it.type == StorageType.HBASE && it.namesTable(namespace, tableName) }
-                    .map { DatastoreTableReference(DatastoreTableReference.Kind.STORAGE, it.name, it.active) }
+                    .filter { it.type == StorageType.HBASE }
+                    .mapNotNull { storage ->
+                        storage.target()?.let { (ns, table) ->
+                            Binding(ns, table, DatastoreTableReference(DatastoreTableReference.Kind.STORAGE, storage.name, storage.active))
+                        }
+                    }
             }
 
-    private fun labelRefs(
-        namespace: String,
-        tableName: String,
-    ): Mono<List<DatastoreTableReference>> =
+    private fun labelBindings(): Mono<List<Binding>> =
         graph.serviceDdl
             .getAll(EntityName.origin)
             .flatMapMany { services -> Flux.fromIterable(services.whole("services").content) }
@@ -73,9 +99,11 @@ class DatastoreTableReferences(
                 val serviceName = service.name.shiftNameToService()
                 graph.labelDdl.getAll(serviceName).map { it.whole("labels of $serviceName") }
             }.flatMapIterable { page -> page.content }
-            .filter { label -> label.storage.uriNames(namespace, tableName) }
-            .map { label -> DatastoreTableReference(DatastoreTableReference.Kind.LABEL, label.name, label.active) }
-            .collectList()
+            .mapNotNull { label ->
+                label.storage.uriTarget()?.let { (ns, table) ->
+                    Binding(ns, table, DatastoreTableReference(DatastoreTableReference.Kind.LABEL, label.name, label.active))
+                }
+            }.collectList()
 
     /**
      * A metadata scan stops at `metadataFetchLimit` without saying so, and a truncated page cannot
@@ -92,20 +120,15 @@ class DatastoreTableReferences(
 
     // A malformed URI is skipped rather than raised: one label's bad metadata must not make an
     // unrelated table unlistable.
-    private fun String.uriNames(
-        namespace: String,
-        tableName: String,
-    ): Boolean {
-        if (!EngineConstants.isSchemeUri(this)) return false
-        val (ns, table) = runCatching { DatastoreUri.parse(this) }.getOrNull() ?: return false
-        if (table != tableName) return false
-        if (ns.isNotEmpty()) return ns == namespace
-        // Namespace omitted and no default to resolve it with, so the table name is all we can match on.
-        return defaultNamespace == null || defaultNamespace == namespace
+    private fun String.uriTarget(): Pair<String?, String>? {
+        if (!EngineConstants.isSchemeUri(this)) return null
+        val (ns, table) = runCatching { DatastoreUri.parse(this) }.getOrNull() ?: return null
+        return (ns.ifEmpty { defaultNamespace }) to table
     }
 
-    private fun StorageEntity.namesTable(
-        namespace: String,
-        tableName: String,
-    ): Boolean = conf.get("namespace")?.asText() == namespace && conf.get("tableName")?.asText() == tableName
+    private fun StorageEntity.target(): Pair<String, String>? {
+        val ns = conf.get("namespace")?.asText() ?: return null
+        val table = conf.get("tableName")?.asText() ?: return null
+        return ns to table
+    }
 }

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferencesSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/service/ddl/DatastoreTableReferencesSpec.kt
@@ -191,6 +191,33 @@ class DatastoreTableReferencesSpec :
                 }.verifyComplete()
         }
 
+        "groups every binding by the table it points at" {
+            createHbaseStorage("grouped_storage", "ab_test", "storage_bound")
+            createLabel("grouped_label", "datastore://ab_test/label_bound")
+            createLabel("grouped_short", "datastore:///short_bound")
+
+            references
+                .findAllByTable()
+                .test()
+                .assertNext { byTable ->
+                    byTable["ab_test:storage_bound"]?.single()?.kind shouldBe DatastoreTableReference.Kind.STORAGE
+                    byTable["ab_test:label_bound"]?.single()?.kind shouldBe DatastoreTableReference.Kind.LABEL
+                    byTable["$defaultNamespace:short_bound"]?.size shouldBe 1
+                }.verifyComplete()
+        }
+
+        "the namespace filter drops bindings in other namespaces" {
+            createLabel("here_label", "datastore://ab_here/here_bound")
+            createLabel("there_label", "datastore://ab_there/there_bound")
+
+            references
+                .findAllByTable(namespace = "ab_here")
+                .test()
+                .assertNext { byTable ->
+                    byTable.keys shouldBe setOf("ab_here:here_bound")
+                }.verifyComplete()
+        }
+
         "both binding forms on one table are reported together" {
             createHbaseStorage("shared_storage", "ab_test", "shared_bound")
             createLabel("shared_uri_label", "datastore://ab_test/shared_bound")

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseController.kt
@@ -5,6 +5,7 @@ import com.kakao.actionbase.server.auth.ActorRole
 import com.kakao.actionbase.server.configuration.ConditionalOnHBaseDatastore
 import com.kakao.actionbase.server.configuration.GraphProperties
 import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReference
 
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 import reactor.core.publisher.Mono
@@ -129,6 +131,32 @@ class DatastoreHBaseController(
             .deleteTable(tableName)
             .then(Mono.just(mapOf("result" to "deleted")))
     }
+
+    /**
+     * Every binding on the cluster, keyed by `namespace:tableName`. Resolving tables one at a time
+     * costs a metadata scan per database per table, so walking a cluster should start here.
+     *
+     * Not under `tables/` - that would collide with `tables/{tableName}`.
+     */
+    @GetMapping("/graph/v3/datastore/hbase/references")
+    fun getAllTableReferences(
+        @RequestParam(required = false) namespace: String?,
+    ): Mono<Map<String, Map<String, List<DatastoreTableReference>>>> =
+        service
+            .getAllTableReferences(namespace)
+            .map { mapOf("references" to it) }
+
+    /**
+     * What still binds to this table. A cleanup client reads this instead of reconstructing the
+     * `alias -> label -> storage -> table` chain from the metadata listings.
+     */
+    @GetMapping("/graph/v3/datastore/hbase/tables/{tableName}/references")
+    fun getTableReferences(
+        @PathVariable tableName: String,
+    ): Mono<Map<String, List<DatastoreTableReference>>> =
+        service
+            .getTableReferences(tableName)
+            .map { mapOf("references" to it) }
 
     @GetMapping("/graph/v3/datastore/hbase/tables/{tableName}/metric")
     fun getTableMetricSummary(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreHBaseService.kt
@@ -8,6 +8,7 @@ import com.kakao.actionbase.server.util.NameValidator
 import com.kakao.actionbase.v2.engine.Graph
 import com.kakao.actionbase.v2.engine.entity.EntityName
 import com.kakao.actionbase.v2.engine.metadata.StorageType
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReference
 import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReferences
 
 import org.apache.hadoop.hbase.NamespaceDescriptor
@@ -43,6 +44,22 @@ class DatastoreHBaseService(
     private val references = DatastoreTableReferences(graph, tenantNamespace)
 
     fun getNamespaces(): List<String> = namespaces
+
+    /**
+     * Everything bound to this table, active or not. Active bindings are what block a disable or
+     * drop; inactive ones are reported so an operator can see a teardown already in progress.
+     */
+    fun getTableReferences(optionalFullQualifierTableName: String): Mono<List<DatastoreTableReference>> =
+        withValidatedTableName(optionalFullQualifierTableName) { tableName ->
+            references.findAll(tableName.namespaceAsString, tableName.qualifierAsString)
+        }
+
+    /**
+     * Every binding on this cluster, keyed by `namespace:tableName`. One scan for the whole cluster
+     * rather than one per table. An unknown [namespace] yields an empty result rather than an
+     * error: a table reached only through a `datastore://` URI need not appear in [namespaces].
+     */
+    fun getAllTableReferences(namespace: String?): Mono<Map<String, List<DatastoreTableReference>>> = references.findAllByTable(namespace)
 
     fun getTables(): Mono<List<HBaseTableInfo>> {
         // Extract namespaces from all storages to create a distinct namespace list


### PR DESCRIPTION
## Summary

Deciding whether an HBase table is safe to tear down means reconstructing the `alias -> label -> storage -> table` chain client-side. The server already resolves that chain to guard its own disable and drop, so let clients ask instead.

Stacked on #477. Relates to #370

## Changes

- `GET .../tables/{tableName}/references` for one table
- `GET /graph/v3/datastore/hbase/references` for the whole cluster from a single scan, keyed by `namespace:tableName`

Per-table resolution costs a metadata scan per database, so anything walking a cluster should use the bulk form. It sits outside `tables/` to avoid colliding with `tables/{tableName}`. Inactive bindings are included so an operator can tell a teardown in progress from a table nothing ever pointed at.

## How to Test

```
./gradlew :engine:test :server:test
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
