### PR TITLE
Answer what is left to clean up across the fleet

### DIFF
--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/control/cleanup/ControlCleanupController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/control/cleanup/ControlCleanupController.kt
@@ -1,0 +1,34 @@
+package com.kakao.actionbase.server.api.control.cleanup
+
+import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+import com.kakao.actionbase.server.control.cleanup.CleanupService
+import com.kakao.actionbase.server.control.cleanup.HtablesView
+import com.kakao.actionbase.server.control.cluster.CallerHeaders
+import com.kakao.actionbase.server.control.topology.Env
+
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
+/**
+ * What is left to clean up across the fleet. One request answers for every configured tenant, both
+ * sides, with the bindings that still hold each table.
+ */
+@RestController
+@ConditionalOnControlRole
+class ControlCleanupController(
+    private val cleanupService: CleanupService,
+) {
+    @GetMapping("/control/htables")
+    fun htables(
+        @RequestParam(required = false) tenant: String?,
+        @RequestParam(required = false) env: String?,
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestHeader(value = HttpHeaderConstants.ACTOR_ROLE, required = false) actorRole: String?,
+    ): Mono<HtablesView> = cleanupService.htables(tenant, env?.let(Env::of), CallerHeaders.forwarded(authorization, actorRole))
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/control/datastore/ControlDatastoreController.kt
@@ -3,6 +3,7 @@ package com.kakao.actionbase.server.api.control.datastore
 import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableInfo
 import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
 import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+import com.kakao.actionbase.server.control.cluster.CallerHeaders
 import com.kakao.actionbase.server.control.cluster.ClusterClient
 import com.kakao.actionbase.server.control.cluster.SideResponse
 import com.kakao.actionbase.server.control.topology.Side
@@ -46,18 +47,8 @@ class ControlDatastoreController(
         @RequestHeader(value = HttpHeaderConstants.ACTOR_ROLE, required = false) actorRole: String?,
     ): Mono<TablesView> =
         clusterClient
-            .get(tenant, TABLES_PATH, fanout, TABLES, forwarded(authorization, actorRole))
+            .get(tenant, TABLES_PATH, fanout, TABLES, CallerHeaders.forwarded(authorization, actorRole))
             .map { sides -> TablesView(tenant, sides.map { it.toView() }) }
-
-    /** The caller's identity is the one the cluster should see, so it travels with the request. */
-    private fun forwarded(
-        authorization: String?,
-        actorRole: String?,
-    ): Map<String, String> =
-        buildMap {
-            authorization?.let { put(HttpHeaders.AUTHORIZATION, it) }
-            actorRole?.let { put(HttpHeaderConstants.ACTOR_ROLE, it) }
-        }
 
     private fun SideResponse<Map<String, List<HBaseTableInfo>>>.toView() =
         SideView(

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupProjection.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupProjection.kt
@@ -1,0 +1,85 @@
+package com.kakao.actionbase.server.control.cleanup
+
+import com.kakao.actionbase.server.control.topology.Side
+
+/**
+ * Turns what each side reported into one row per table.
+ *
+ * Pure: everything it knows arrives in the snapshots. The one thing it can say that no single
+ * cluster can is who else holds a table - two tenants configured against the same cluster produce
+ * the same cluster key, so a table held from elsewhere shows up as [TableView.sharedWith].
+ */
+object CleanupProjection {
+    fun project(snapshots: List<SideSnapshot>): HtablesView {
+        val answered = snapshots.filter { it.error == null }
+        val holders = answered.holdersByClusterTable()
+
+        return HtablesView(
+            tables =
+                answered
+                    .groupBy { it.tenant }
+                    .flatMap { (tenant, sides) -> tenant.tablesOf(sides, holders) }
+                    .sortedWith(compareBy({ it.tenant }, { it.name })),
+            failures =
+                snapshots
+                    .filter { it.error != null }
+                    .map { SideFailure(it.tenant, it.side, it.error!!) }
+                    .sortedWith(compareBy({ it.tenant }, { it.side })),
+        )
+    }
+
+    /** Who has each `cluster -> table`, so a row can name the tenants that also hold it. */
+    private fun List<SideSnapshot>.holdersByClusterTable(): Map<Pair<String, String>, List<TenantSide>> =
+        flatMap { snapshot -> snapshot.tables.map { (snapshot.cluster to it.name) to TenantSide(snapshot.tenant, snapshot.side) } }
+            .groupBy({ it.first }, { it.second })
+
+    private fun String.tablesOf(
+        sides: List<SideSnapshot>,
+        holders: Map<Pair<String, String>, List<TenantSide>>,
+    ): List<TableView> {
+        val tenant = this
+        val byName = sides.associateBy { it.side }
+
+        // Metadata outliving its table is cleanup work too, and it is the only work left on such a
+        // row - so names come from the references as well, not just from the tables that still exist.
+        return (sides.flatMap { snapshot -> snapshot.tables.map { it.name } } + sides.flatMap { it.references.keys })
+            .distinct()
+            .map { name ->
+                TableView(
+                    tenant = tenant,
+                    name = name,
+                    sides = Side.entries.mapNotNull { side -> byName[side]?.let { side to it.stateOf(name) } }.toMap(),
+                    references = byName.values.flatMap { it.referencesTo(name) }.sortedWith(referenceOrder),
+                    sharedWith =
+                        byName.values
+                            .flatMap { holders[it.cluster to name].orEmpty() }
+                            .filter { it.tenant != tenant }
+                            .distinct()
+                            .sortedWith(compareBy({ it.tenant }, { it.side })),
+                )
+            }
+    }
+
+    private fun SideSnapshot.stateOf(name: String): SideState {
+        val table = tables.firstOrNull { it.name == name }
+        return SideState(
+            cluster = cluster,
+            present = table != null,
+            enabled = table?.enabled,
+            replicationScope = table?.replicationScope,
+        )
+    }
+
+    private fun SideSnapshot.referencesTo(name: String): List<ReferenceView> =
+        references[name].orEmpty().map {
+            ReferenceView(
+                tenant = tenant,
+                side = side,
+                kind = it.kind,
+                name = it.name.fullQualifiedName,
+                active = it.active,
+            )
+        }
+
+    private val referenceOrder = compareBy<ReferenceView>({ it.tenant }, { it.side }, { it.kind }, { it.name })
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupService.kt
@@ -1,0 +1,98 @@
+package com.kakao.actionbase.server.control.cleanup
+
+import com.kakao.actionbase.engine.datastore.hbase.admin.HBaseTableInfo
+import com.kakao.actionbase.server.control.cluster.ClusterClient
+import com.kakao.actionbase.server.control.cluster.SideResponse
+import com.kakao.actionbase.server.control.topology.Env
+import com.kakao.actionbase.server.control.topology.Topology
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReference
+
+import org.springframework.core.ParameterizedTypeReference
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/**
+ * Collects what every selected tenant's clusters hold and hands it to [CleanupProjection].
+ *
+ * Both sides of a tenant are always read: a cleanup view whose standby is missing would hide
+ * exactly the work that is left to do.
+ */
+class CleanupService(
+    private val topology: Topology,
+    private val clusterClient: ClusterClient,
+) {
+    fun htables(
+        tenant: String?,
+        env: Env?,
+        headers: Map<String, String>,
+    ): Mono<HtablesView> =
+        Flux
+            .fromIterable(selected(tenant, env))
+            .flatMapSequential { snapshots(it, headers) }
+            .collectList()
+            .map { CleanupProjection.project(it.flatten()) }
+
+    /** A named tenant that is not configured is a bad request, not an empty answer. */
+    private fun selected(
+        tenant: String?,
+        env: Env?,
+    ): List<String> {
+        tenant?.let { topology.tenant(it) }
+        return topology.tenants
+            .filter { tenant == null || it.tenant == tenant }
+            .filter { env == null || it.env == env }
+            .map { it.tenant }
+    }
+
+    private fun snapshots(
+        tenant: String,
+        headers: Map<String, String>,
+    ): Mono<List<SideSnapshot>> =
+        Mono
+            .zip(
+                clusterClient.get(tenant, TABLES_PATH, fanout = true, TABLES, headers),
+                clusterClient.get(tenant, REFERENCES_PATH, fanout = true, REFERENCES, headers),
+            ).map { answers -> merge(tenant, answers.t1, answers.t2) }
+
+    private fun merge(
+        tenant: String,
+        tables: List<SideResponse<Map<String, List<HBaseTableInfo>>>>,
+        references: List<SideResponse<Map<String, Map<String, List<DatastoreTableReference>>>>>,
+    ): List<SideSnapshot> {
+        val referencesBySide = references.associateBy { it.side }
+        return tables.map { table ->
+            val reference = referencesBySide[table.side]
+            SideSnapshot(
+                tenant = tenant,
+                side = table.side,
+                cluster = topology.cluster(tenant, table.side),
+                tables =
+                    table.body
+                        ?.get("tables")
+                        .orEmpty()
+                        .map { it.toTableInfo() },
+                references = reference?.body?.get("references").orEmpty(),
+                // Either call failing leaves this side's picture incomplete, so it is a failed side
+                // rather than a half-answered one that reads as "nothing left to clean up".
+                error = table.error ?: reference?.error,
+            )
+        }
+    }
+
+    private fun HBaseTableInfo.toTableInfo() =
+        SideSnapshot.TableInfo(
+            name = name,
+            enabled = isEnabled,
+            replicationScope = replicationScope,
+        )
+
+    companion object {
+        private const val TABLES_PATH = "/graph/v3/datastore/hbase/tables"
+        private const val REFERENCES_PATH = "/graph/v3/datastore/hbase/references"
+
+        private val TABLES = object : ParameterizedTypeReference<Map<String, List<HBaseTableInfo>>>() {}
+
+        private val REFERENCES = object : ParameterizedTypeReference<Map<String, Map<String, List<DatastoreTableReference>>>>() {}
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/HtablesView.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cleanup/HtablesView.kt
@@ -1,0 +1,64 @@
+package com.kakao.actionbase.server.control.cleanup
+
+import com.kakao.actionbase.server.control.topology.Side
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReference
+
+/** What one side of one tenant reported. The input to the projection, one entry per call made. */
+data class SideSnapshot(
+    val tenant: String,
+    val side: Side,
+    val cluster: String,
+    val tables: List<TableInfo> = emptyList(),
+    val references: Map<String, List<DatastoreTableReference>> = emptyMap(),
+    val error: String? = null,
+) {
+    data class TableInfo(
+        val name: String,
+        val enabled: Boolean,
+        val replicationScope: Int,
+    )
+}
+
+data class HtablesView(
+    val tables: List<TableView>,
+    val failures: List<SideFailure>,
+)
+
+/**
+ * One datastore table as the fleet sees it. Sides are symmetric: a table that exists only on the
+ * standby is simply an absent active side, not a separate kind of row.
+ */
+data class TableView(
+    val tenant: String,
+    val name: String,
+    val sides: Map<Side, SideState>,
+    val references: List<ReferenceView>,
+    val sharedWith: List<TenantSide>,
+)
+
+data class SideState(
+    val cluster: String,
+    val present: Boolean,
+    val enabled: Boolean? = null,
+    val replicationScope: Int? = null,
+)
+
+/** A binding that still holds the table, and which side it was found on. */
+data class ReferenceView(
+    val tenant: String,
+    val side: Side,
+    val kind: DatastoreTableReference.Kind,
+    val name: String,
+    val active: Boolean,
+)
+
+data class TenantSide(
+    val tenant: String,
+    val side: Side,
+)
+
+data class SideFailure(
+    val tenant: String,
+    val side: Side,
+    val error: String,
+)

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/CallerHeaders.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/CallerHeaders.kt
@@ -1,0 +1,17 @@
+package com.kakao.actionbase.server.control.cluster
+
+import com.kakao.actionbase.server.configuration.HttpHeaderConstants
+
+import org.springframework.http.HttpHeaders
+
+/** The cluster should see who is asking, not who is relaying. */
+object CallerHeaders {
+    fun forwarded(
+        authorization: String?,
+        actorRole: String?,
+    ): Map<String, String> =
+        buildMap {
+            authorization?.let { put(HttpHeaders.AUTHORIZATION, it) }
+            actorRole?.let { put(HttpHeaderConstants.ACTOR_ROLE, it) }
+        }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/cluster/ClusterClientConfiguration.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.control.cluster
 
 import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+import com.kakao.actionbase.server.control.cleanup.CleanupService
 import com.kakao.actionbase.server.control.topology.Topology
 import com.kakao.actionbase.server.control.topology.TopologyProperties
 
@@ -17,4 +18,10 @@ class ClusterClientConfiguration {
         builder: WebClient.Builder,
         properties: TopologyProperties,
     ): ClusterClient = ClusterClient(topology, builder.build(), properties.requestTimeout)
+
+    @Bean
+    fun cleanupService(
+        topology: Topology,
+        clusterClient: ClusterClient,
+    ): CleanupService = CleanupService(topology, clusterClient)
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/Topology.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/topology/Topology.kt
@@ -1,9 +1,22 @@
 package com.kakao.actionbase.server.control.topology
 
+import java.net.URI
+
 enum class Env {
     DEV,
     TEST,
     PROD,
+    ;
+
+    companion object {
+        /**
+         * Config binding accepts `env: prod`, so a query parameter has to as well - a surface that
+         * takes one spelling in yaml and another in a url is a surface people get wrong.
+         */
+        fun of(value: String): Env =
+            entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("unknown env '$value', expected one of ${entries.map { it.name.lowercase() }}")
+    }
 }
 
 /** Which cluster of a tenant a request is aimed at. */
@@ -45,6 +58,15 @@ class Topology(
         tenant: String,
         side: Side,
     ): String = tenant(tenant).sides[side] ?: throw UnknownSideException(tenant, side)
+
+    /**
+     * Which cluster a side is, as `host:port`. Two tenants configured against the same cluster get
+     * the same answer, which is how sharing is noticed without asking anyone to declare it.
+     */
+    fun cluster(
+        tenant: String,
+        side: Side,
+    ): String = URI(baseUrl(tenant, side)).authority
 
     /** Fanout on an unpaired tenant reaches the active only - a caller need not know which are paired. */
     fun sidesFor(

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/cleanup/ControlCleanupE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/cleanup/ControlCleanupE2ETest.kt
@@ -1,0 +1,97 @@
+package com.kakao.actionbase.server.api.control.cleanup
+
+import com.kakao.actionbase.server.test.E2ETestBase
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * The cleanup view over http. Both configured clusters are closed ports, so every side fails - the
+ * case that must not read as "nothing left to clean up".
+ */
+@SpringBootTest(
+    properties = [
+        "actionbase.role=CONTROL",
+        "actionbase.control.request-timeout=2s",
+        "actionbase.control.tenants.alpha.env=prod",
+        "actionbase.control.tenants.alpha.namespace=ab_alpha",
+        "actionbase.control.tenants.alpha.active-url=http://127.0.0.1:1",
+        "actionbase.control.tenants.alpha.standby-url=http://127.0.0.1:2",
+        "actionbase.control.tenants.stg.env=test",
+        "actionbase.control.tenants.stg.namespace=ab_stg",
+        "actionbase.control.tenants.stg.active-url=http://127.0.0.1:3",
+    ],
+)
+class ControlCleanupE2ETest : E2ETestBase() {
+    @Test
+    fun `every unreachable side is reported as a failure`() {
+        client
+            .get()
+            .uri("/control/htables")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.tables.length()")
+            .isEqualTo(0)
+            // alpha active, alpha standby, stg active
+            .jsonPath("$.failures.length()")
+            .isEqualTo(3)
+            .jsonPath("$.failures[0].tenant")
+            .isEqualTo("alpha")
+            .jsonPath("$.failures[0].error")
+            .exists()
+    }
+
+    @Test
+    fun `a tenant filter narrows the fleet`() {
+        client
+            .get()
+            .uri("/control/htables?tenant=stg")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.failures.length()")
+            .isEqualTo(1)
+            .jsonPath("$.failures[0].tenant")
+            .isEqualTo("stg")
+    }
+
+    @Test
+    fun `an env filter narrows the fleet`() {
+        client
+            .get()
+            .uri("/control/htables?env=prod")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.failures.length()")
+            .isEqualTo(2)
+    }
+
+    @Test
+    fun `an unknown env names the ones that exist`() {
+        client
+            .get()
+            .uri("/control/htables?env=staging")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.message")
+            .value<String> { assertTrue(it.contains("dev"), it) }
+    }
+
+    @Test
+    fun `an unknown tenant is a bad request`() {
+        client
+            .get()
+            .uri("/control/htables?tenant=nope")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupProjectionTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/cleanup/CleanupProjectionTest.kt
@@ -1,0 +1,184 @@
+package com.kakao.actionbase.server.control.cleanup
+
+import com.kakao.actionbase.server.control.topology.Side
+import com.kakao.actionbase.v2.engine.entity.EntityName
+import com.kakao.actionbase.v2.engine.service.ddl.DatastoreTableReference
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CleanupProjectionTest {
+    @Test
+    fun `a table reports the state of each side`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "a:80", table("ns:t", enabled = true, scope = 1)),
+                    snapshot(Side.STANDBY, "b:80", table("ns:t", enabled = false, scope = 0)),
+                ),
+            )
+
+        val table = view.tables.single()
+        assertEquals(listOf(Side.ACTIVE, Side.STANDBY), table.sides.keys.toList())
+        assertEquals(SideState("a:80", present = true, enabled = true, replicationScope = 1), table.sides[Side.ACTIVE])
+        assertEquals(SideState("b:80", present = true, enabled = false, replicationScope = 0), table.sides[Side.STANDBY])
+    }
+
+    // The standby-only table is the case a client-side model usually needs a separate list for.
+    @Test
+    fun `a table only on the standby is an absent active side`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "a:80"),
+                    snapshot(Side.STANDBY, "b:80", table("ns:leftover")),
+                ),
+            )
+
+        val table = view.tables.single()
+        assertEquals("ns:leftover", table.name)
+        assertFalse(table.sides.getValue(Side.ACTIVE).present)
+        assertNull(table.sides.getValue(Side.ACTIVE).enabled)
+        assertTrue(table.sides.getValue(Side.STANDBY).present)
+    }
+
+    // The purge case: the table is gone everywhere and only its metadata is left. A row driven by
+    // the tables that still exist would drop it, which is the one row with work left on it.
+    @Test
+    fun `metadata outliving its table is still a row`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(
+                        Side.ACTIVE,
+                        "a:80",
+                        references = mapOf("ns:dropped" to listOf(reference(DatastoreTableReference.Kind.STORAGE, "svc.store", active = false))),
+                    ),
+                ),
+            )
+
+        val table = view.tables.single()
+        assertEquals("ns:dropped", table.name)
+        assertFalse(table.sides.getValue(Side.ACTIVE).present)
+        assertEquals("svc.store", table.references.single().name)
+    }
+
+    // Only the control plane can see this: one cluster, two tenants configured against it.
+    @Test
+    fun `a table held from another tenant names that tenant`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "shared:80", table("ns:t"), tenant = "kc"),
+                    snapshot(Side.ACTIVE, "shared:80", table("ns:t"), tenant = "talk"),
+                ),
+            )
+
+        val kc = view.tables.single { it.tenant == "kc" }
+        assertEquals(listOf(TenantSide("talk", Side.ACTIVE)), kc.sharedWith)
+
+        val talk = view.tables.single { it.tenant == "talk" }
+        assertEquals(listOf(TenantSide("kc", Side.ACTIVE)), talk.sharedWith)
+    }
+
+    @Test
+    fun `a table on its own cluster is shared with nobody`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "a:80", table("ns:t"), tenant = "kc"),
+                    snapshot(Side.ACTIVE, "b:80", table("ns:t"), tenant = "talk"),
+                ),
+            )
+
+        assertTrue(view.tables.all { it.sharedWith.isEmpty() }, view.tables.toString())
+    }
+
+    @Test
+    fun `references carry the side they were found on`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(
+                        Side.STANDBY,
+                        "b:80",
+                        table("ns:t"),
+                        references = mapOf("ns:t" to listOf(reference(DatastoreTableReference.Kind.LABEL, "svc.label", active = true))),
+                    ),
+                ),
+            )
+
+        val held =
+            view.tables
+                .single()
+                .references
+                .single()
+        assertEquals(Side.STANDBY, held.side)
+        assertEquals(DatastoreTableReference.Kind.LABEL, held.kind)
+        assertEquals("svc.label", held.name)
+        assertTrue(held.active)
+    }
+
+    @Test
+    fun `a failed side is reported instead of read as nothing to clean up`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "a:80", table("ns:t")),
+                    SideSnapshot(tenant = "kc", side = Side.STANDBY, cluster = "b:80", error = "connection refused"),
+                ),
+            )
+
+        assertEquals(listOf(SideFailure("kc", Side.STANDBY, "connection refused")), view.failures)
+        // The active answer survives, and the standby is absent from the row rather than "not present".
+        assertEquals(
+            listOf(Side.ACTIVE),
+            view.tables
+                .single()
+                .sides.keys
+                .toList(),
+        )
+    }
+
+    @Test
+    fun `rows are ordered by tenant then name`() {
+        val view =
+            CleanupProjection.project(
+                listOf(
+                    snapshot(Side.ACTIVE, "a:80", table("ns:b"), table("ns:a"), tenant = "talk"),
+                    snapshot(Side.ACTIVE, "c:80", table("ns:z"), tenant = "kc"),
+                ),
+            )
+
+        assertEquals(listOf("kc" to "ns:z", "talk" to "ns:a", "talk" to "ns:b"), view.tables.map { it.tenant to it.name })
+    }
+
+    private fun snapshot(
+        side: Side,
+        cluster: String,
+        vararg tables: SideSnapshot.TableInfo,
+        tenant: String = "kc",
+        references: Map<String, List<DatastoreTableReference>> = emptyMap(),
+    ) = SideSnapshot(
+        tenant = tenant,
+        side = side,
+        cluster = cluster,
+        tables = tables.toList(),
+        references = references,
+    )
+
+    private fun table(
+        name: String,
+        enabled: Boolean = true,
+        scope: Int = 0,
+    ) = SideSnapshot.TableInfo(name, enabled, scope)
+
+    private fun reference(
+        kind: DatastoreTableReference.Kind,
+        name: String,
+        active: Boolean,
+    ) = DatastoreTableReference(kind, EntityName.of(name), active)
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/topology/TopologyTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/topology/TopologyTest.kt
@@ -85,6 +85,39 @@ class TopologyTest {
         assertEquals(listOf(Side.ACTIVE), topology.sidesFor("alpha", fanout = false))
     }
 
