### PR TITLE
Test the HBase datastore controllers over HTTP

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
 
     // test
     testImplementation(testFixtures(project(":core")))
+    // The datastore controllers depend on HBaseAdmin, a final class, so standing them up in a test
+    // context needs inline mocking.
+    testImplementation(Dependencies.Testing.MOCKK)
 }
 
 gitProperties {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/admin/HBaseAdminTeardownGuardE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v2/admin/HBaseAdminTeardownGuardE2ETest.kt
@@ -1,0 +1,95 @@
+package com.kakao.actionbase.server.api.graph.v2.admin
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+/**
+ * The deprecated devtools endpoints reach the same tables as `/graph/v3/datastore/hbase`, so they
+ * have to refuse a teardown for the same reason. This runs on the default context: the guard
+ * answers from metadata and rejects before `HBaseAdminService` is involved, so no cluster is needed.
+ */
+class HBaseAdminTeardownGuardE2ETest : E2ETestBase() {
+    private val cluster = "any_cluster"
+    private val htable = "v2_ns:v2_bound"
+
+    private fun bindTable() {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "v2_guard_db", "comment": "v2 guard e2e"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/v2_guard_db/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "v2_guard_tbl",
+                  "storage": "datastore://v2_ns/v2_bound",
+                  "mode": "SYNC",
+                  "comment": "v2 guard e2e",
+                  "schema": {
+                    "type": "EDGE",
+                    "direction": "OUT",
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [],
+                    "indexes": [],
+                    "groups": []
+                  }
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `refuses to delete a table a URI-bound label references`() {
+        bindTable()
+
+        client
+            .delete()
+            .uri("/graph/v2/admin/hbase/cluster/$cluster/table/$htable")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.message")
+            .value<String> { message -> assert(message.contains("is used by")) { message } }
+    }
+
+    @Test
+    fun `refuses to disable a table a URI-bound label references`() {
+        bindTable()
+
+        client
+            .put()
+            .uri("/graph/v2/admin/hbase/cluster/$cluster/table/$htable")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"enable": false}""")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.message")
+            .value<String> { message -> assert(message.contains("is used by")) { message } }
+    }
+
+    @Test
+    fun `rejects a table name that is not namespace qualified`() {
+        client
+            .delete()
+            .uri("/graph/v2/admin/hbase/cluster/$cluster/table/unqualified")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreTableReferencesE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/DatastoreTableReferencesE2ETest.kt
@@ -1,0 +1,174 @@
+package com.kakao.actionbase.server.api.graph.v3.datastore.hbase
+
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+import io.mockk.every
+import reactor.core.publisher.Mono
+
+/** The context and its metastore are shared across tests, so each one uses its own htable. */
+class DatastoreTableReferencesE2ETest : HBaseDatastoreE2ETestBase() {
+    /** Creates a v3 table bound to `$TEST_NAMESPACE:{suffix}` and returns the htable name. */
+    private fun bindTable(suffix: String): String {
+        client
+            .post()
+            .uri("/graph/v3/databases")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"database": "db_$suffix", "comment": "references e2e"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        client
+            .post()
+            .uri("/graph/v3/databases/db_$suffix/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "table": "tbl_$suffix",
+                  "storage": "datastore://$TEST_NAMESPACE/$suffix",
+                  "mode": "SYNC",
+                  "comment": "references e2e",
+                  "schema": {
+                    "type": "EDGE",
+                    "direction": "OUT",
+                    "source": {"type": "long", "comment": "src"},
+                    "target": {"type": "long", "comment": "tgt"},
+                    "properties": [],
+                    "indexes": [],
+                    "groups": []
+                  }
+                }
+                """.trimIndent(),
+            ).exchange()
+            .expectStatus()
+            .isOk
+
+        return "$TEST_NAMESPACE:$suffix"
+    }
+
+    private fun deactivate(suffix: String) {
+        client
+            .put()
+            .uri("/graph/v3/databases/db_$suffix/tables/tbl_$suffix")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"active": false}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `reports the table bound by a datastore URI`() {
+        val htable = bindTable("bound")
+
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/tables/$htable/references")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references.length()")
+            .isEqualTo(1)
+            .jsonPath("$.references[0].kind")
+            .isEqualTo("LABEL")
+            .jsonPath("$.references[0].active")
+            .isEqualTo(true)
+    }
+
+    @Test
+    fun `reports no references for a table nothing is bound to`() {
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/tables/$TEST_NAMESPACE:unbound/references")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references.length()")
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `refuses to drop a table an active table is bound to`() {
+        val htable = bindTable("undroppable")
+        // Subscribing means the guard let the drop through. The call itself is built either way.
+        every { hBaseAdmin.deleteTable(any(), any()) } returns
+            Mono.error(AssertionError("drop reached HBase despite an active binding"))
+
+        client
+            .delete()
+            .uri("/graph/v3/datastore/hbase/tables/$htable")
+            .header(HttpHeaderConstants.ACTOR_ROLE, "ADMIN")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.message")
+            .value<String> { message -> assert(message.contains("is used by")) { message } }
+    }
+
+    @Test
+    fun `reports every binding on the cluster from one scan`() {
+        val htable = bindTable("bulk")
+
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/references")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references['$htable'].length()")
+            .isEqualTo(1)
+            .jsonPath("$.references['$htable'][0].kind")
+            .isEqualTo("LABEL")
+    }
+
+    @Test
+    fun `narrows the cluster listing to one namespace`() {
+        val htable = bindTable("filtered")
+
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/references?namespace=$TEST_NAMESPACE")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references['$htable']")
+            .exists()
+
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/references?namespace=somewhere_else")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references.length()")
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `keeps reporting the binding after it is deactivated`() {
+        val htable = bindTable("deactivated")
+        deactivate("deactivated")
+
+        client
+            .get()
+            .uri("/graph/v3/datastore/hbase/tables/$htable/references")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.references.length()")
+            .isEqualTo(1)
+            .jsonPath("$.references[0].active")
+            .isEqualTo(false)
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/HBaseDatastoreE2ETestBase.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/graph/v3/datastore/hbase/HBaseDatastoreE2ETestBase.kt
@@ -1,0 +1,53 @@
+package com.kakao.actionbase.server.api.graph.v3.datastore.hbase
+
+import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseAdmin
+import com.kakao.actionbase.server.ServerApplication
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+
+import io.mockk.mockk
+
+internal const val TEST_NAMESPACE = "ab_test"
+
+/**
+ * Stands up the HBase datastore controllers, which the default test context leaves out - it runs on
+ * `actionbase.datastore.type=memory`.
+ *
+ * [hBaseAdmin] replaces the cluster-backed one. Note that the service builds the admin call before
+ * the guard runs - `guard.then(hBaseAdmin.deleteTable(..))` evaluates its argument eagerly - so a
+ * test proves a rejection by stubbing the call with a publisher that fails on subscribe, not by
+ * leaving it unstubbed.
+ */
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+@Import(HBaseDatastoreE2ETestBase.StubbedDatastore::class)
+@SpringBootTest(
+    classes = [ServerApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "actionbase.datastore.type=HBASE",
+        "actionbase.datastore.configuration[actionbase.hbase.namespace]=$TEST_NAMESPACE",
+    ],
+)
+abstract class HBaseDatastoreE2ETestBase {
+    @Autowired
+    protected lateinit var client: WebTestClient
+
+    @Autowired
+    protected lateinit var hBaseAdmin: HBaseAdmin
+
+    @TestConfiguration
+    class StubbedDatastore {
+        @Bean
+        @Primary
+        fun stubHBaseAdmin(): HBaseAdmin = mockk()
+    }
+}


### PR DESCRIPTION
## Summary

Nothing under `/graph/v3/datastore/hbase` was reachable from a test — the controllers only exist under `actionbase.datastore.type=HBASE` and the test profile runs on `memory`. This adds the harness and uses it to cover #477 and #478.

Stacked on #478. Relates to #370

## Changes

- `HBaseDatastoreE2ETestBase`: flips the datastore type and takes over the `HBaseAdmin` bean with a mock
- Add mockk to `:server` test deps — `HBaseAdmin` is final
- Cover both reference endpoints, plus the teardown guard on v3 and on the v2 devtools controller

Proving a rejection needs the admin call stubbed with a publisher that fails on subscribe rather than left unstubbed. The service builds the call before the guard runs — an argument to `then` is evaluated eagerly — so an unstubbed mock reports a failure that isn't one.

## How to Test

```
./gradlew :server:test --tests "*DatastoreTableReferencesE2ETest*" --tests "*HBaseAdminTeardownGuardE2ETest*"
```

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
