### PR TITLE
Reach a tenant's clusters from the control plane

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreController.kt
@@ -1,0 +1,75 @@
+package com.kakao.actionbase.server.api.control.datastore
+
+import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableInfo
+import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+import com.kakao.actionbase.server.control.cluster.ClusterClient
+import com.kakao.actionbase.server.control.cluster.SideResponse
+import com.kakao.actionbase.server.control.topology.Side
+
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
+/**
+ * What each of a tenant's clusters holds, in one answer. A client asks the control plane once
+ * instead of addressing every cluster itself.
+ */
+@RestController
+@ConditionalOnControlRole
+class ControlDatastoreController(
+    private val clusterClient: ClusterClient,
+) {
+    data class TablesView(
+        val tenant: String,
+        val sides: List<SideView>,
+    )
+
+    data class SideView(
+        val side: Side,
+        val ok: Boolean,
+        val tables: List<HBaseTableInfo>? = null,
+        val error: String? = null,
+    )
+
+    @GetMapping("/control/tenants/{tenant}/datastore/tables")
+    fun listTables(
+        @PathVariable tenant: String,
+        @RequestParam(required = false, defaultValue = "false") fanout: Boolean,
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestHeader(value = HttpHeaderConstants.ACTOR_ROLE, required = false) actorRole: String?,
+    ): Mono<TablesView> =
+        clusterClient
+            .get(tenant, TABLES_PATH, fanout, TABLES, forwarded(authorization, actorRole))
+            .map { sides -> TablesView(tenant, sides.map { it.toView() }) }
+
+    /** The caller's identity is the one the cluster should see, so it travels with the request. */
+    private fun forwarded(
+        authorization: String?,
+        actorRole: String?,
+    ): Map<String, String> =
+        buildMap {
+            authorization?.let { put(HttpHeaders.AUTHORIZATION, it) }
+            actorRole?.let { put(HttpHeaderConstants.ACTOR_ROLE, it) }
+        }
+
+    private fun SideResponse<Map<String, List<HBaseTableInfo>>>.toView() =
+        SideView(
+            side = side,
+            ok = ok,
+            tables = body?.get("tables"),
+            error = error,
+        )
+
+    companion object {
+        private const val TABLES_PATH = "/graph/v3/datastore/hbase/tables"
+
+        private val TABLES = object : ParameterizedTypeReference<Map<String, List<HBaseTableInfo>>>() {}
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClient.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClient.kt
@@ -1,0 +1,75 @@
+package com.kakao.actionbase.server.control.cluster
+
+import com.kakao.actionbase.server.control.topology.Side
+import com.kakao.actionbase.server.control.topology.Topology
+
+import java.time.Duration
+
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.web.reactive.function.client.WebClient
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/** One side's answer. A side that failed carries its reason rather than nothing. */
+data class SideResponse<T>(
+    val side: Side,
+    val body: T? = null,
+    val error: String? = null,
+) {
+    val ok: Boolean get() = error == null
+}
+
+/**
+ * Reaches the clusters of one tenant.
+ *
+ * A failing side does not fail the call: an operator needs to know which cluster is unwell, and the
+ * other side's answer is still worth having. Sides come back in a stable order however slow each was.
+ */
+class ClusterClient(
+    private val topology: Topology,
+    private val webClient: WebClient,
+    private val timeout: Duration,
+) {
+    private val log = LoggerFactory.getLogger(ClusterClient::class.java)
+
+    fun <T : Any> get(
+        tenant: String,
+        path: String,
+        fanout: Boolean,
+        type: ParameterizedTypeReference<T>,
+        headers: Map<String, String> = emptyMap(),
+    ): Mono<List<SideResponse<T>>> =
+        Flux
+            .fromIterable(topology.sidesFor(tenant, fanout))
+            .flatMapSequential { side -> get(tenant, side, path, type, headers) }
+            .collectList()
+
+    private fun <T : Any> get(
+        tenant: String,
+        side: Side,
+        path: String,
+        type: ParameterizedTypeReference<T>,
+        headers: Map<String, String>,
+    ): Mono<SideResponse<T>> =
+        webClient
+            .get()
+            .uri(topology.baseUrl(tenant, side) + path)
+            .headers { outgoing -> headers.forEach { (name, value) -> outgoing.set(name, value) } }
+            .retrieve()
+            .bodyToMono(type)
+            .timeout(timeout)
+            .map { SideResponse(side, body = it) }
+            .onErrorResume { failure ->
+                log.warn("Cluster call failed. tenant={}, side={}, path={}", tenant, side, path, failure)
+                Mono.just(SideResponse<T>(side, error = failure.describe()))
+            }
+
+    /** The cause carries the reason a connection failed, so it is surfaced next to the message. */
+    private fun Throwable.describe(): String {
+        val message = message ?: this::class.simpleName
+        val cause = cause?.message?.takeIf { it != message }
+        return listOfNotNull(message, cause).joinToString(" / ")
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientConfiguration.kt
@@ -1,0 +1,20 @@
+package com.kakao.actionbase.server.control.cluster
+
+import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+import com.kakao.actionbase.server.control.topology.Topology
+import com.kakao.actionbase.server.control.topology.TopologyProperties
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+@ConditionalOnControlRole
+class ClusterClientConfiguration {
+    @Bean
+    fun clusterClient(
+        topology: Topology,
+        builder: WebClient.Builder,
+        properties: TopologyProperties,
+    ): ClusterClient = ClusterClient(topology, builder.build(), properties.requestTimeout)
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/TopologyProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/TopologyProperties.kt
@@ -1,5 +1,7 @@
 package com.kakao.actionbase.server.control.topology
 
+import java.time.Duration
+
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -23,6 +25,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "actionbase.control")
 data class TopologyProperties(
     val tenants: Map<String, Tenant> = emptyMap(),
+    /** How long one cluster may take before its side is reported as failed. */
+    val requestTimeout: Duration = Duration.ofSeconds(10),
 ) {
     data class Tenant(
         val env: Env,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/TopologyProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/TopologyProperties.kt
@@ -12,11 +12,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *   role: CONTROL
  *   control:
  *     tenants:
- *       kc:
+ *       alpha:
  *         env: prod
- *         namespace: ab_kc
- *         active-url: http://ab-kc.example.net
- *         standby-url: http://ab-kc-standby.example.net   # omit when there is no standby
+ *         namespace: ab_alpha
+ *         active-url: http://ab-alpha.example.net
+ *         standby-url: http://ab-alpha-standby.example.net   # omit when there is no standby
  * ```
  *
  * `namespace` is declared, not reconciled with the cluster's own config, so a rename on one side

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreE2ETest.kt
@@ -1,0 +1,70 @@
+package com.kakao.actionbase.server.api.control.datastore
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * The fanout endpoint over http. The configured cluster is a closed port, which is the interesting
+ * case: an unreachable cluster is reported as that side failing, not as the request failing.
+ */
+@SpringBootTest(
+    properties = [
+        "actionbase.role=CONTROL",
+        "actionbase.control.request-timeout=2s",
+        "actionbase.control.tenants.kc.env=prod",
+        "actionbase.control.tenants.kc.namespace=ab_kc",
+        "actionbase.control.tenants.kc.active-url=http://127.0.0.1:1",
+        "actionbase.control.tenants.kc.standby-url=http://127.0.0.1:2",
+    ],
+)
+class ControlDatastoreE2ETest : E2ETestBase() {
+    @Test
+    fun `reports an unreachable cluster as that side failing`() {
+        client
+            .get()
+            .uri("/control/tenants/kc/datastore/tables")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.tenant")
+            .isEqualTo("kc")
+            .jsonPath("$.sides.length()")
+            .isEqualTo(1)
+            .jsonPath("$.sides[0].side")
+            .isEqualTo("ACTIVE")
+            .jsonPath("$.sides[0].ok")
+            .isEqualTo(false)
+            .jsonPath("$.sides[0].error")
+            .exists()
+    }
+
+    @Test
+    fun `fanout reaches both sides of a paired tenant`() {
+        client
+            .get()
+            .uri("/control/tenants/kc/datastore/tables?fanout=true")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.sides.length()")
+            .isEqualTo(2)
+            .jsonPath("$.sides[0].side")
+            .isEqualTo("ACTIVE")
+            .jsonPath("$.sides[1].side")
+            .isEqualTo("STANDBY")
+    }
+
+    @Test
+    fun `an unknown tenant is a bad request`() {
+        client
+            .get()
+            .uri("/control/tenants/nope/datastore/tables")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreE2ETest.kt
@@ -13,10 +13,10 @@ import org.springframework.boot.test.context.SpringBootTest
     properties = [
         "actionbase.role=CONTROL",
         "actionbase.control.request-timeout=2s",
-        "actionbase.control.tenants.kc.env=prod",
-        "actionbase.control.tenants.kc.namespace=ab_kc",
-        "actionbase.control.tenants.kc.active-url=http://127.0.0.1:1",
-        "actionbase.control.tenants.kc.standby-url=http://127.0.0.1:2",
+        "actionbase.control.tenants.alpha.env=prod",
+        "actionbase.control.tenants.alpha.namespace=ab_alpha",
+        "actionbase.control.tenants.alpha.active-url=http://127.0.0.1:1",
+        "actionbase.control.tenants.alpha.standby-url=http://127.0.0.1:2",
     ],
 )
 class ControlDatastoreE2ETest : E2ETestBase() {
@@ -24,13 +24,13 @@ class ControlDatastoreE2ETest : E2ETestBase() {
     fun `reports an unreachable cluster as that side failing`() {
         client
             .get()
-            .uri("/control/tenants/kc/datastore/tables")
+            .uri("/control/tenants/alpha/datastore/tables")
             .exchange()
             .expectStatus()
             .isOk
             .expectBody()
             .jsonPath("$.tenant")
-            .isEqualTo("kc")
+            .isEqualTo("alpha")
             .jsonPath("$.sides.length()")
             .isEqualTo(1)
             .jsonPath("$.sides[0].side")
@@ -45,7 +45,7 @@ class ControlDatastoreE2ETest : E2ETestBase() {
     fun `fanout reaches both sides of a paired tenant`() {
         client
             .get()
-            .uri("/control/tenants/kc/datastore/tables?fanout=true")
+            .uri("/control/tenants/alpha/datastore/tables?fanout=true")
             .exchange()
             .expectStatus()
             .isOk

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/topology/ControlRoleE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/topology/ControlRoleE2ETest.kt
@@ -10,13 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest(
     properties = [
         "actionbase.role=CONTROL",
-        "actionbase.control.tenants.kc.env=prod",
-        "actionbase.control.tenants.kc.namespace=ab_kc",
-        "actionbase.control.tenants.kc.active-url=http://ab-kc.example.net",
-        "actionbase.control.tenants.kc.standby-url=http://ab-kc-standby.example.net",
-        "actionbase.control.tenants.talk.env=prod",
-        "actionbase.control.tenants.talk.namespace=ab_talk",
-        "actionbase.control.tenants.talk.active-url=http://ab-talk.example.net",
+        "actionbase.control.tenants.alpha.env=prod",
+        "actionbase.control.tenants.alpha.namespace=ab_alpha",
+        "actionbase.control.tenants.alpha.active-url=http://ab-alpha.example.net",
+        "actionbase.control.tenants.alpha.standby-url=http://ab-alpha-standby.example.net",
+        "actionbase.control.tenants.beta.env=prod",
+        "actionbase.control.tenants.beta.namespace=ab_beta",
+        "actionbase.control.tenants.beta.active-url=http://ab-beta.example.net",
     ],
 )
 class ControlRoleE2ETest : E2ETestBase() {
@@ -32,11 +32,11 @@ class ControlRoleE2ETest : E2ETestBase() {
             .jsonPath("$.tenants.length()")
             .isEqualTo(2)
             .jsonPath("$.tenants[0].tenant")
-            .isEqualTo("kc")
+            .isEqualTo("alpha")
             .jsonPath("$.tenants[0].sides")
             .isEqualTo(listOf("ACTIVE", "STANDBY"))
             .jsonPath("$.tenants[1].tenant")
-            .isEqualTo("talk")
+            .isEqualTo("beta")
             .jsonPath("$.tenants[1].sides")
             .isEqualTo(listOf("ACTIVE"))
     }
@@ -45,13 +45,13 @@ class ControlRoleE2ETest : E2ETestBase() {
     fun `answers for a single tenant`() {
         client
             .get()
-            .uri("/control/topology/talk")
+            .uri("/control/topology/beta")
             .exchange()
             .expectStatus()
             .isOk
             .expectBody()
             .jsonPath("$.namespace")
-            .isEqualTo("ab_talk")
+            .isEqualTo("ab_beta")
             .jsonPath("$.env")
             .isEqualTo("PROD")
     }
@@ -86,6 +86,6 @@ class ControlRoleE2ETest : E2ETestBase() {
             .isBadRequest
             .expectBody()
             .jsonPath("$.message")
-            .value<String> { assertTrue(it.contains("[kc, talk]"), it) }
+            .value<String> { assertTrue(it.contains("[alpha, beta]"), it) }
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientTest.kt
@@ -31,7 +31,7 @@ class ClusterClientTest {
     fun `reaches every configured side and keeps their order`() {
         val client = clusterClient { request -> respond("from ${request.url().host}") }
 
-        val sides = client.get("kc", "/graph/v3/datastore/hbase/tables", fanout = true, stringBody).block()!!
+        val sides = client.get("alpha", "/graph/v3/datastore/hbase/tables", fanout = true, stringBody).block()!!
 
         assertEquals(listOf(Side.ACTIVE, Side.STANDBY), sides.map { it.side })
         assertEquals(
@@ -47,7 +47,7 @@ class ClusterClientTest {
     fun `without fanout only the active side is reached`() {
         val client = clusterClient { respond("ok") }
 
-        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+        val sides = client.get("alpha", "/tables", fanout = false, stringBody).block()!!
 
         assertEquals(listOf(Side.ACTIVE), sides.map { it.side })
         assertEquals(1, recorded.size)
@@ -65,7 +65,7 @@ class ClusterClientTest {
                 }
             }
 
-        val sides = client.get("kc", "/tables", fanout = true, stringBody).block()!!
+        val sides = client.get("alpha", "/tables", fanout = true, stringBody).block()!!
 
         val active = sides.single { it.side == Side.ACTIVE }
         assertTrue(active.ok)
@@ -81,7 +81,7 @@ class ClusterClientTest {
     fun `a non 2xx side reports the status rather than a body`() {
         val client = clusterClient { ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build().toMono() }
 
-        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+        val sides = client.get("alpha", "/tables", fanout = false, stringBody).block()!!
 
         assertTrue(!sides.single().ok)
         assertTrue(sides.single().error!!.contains("500"), sides.single().error)
@@ -94,7 +94,7 @@ class ClusterClientTest {
                 respond("too late").delayElement(Duration.ofSeconds(5))
             }
 
-        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+        val sides = client.get("alpha", "/tables", fanout = false, stringBody).block()!!
 
         assertTrue(!sides.single().ok)
     }
@@ -106,7 +106,7 @@ class ClusterClientTest {
 
         client
             .get(
-                "kc",
+                "alpha",
                 "/tables",
                 fanout = false,
                 stringBody,
@@ -154,10 +154,10 @@ class ClusterClientTest {
     private fun topology(): Topology =
         TopologyProperties(
             mapOf(
-                "kc" to
+                "alpha" to
                     TopologyProperties.Tenant(
                         env = Env.PROD,
-                        namespace = "ab_kc",
+                        namespace = "ab_alpha",
                         activeUrl = "http://active.example.net",
                         standbyUrl = "http://standby.example.net",
                     ),

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientTest.kt
@@ -1,0 +1,172 @@
+package com.kakao.actionbase.server.control.cluster
+
+import com.kakao.actionbase.server.control.topology.Env
+import com.kakao.actionbase.server.control.topology.Side
+import com.kakao.actionbase.server.control.topology.Topology
+import com.kakao.actionbase.server.control.topology.TopologyProperties
+
+import java.time.Duration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+
+import reactor.core.publisher.Mono
+
+// No stub server: the exchange function stands in for the clusters, so nothing binds a port.
+class ClusterClientTest {
+    private val recorded = mutableListOf<ClientRequest>()
+
+    private val stringBody = object : ParameterizedTypeReference<String>() {}
+
+    @Test
+    fun `reaches every configured side and keeps their order`() {
+        val client = clusterClient { request -> respond("from ${request.url().host}") }
+
+        val sides = client.get("kc", "/graph/v3/datastore/hbase/tables", fanout = true, stringBody).block()!!
+
+        assertEquals(listOf(Side.ACTIVE, Side.STANDBY), sides.map { it.side })
+        assertEquals(
+            listOf(
+                "http://active.example.net/graph/v3/datastore/hbase/tables",
+                "http://standby.example.net/graph/v3/datastore/hbase/tables",
+            ),
+            recorded.map { it.url().toString() },
+        )
+    }
+
+    @Test
+    fun `without fanout only the active side is reached`() {
+        val client = clusterClient { respond("ok") }
+
+        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+
+        assertEquals(listOf(Side.ACTIVE), sides.map { it.side })
+        assertEquals(1, recorded.size)
+    }
+
+    // The point of the per-side shape: a broken standby must not cost the operator the active answer.
+    @Test
+    fun `a failing side does not hide the other`() {
+        val client =
+            clusterClient { request ->
+                if (request.url().host == "standby.example.net") {
+                    Mono.error(IllegalStateException("connection refused"))
+                } else {
+                    respond("healthy")
+                }
+            }
+
+        val sides = client.get("kc", "/tables", fanout = true, stringBody).block()!!
+
+        val active = sides.single { it.side == Side.ACTIVE }
+        assertTrue(active.ok)
+        assertEquals("healthy", active.body)
+
+        val standby = sides.single { it.side == Side.STANDBY }
+        assertTrue(!standby.ok)
+        assertNull(standby.body)
+        assertTrue(standby.error!!.contains("connection refused"), standby.error)
+    }
+
+    @Test
+    fun `a non 2xx side reports the status rather than a body`() {
+        val client = clusterClient { ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build().toMono() }
+
+        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+
+        assertTrue(!sides.single().ok)
+        assertTrue(sides.single().error!!.contains("500"), sides.single().error)
+    }
+
+    @Test
+    fun `a side that never answers is failed by the timeout`() {
+        val client =
+            clusterClient(timeout = Duration.ofMillis(50)) {
+                respond("too late").delayElement(Duration.ofSeconds(5))
+            }
+
+        val sides = client.get("kc", "/tables", fanout = false, stringBody).block()!!
+
+        assertTrue(!sides.single().ok)
+    }
+
+    // The cluster must see who is asking, not who is relaying.
+    @Test
+    fun `forwards the caller's identity`() {
+        val client = clusterClient { respond("ok") }
+
+        client
+            .get(
+                "kc",
+                "/tables",
+                fanout = false,
+                stringBody,
+                headers = mapOf("Authorization" to "token", "Actor-ROLE" to "ADMIN"),
+            ).block()
+
+        val sent = recorded.single().headers()
+        assertEquals("token", sent.getFirst("Authorization"))
+        assertEquals("ADMIN", sent.getFirst("Actor-ROLE"))
+    }
+
+    @Test
+    fun `an unpaired tenant ignores fanout instead of failing`() {
+        val client = clusterClient { respond("ok") }
+
+        val sides = client.get("solo", "/tables", fanout = true, stringBody).block()!!
+
+        assertEquals(listOf(Side.ACTIVE), sides.map { it.side })
+    }
+
+    private fun respond(body: String): Mono<ClientResponse> =
+        ClientResponse
+            .create(HttpStatus.OK)
+            .header("Content-Type", MediaType.TEXT_PLAIN_VALUE)
+            .body(body)
+            .build()
+            .toMono()
+
+    private fun ClientResponse.toMono(): Mono<ClientResponse> = Mono.just(this)
+
+    private fun clusterClient(
+        timeout: Duration = Duration.ofSeconds(5),
+        exchange: (ClientRequest) -> Mono<ClientResponse>,
+    ): ClusterClient {
+        val webClient =
+            WebClient
+                .builder()
+                .exchangeFunction { request ->
+                    recorded += request
+                    exchange(request)
+                }.build()
+        return ClusterClient(topology(), webClient, timeout)
+    }
+
+    private fun topology(): Topology =
+        TopologyProperties(
+            mapOf(
+                "kc" to
+                    TopologyProperties.Tenant(
+                        env = Env.PROD,
+                        namespace = "ab_kc",
+                        activeUrl = "http://active.example.net",
+                        standbyUrl = "http://standby.example.net",
+                    ),
+                "solo" to
+                    TopologyProperties.Tenant(
+                        env = Env.DEV,
+                        namespace = "ab_solo",
+                        activeUrl = "http://solo.example.net",
+                    ),
+            ),
+        ).toTopology()
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/topology/TopologyTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/topology/TopologyTest.kt
@@ -11,33 +11,33 @@ class TopologyTest {
 
     private fun paired(
         env: Env = Env.PROD,
-        standby: String? = "http://ab-kc.example.net:8080",
+        standby: String? = "http://ab-alpha.example.net:8080",
     ) = TopologyProperties.Tenant(
         env = env,
-        namespace = "ab_kc",
-        activeUrl = "http://ab-kc.example.net",
+        namespace = "ab_alpha",
+        activeUrl = "http://ab-alpha.example.net",
         standbyUrl = standby,
     )
 
     @Test
     fun `a tenant resolves to the url of each configured side`() {
-        val topology = props("kc" to paired()).toTopology()
+        val topology = props("alpha" to paired()).toTopology()
 
-        assertEquals("http://ab-kc.example.net", topology.baseUrl("kc", Side.ACTIVE))
-        assertEquals("http://ab-kc.example.net:8080", topology.baseUrl("kc", Side.STANDBY))
+        assertEquals("http://ab-alpha.example.net", topology.baseUrl("alpha", Side.ACTIVE))
+        assertEquals("http://ab-alpha.example.net:8080", topology.baseUrl("alpha", Side.STANDBY))
     }
 
     @Test
     fun `a trailing slash is trimmed so paths can be appended`() {
-        val topology = props("kc" to paired().copy(activeUrl = "http://ab-kc.example.net/")).toTopology()
+        val topology = props("alpha" to paired().copy(activeUrl = "http://ab-alpha.example.net/")).toTopology()
 
-        assertEquals("http://ab-kc.example.net", topology.baseUrl("kc", Side.ACTIVE))
+        assertEquals("http://ab-alpha.example.net", topology.baseUrl("alpha", Side.ACTIVE))
     }
 
     @Test
     fun `a relative url is rejected at startup rather than at the first request`() {
         assertThrows(IllegalArgumentException::class.java) {
-            props("kc" to paired().copy(activeUrl = "ab-kc.example.net")).toTopology()
+            props("alpha" to paired().copy(activeUrl = "ab-alpha.example.net")).toTopology()
         }
     }
 
@@ -49,51 +49,51 @@ class TopologyTest {
 
     @Test
     fun `an unknown tenant names what is configured`() {
-        val topology = props("kc" to paired()).toTopology()
+        val topology = props("alpha" to paired()).toTopology()
 
         val thrown = assertThrows(UnknownTenantException::class.java) { topology.tenant("nope") }
-        assertTrue(thrown.message!!.contains("[kc]"), thrown.message)
+        assertTrue(thrown.message!!.contains("[alpha]"), thrown.message)
     }
 
     @Test
     fun `a tenant without a standby has no standby url`() {
-        val topology = props("talk" to paired(standby = null)).toTopology()
+        val topology = props("beta" to paired(standby = null)).toTopology()
 
-        assertFalse(topology.tenant("talk").hasStandby)
-        assertThrows(UnknownSideException::class.java) { topology.baseUrl("talk", Side.STANDBY) }
+        assertFalse(topology.tenant("beta").hasStandby)
+        assertThrows(UnknownSideException::class.java) { topology.baseUrl("beta", Side.STANDBY) }
     }
 
     @Test
     fun `fanout reaches both sides when the tenant is paired`() {
-        val topology = props("kc" to paired()).toTopology()
+        val topology = props("alpha" to paired()).toTopology()
 
-        assertEquals(listOf(Side.ACTIVE, Side.STANDBY), topology.sidesFor("kc", fanout = true))
+        assertEquals(listOf(Side.ACTIVE, Side.STANDBY), topology.sidesFor("alpha", fanout = true))
     }
 
     @Test
     fun `fanout on an unpaired tenant is ignored, not an error`() {
         // A caller should not have to know which tenants are paired to ask for a fanout.
-        val topology = props("talk" to paired(standby = null)).toTopology()
+        val topology = props("beta" to paired(standby = null)).toTopology()
 
-        assertEquals(listOf(Side.ACTIVE), topology.sidesFor("talk", fanout = true))
+        assertEquals(listOf(Side.ACTIVE), topology.sidesFor("beta", fanout = true))
     }
 
     @Test
     fun `without fanout only the active side is reached`() {
-        val topology = props("kc" to paired()).toTopology()
+        val topology = props("alpha" to paired()).toTopology()
 
-        assertEquals(listOf(Side.ACTIVE), topology.sidesFor("kc", fanout = false))
+        assertEquals(listOf(Side.ACTIVE), topology.sidesFor("alpha", fanout = false))
     }
 
     @Test
     fun `tenants are listed in a stable order`() {
         val topology =
             props(
-                "talk" to paired(standby = null),
-                "kc" to paired(),
+                "beta" to paired(standby = null),
+                "alpha" to paired(),
                 "stg" to paired(env = Env.TEST),
             ).toTopology()
 
-        assertEquals(listOf("kc", "stg", "talk"), topology.tenants.map { it.tenant })
+        assertEquals(listOf("alpha", "beta", "stg"), topology.tenants.map { it.tenant })
     }
 }

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -317,7 +317,7 @@ class ReadOnlyRequestFilterTest {
                 "table" to "t",
                 "tableFullName" to "t",
                 "tableName" to "t",
-                "tenant" to "kc",
+                "tenant" to "alpha",
             )
 
         private fun resolvePath(template: String): String =

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -259,6 +259,7 @@ class ReadOnlyRequestFilterTest {
             setOf(
                 "GET /control/topology",
                 "GET /control/topology/{tenant}",
+                "GET /control/tenants/{tenant}/datastore/tables",
             )
 
         val NON_GRAPH_ENDPOINTS =


### PR DESCRIPTION
## Summary

#480 resolved a tenant's clusters into a `Topology` and then stopped: `baseUrl(tenant, side)` and `sidesFor(tenant, fanout)` were written and tested with nothing calling them. This is the layer that calls them.

`ClusterClient` reaches the clusters of one tenant and returns one entry per side. **A failing side does not fail the call.** An operator asking what a tenant holds needs to know which cluster is unwell, and the healthy side's answer is still worth having — so each side comes back with either a body or its reason, in a stable order however slow either was. The cause is surfaced next to the message, because that is where the reason a connection failed actually lives.

The caller's `Authorization` and `Actor-ROLE` travel with the request: the cluster should see who is asking, not who is relaying.

Nothing mutates yet. Per the roadmap in #370, destructive execution lands after authorization.

## Changes

- Add `ClusterClient` and `SideResponse` under `server/control/cluster`
- Add `actionbase.control.request-timeout` (default 10s) — how long one cluster may take before its side is reported as failed
- Add `GET /control/tenants/{tenant}/datastore/tables?fanout=true`, merging each side's table listing

## How to Test

```
./gradlew :server:test --tests "*ClusterClientTest*" --tests "*ControlDatastoreE2ETest*"
```

There is no stub-server dependency in this repo and this PR does not add one: the unit tests substitute an exchange function for the clusters, so nothing binds a port. Covered there: per-side ordering, fanout on and off, a failing side not hiding a healthy one, a non-2xx side reporting its status, the timeout, and header forwarding.

`ControlDatastoreE2ETest` points the topology at a closed port, which is the interesting case over http — an unreachable cluster must be reported as *that side* failing with a 200 overall, not as the request failing.

## Notes

A `CONTROL` instance refuses `/graph/v2`, `/graph/v3` and `/queue/v1` on itself, so it cannot be its own data plane. That rules out the tempting shortcut of pointing a test's `active-url` at its own port.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