+    // Sharing is noticed by two tenants resolving to the same cluster, so this is how it is noticed.
+    @Test
+    fun `tenants configured against the same cluster get the same cluster key`() {
+        val topology =
+            props(
+                "alpha" to paired(standby = null),
+                "beta" to paired(standby = null),
+            ).toTopology()
+
+        assertEquals(topology.cluster("alpha", Side.ACTIVE), topology.cluster("beta", Side.ACTIVE))
+    }
+
+    @Test
+    fun `the cluster key keeps the port so two clusters on one host stay apart`() {
+        val topology = props("alpha" to paired()).toTopology()
+
+        assertEquals("ab-alpha.example.net", topology.cluster("alpha", Side.ACTIVE))
+        assertEquals("ab-alpha.example.net:8080", topology.cluster("alpha", Side.STANDBY))
+    }
+
+    @Test
+    fun `env accepts the spelling config uses`() {
+        assertEquals(Env.PROD, Env.of("prod"))
+        assertEquals(Env.PROD, Env.of("PROD"))
+    }
+
+    @Test
+    fun `an unknown env names the ones that exist`() {
+        val thrown = assertThrows(IllegalArgumentException::class.java) { Env.of("staging") }
+
+        assertTrue(thrown.message!!.contains("dev"), thrown.message)
+    }
+
     @Test
     fun `tenants are listed in a stable order`() {
         val topology =

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -260,6 +260,7 @@ class ReadOnlyRequestFilterTest {
                 "GET /control/topology",
                 "GET /control/topology/{tenant}",
                 "GET /control/tenants/{tenant}/datastore/tables",
+                "GET /control/htables",
             )
 
         val NON_GRAPH_ENDPOINTS =


### PR DESCRIPTION
> Builds on #482 — merge that first. Both commits show here because CI only runs on PRs based on `main`; the second commit is this PR's change, and the diff collapses to it once #482 lands.

## Summary

A cleanup client needs to know, per datastore table, what each side holds and what still binds to it. Every client derives that itself today — and two of the facts involved are ones no single cluster can supply.

`GET /control/htables` answers it once for the whole fleet.

**Sides are symmetric.** A table's state is one entry per side, so a table that survives only on the standby is an absent active side rather than a second kind of row. Clients model that as a separate list because they see one cluster at a time; the control plane does not have to.

**The chain is read, not reconstructed.** References come from the endpoint added in #478, and each one carries the side it was found on — a label still active on the standby is exactly the thing that blocks a teardown halfway through.

**Sharing is noticed without anyone declaring it.** Two tenants configured against the same cluster resolve to the same cluster key (`host:port`), so a table held by another tenant shows up as `sharedWith` — and it names the tenant, because "blocked" without "by whom" leaves the operator where they started.

**A failed side is reported as failed.** An empty table list from a cluster that never answered would read as *nothing left to clean up*, which is the one wrong answer this endpoint must never give.

## Changes

- Add `CleanupProjection` (pure) and `CleanupService` under `server/control/cleanup`
- Add `GET /control/htables` with optional `tenant` and `env` filters
- Add `Topology.cluster(tenant, side)` — the cluster key that makes sharing visible
- `Env.of` accepts the spelling config uses: `env: prod` in yaml and `?env=prod` in a url should not disagree, and an unknown value names the ones that exist
- Extract `CallerHeaders` so both control endpoints forward the caller's identity the same way

## How to Test

```
./gradlew :server:test --tests "*CleanupProjectionTest*" --tests "*ControlCleanupE2ETest*" --tests "*TopologyTest*"
```

`CleanupProjectionTest` drives the projection from fixtures — standby-only tables, a table held from another tenant, references carrying their side, and a failed side not reading as a clean fleet. `ControlCleanupE2ETest` points every configured cluster at a closed port, so the all-sides-failed path is exercised over http.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
