### PR TITLE
Purge tombstoned metastore rows from the control plane

### DIFF
--- a/cli/internal/command/command_type.go
+++ b/cli/internal/command/command_type.go
@@ -85,6 +85,11 @@ var (
 		name:    "migrate",
 		command: "migrate <plan [-o <file>]|apply [-i <file>]>",
 	}
+
+	TypePurge = Type{
+		name:    "purge",
+		command: "purge <plan --metastore <name> --service <service> [--older-than <days>] [--max <rows>] [--file <file>]|show [--file <file>]|apply [--file <file>] --yes|restore [--file <file>] --yes>",
+	}
 )
 
 func (t Type) GetName() string {

--- a/cli/internal/command/purge.go
+++ b/cli/internal/command/purge.go
@@ -1,0 +1,229 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/kakao/actionbase/internal/client"
+	"github.com/kakao/actionbase/internal/command/model"
+	"github.com/kakao/actionbase/internal/util"
+)
+
+const (
+	defaultPurgeFile = "purge.json"
+	candidatesPath   = "/control/metastore/purge/candidates"
+	executePath      = "/control/metastore/purge/execute"
+	restorePath      = "/control/metastore/purge/restore"
+	defaultOlderThan = 30
+	defaultMaxRows   = 500
+	purgeFilePerm    = 0o600
+	httpOK           = 200
+)
+
+// purgeSet is only enough of the document to summarise it. The file is posted
+// back byte for byte, so nothing here reshapes it - a field the server adds
+// later still round-trips even though this struct has never heard of it.
+type purgeSet struct {
+	Metastore   string `json:"metastore"`
+	Table       string `json:"table"`
+	Service     string `json:"service"`
+	GeneratedAt string `json:"generatedAt"`
+	Scanned     int    `json:"scanned"`
+	NextCursor  *int64 `json:"nextCursor"`
+	Rows        []struct {
+		K string `json:"k"`
+	} `json:"rows"`
+	Undecodable []struct {
+		K      string `json:"k"`
+		Reason string `json:"reason"`
+	} `json:"undecodable"`
+}
+
+type purgeResult struct {
+	Requested int `json:"requested"`
+	Applied   int `json:"applied"`
+	Skipped   []struct {
+		K      string `json:"k"`
+		Reason string `json:"reason"`
+	} `json:"skipped"`
+}
+
+// Purge drives the three metastore purge endpoints.
+//
+// The file written by plan is the response as it arrived, and apply and restore
+// post it back unchanged. That is what makes it a backup: the rows are on disk
+// before anything is deleted, so a lost response can never leave rows gone with
+// no copy of them. Committing a purge is keeping the file; reverting one is
+// handing the same file to restore.
+type Purge struct {
+	client *client.ActionbaseClient
+}
+
+func NewPurge(c *client.ActionbaseClient) *Purge {
+	return &Purge{client: c}
+}
+
+func (p *Purge) Execute(args []string) *model.Response {
+	if len(args) < 1 {
+		return model.Fail(fmt.Sprintf("Usage: %s", p.GetType().GetCommand()))
+	}
+	parser := util.ParseArgs(args[1:])
+
+	switch args[0] {
+	case "plan":
+		return p.plan(parser)
+	case "show":
+		return p.show(fileArg(parser))
+	case "apply":
+		return p.send(executePath, "delete", parser)
+	case "restore":
+		return p.send(restorePath, "restore", parser)
+	default:
+		return model.Fail(fmt.Sprintf("Usage: %s", p.GetType().GetCommand()))
+	}
+}
+
+func (p *Purge) plan(parser *util.Parser) *model.Response {
+	metastore, ok := parser.Get("metastore")
+	if !ok {
+		return model.Fail("--metastore is required: it names a metastore configured on the control plane")
+	}
+	service, ok := parser.Get("service")
+	if !ok {
+		return model.Fail("--service is required: a purge is always scoped to one service")
+	}
+
+	status, body := p.client.PostRaw(candidatesPath, map[string]any{
+		"metastore":     metastore,
+		"service":       service,
+		"olderThanDays": intArg(parser, "older-than", defaultOlderThan),
+		"maxRows":       intArg(parser, "max", defaultMaxRows),
+	})
+	if status != httpOK {
+		return model.Fail(fmt.Sprintf("candidates failed (%d): %s", status, body))
+	}
+
+	set, err := parseSet([]byte(body))
+	if err != nil {
+		return model.Fail(err.Error())
+	}
+
+	out := fileArg(parser)
+	if err := os.WriteFile(out, []byte(body), purgeFilePerm); err != nil {
+		return model.Fail(fmt.Sprintf("failed to write %s: %v", out, err))
+	}
+	return model.SuccessWithResult(summarise(set, out))
+}
+
+func (p *Purge) show(path string) *model.Response {
+	set, _, err := read(path)
+	if err != nil {
+		return model.Fail(err.Error())
+	}
+	return model.SuccessWithResult(summarise(set, path))
+}
+
+// send posts a saved document back, unchanged.
+//
+// --yes is required rather than prompting: the console runs inside a readline
+// loop, and a confirmation competing with it for stdin is worse than one the
+// operator types deliberately. Without it this prints what would happen.
+func (p *Purge) send(path, verb string, parser *util.Parser) *model.Response {
+	file := fileArg(parser)
+	set, body, err := read(file)
+	if err != nil {
+		return model.Fail(err.Error())
+	}
+
+	if _, confirmed := parser.GetLenient("yes"); !confirmed {
+		return model.Fail(fmt.Sprintf(
+			"%s\nThis would %s %d rows. Re-run with --yes to go ahead.",
+			summarise(set, file), verb, len(set.Rows),
+		))
+	}
+
+	status, response := p.client.PostRaw(path, json.RawMessage(body))
+	if status != httpOK {
+		return model.Fail(fmt.Sprintf("%s failed (%d): %s", verb, status, response))
+	}
+
+	var result purgeResult
+	if err := json.Unmarshal([]byte(response), &result); err != nil {
+		return model.Fail(fmt.Sprintf("could not read the response: %v", err))
+	}
+
+	out := fmt.Sprintf("%s: %d of %d rows", verb, result.Applied, result.Requested)
+	for _, skipped := range result.Skipped {
+		out += fmt.Sprintf("\n  skipped %s (%s)", skipped.K, skipped.Reason)
+	}
+	if verb == "delete" && result.Applied > 0 {
+		out += fmt.Sprintf("\nKeep %s: it is the only copy of what was deleted.", file)
+	}
+	return model.SuccessWithResult(out)
+}
+
+func read(path string) (*purgeSet, []byte, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	set, err := parseSet(body)
+	if err != nil {
+		return nil, nil, err
+	}
+	return set, body, nil
+}
+
+func summarise(set *purgeSet, path string) string {
+	out := fmt.Sprintf(
+		"%s\n  metastore  %s\n  table      %s\n  service    %s\n  generated  %s\n  scanned    %d\n  rows       %d",
+		path, set.Metastore, set.Table, set.Service, set.GeneratedAt, set.Scanned, len(set.Rows),
+	)
+	if len(set.Undecodable) > 0 {
+		out += fmt.Sprintf("\n  unreadable %d (reported, never deleted)", len(set.Undecodable))
+	}
+	if set.NextCursor != nil {
+		out += fmt.Sprintf("\n  more       yes, resume from cursor %d", *set.NextCursor)
+	}
+	return out
+}
+
+func parseSet(body []byte) (*purgeSet, error) {
+	var set purgeSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("not a purge document: %w", err)
+	}
+	if set.Metastore == "" {
+		return nil, fmt.Errorf("not a purge document: no metastore in it")
+	}
+	return &set, nil
+}
+
+func fileArg(parser *util.Parser) string {
+	if v, ok := parser.Get("file"); ok {
+		return v
+	}
+	return defaultPurgeFile
+}
+
+func intArg(parser *util.Parser, name string, fallback int) int {
+	v, ok := parser.Get(name)
+	if !ok {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func (p *Purge) GetDescription() string {
+	return "Purge tombstoned rows from a metastore table"
+}
+
+func (p *Purge) GetType() Type {
+	return TypePurge
+}

--- a/cli/internal/command/purge_test.go
+++ b/cli/internal/command/purge_test.go
@@ -1,0 +1,112 @@
+package command
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kakao/actionbase/internal/util"
+)
+
+const sampleSet = `{
+  "metastore": "jdbc:mysql://meta.example.net:3306/graph",
+  "table": "kc_graph_metadata",
+  "service": "prod:wish",
+  "generatedAt": "2026-08-10T04:12:33.481Z",
+  "scanned": 6142,
+  "nextCursor": 184203,
+  "rows": [{"k": "aaa", "v": "bbb", "createdBy": "writer"}],
+  "undecodable": [{"k": "broken", "reason": "bad key"}]
+}`
+
+func TestParseSetReadsTheSummaryFields(t *testing.T) {
+	set, err := parseSet([]byte(sampleSet))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if set.Table != "kc_graph_metadata" {
+		t.Errorf("table = %q", set.Table)
+	}
+	if set.Scanned != 6142 {
+		t.Errorf("scanned = %d", set.Scanned)
+	}
+	if len(set.Rows) != 1 || len(set.Undecodable) != 1 {
+		t.Errorf("rows = %d, undecodable = %d", len(set.Rows), len(set.Undecodable))
+	}
+	if set.NextCursor == nil || *set.NextCursor != 184203 {
+		t.Errorf("nextCursor = %v", set.NextCursor)
+	}
+}
+
+// The document is posted back byte for byte, so a field this CLI has never
+// heard of has to survive the round trip.
+func TestUnknownFieldsSurviveTheRoundTrip(t *testing.T) {
+	withExtra := `{"metastore":"jdbc:h2:mem:x","table":"t","service":"s","rows":[],"undecodable":[],"somethingNew":{"a":1}}`
+
+	if _, err := parseSet([]byte(withExtra)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	posted, err := json.Marshal(json.RawMessage(withExtra))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(posted) != withExtra {
+		t.Errorf("the body was reshaped:\n got %s\nwant %s", posted, withExtra)
+	}
+}
+
+func TestParseSetRejectsSomethingThatIsNotAPurgeDocument(t *testing.T) {
+	for _, body := range []string{`{"hello":"world"}`, `not json at all`} {
+		if _, err := parseSet([]byte(body)); err == nil {
+			t.Errorf("expected %q to be rejected", body)
+		}
+	}
+}
+
+func TestSummariseNamesWhatWouldBeTouched(t *testing.T) {
+	set, err := parseSet([]byte(sampleSet))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := summarise(set, "wish.json")
+
+	for _, want := range []string{"wish.json", "kc_graph_metadata", "prod:wish", "rows       1", "unreadable 1", "cursor 184203"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFileArgFallsBackToTheDefault(t *testing.T) {
+	if got := fileArg(util.ParseArgs([]string{})); got != defaultPurgeFile {
+		t.Errorf("fileArg = %q", got)
+	}
+	if got := fileArg(util.ParseArgs([]string{"--file", "wish.json"})); got != "wish.json" {
+		t.Errorf("fileArg = %q", got)
+	}
+}
+
+func TestIntArgFallsBackWhenAbsentOrUnparseable(t *testing.T) {
+	if got := intArg(util.ParseArgs([]string{}), "max", defaultMaxRows); got != defaultMaxRows {
+		t.Errorf("intArg = %d", got)
+	}
+	if got := intArg(util.ParseArgs([]string{"--max", "seven"}), "max", defaultMaxRows); got != defaultMaxRows {
+		t.Errorf("intArg = %d", got)
+	}
+	if got := intArg(util.ParseArgs([]string{"--max", "12"}), "max", defaultMaxRows); got != 12 {
+		t.Errorf("intArg = %d", got)
+	}
+}
+
+// Nothing destructive happens without --yes.
+func TestApplyWithoutYesRefuses(t *testing.T) {
+	parser := util.ParseArgs([]string{"--file", "wish.json"})
+	if _, confirmed := parser.GetLenient("yes"); confirmed {
+		t.Error("--yes should be absent here")
+	}
+	if _, confirmed := util.ParseArgs([]string{"--file", "wish.json", "--yes"}).GetLenient("yes"); !confirmed {
+		t.Error("--yes should be present here")
+	}
+}

--- a/cli/internal/runner/actionbase_runner.go
+++ b/cli/internal/runner/actionbase_runner.go
@@ -74,6 +74,7 @@ func NewActionbaseCommandLineRunner(version, host string, authKey *string, curre
 	runner.RegisterCommand(command.TypeGuide.GetName(), command.NewGuide(runner, actionbaseClient))
 	runner.RegisterCommand(command.TypeDoctor.GetName(), command.NewDoctor(actionbaseClient))
 	runner.RegisterCommand(command.TypeMigrate.GetName(), command.NewMigrate(actionbaseClient))
+	runner.RegisterCommand(command.TypePurge.GetName(), command.NewPurge(actionbaseClient))
 
 	return runner
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
@@ -6,7 +6,10 @@ import java.time.LocalDateTime
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -84,6 +87,65 @@ class MetastorePurge(
             nextCursor = cursorNow.takeUnless { exhausted },
         )
     }
+
+    /**
+     * Deletes exactly the rows it was given, matching on `k` and `v` together.
+     *
+     * Matching the value is what makes this safe to hand a file saved earlier: a tombstone that was
+     * recreated since holds different bytes and is reported as `CHANGED` rather than destroyed, and
+     * a row a previous call already removed is `ABSENT`, so repeating a request that was answered
+     * but never seen changes nothing.
+     *
+     * The two predicates are one expression on purpose. Splitting them into separate statements
+     * inside the lambda would leave only the last as the predicate, and the delete would match on
+     * value alone.
+     */
+    fun delete(rows: List<PurgeRow>): PurgeOutcome =
+        transaction(database) {
+            val unmatched = mutableListOf<String>()
+            var applied = 0
+            rows.forEach { row ->
+                val deleted = table.deleteWhere { (table.k eq row.k) and (table.v eq row.v) }
+                if (deleted > 0) applied++ else unmatched += row.k
+            }
+            PurgeOutcome(requested = rows.size, applied = applied, skipped = classify(unmatched))
+        }
+
+    /** One query tells `CHANGED` from `ABSENT`, and it only runs when something did not match. */
+    private fun classify(unmatched: List<String>): List<SkippedRow> {
+        if (unmatched.isEmpty()) return emptyList()
+        val stillThere = table.select { table.k inList unmatched }.mapTo(mutableSetOf()) { it[table.k] }
+        return unmatched.map { SkippedRow(it, if (it in stillThere) SkipReason.CHANGED else SkipReason.ABSENT) }
+    }
+
+    /**
+     * Writes rows back, and only where the key is free.
+     *
+     * A key that is occupied is left as it is: whatever holds it now was created after the purge,
+     * and restoring an old tombstone over live metadata would be a worse outcome than a restore
+     * that reports it could not finish.
+     */
+    fun restore(rows: List<PurgeRow>): PurgeOutcome =
+        transaction(database) {
+            val occupied = table.select { table.k inList rows.map { it.k } }.mapTo(mutableSetOf()) { it[table.k] }
+            val (present, free) = rows.partition { it.k in occupied }
+            free.forEach { row ->
+                table.insert {
+                    it[k] = row.k
+                    it[v] = row.v
+                    it[createdAt] = row.createdAt
+                    it[createdBy] = row.createdBy
+                    it[modifiedAt] = row.modifiedAt
+                    it[modifiedBy] = row.modifiedBy
+                    it[updateTs] = row.updateTs
+                }
+            }
+            PurgeOutcome(
+                requested = rows.size,
+                applied = free.size,
+                skipped = present.map { SkippedRow(it.k, SkipReason.PRESENT) },
+            )
+        }
 
     private fun page(
         after: Long,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
@@ -8,8 +8,8 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -99,6 +99,11 @@ class MetastorePurge(
      * The two predicates are one expression on purpose. Splitting them into separate statements
      * inside the lambda would leave only the last as the predicate, and the delete would match on
      * value alone.
+     *
+     * One statement per row rather than a batch, deliberately. Reading the rows first and then
+     * deleting by key would be two round trips instead of many, but it would also open a gap
+     * between the check and the delete - and deleting exactly the bytes that were shown is the
+     * property this endpoint exists to provide. The caller's row cap bounds the cost.
      */
     fun delete(rows: List<PurgeRow>): PurgeOutcome =
         transaction(database) {
@@ -124,21 +129,26 @@ class MetastorePurge(
      * A key that is occupied is left as it is: whatever holds it now was created after the purge,
      * and restoring an old tombstone over live metadata would be a worse outcome than a restore
      * that reports it could not finish.
+     *
+     * Occupancy is read once and the rest is inserted as a batch. A key taken between the two would
+     * violate the unique index and roll the whole restore back, which is the right way to fail:
+     * nothing is half written, and the same file can be posted again.
      */
     fun restore(rows: List<PurgeRow>): PurgeOutcome =
         transaction(database) {
             val occupied = table.select { table.k inList rows.map { it.k } }.mapTo(mutableSetOf()) { it[table.k] }
             val (present, free) = rows.partition { it.k in occupied }
-            free.forEach { row ->
-                table.insert {
-                    it[k] = row.k
-                    it[v] = row.v
-                    it[createdAt] = row.createdAt
-                    it[createdBy] = row.createdBy
-                    it[modifiedAt] = row.modifiedAt
-                    it[modifiedBy] = row.modifiedBy
-                    it[updateTs] = row.updateTs
-                }
+            // `columns` rather than `table`: inside the batch lambda `table` is the statement's own
+            // property, which is a plain Table and has none of these columns.
+            val columns = table
+            columns.batchInsert(free) { row ->
+                this[columns.k] = row.k
+                this[columns.v] = row.v
+                this[columns.createdAt] = row.createdAt
+                this[columns.createdBy] = row.createdBy
+                this[columns.modifiedAt] = row.modifiedAt
+                this[columns.modifiedBy] = row.modifiedBy
+                this[columns.updateTs] = row.updateTs
             }
             PurgeOutcome(
                 requested = rows.size,

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurge.kt
@@ -1,0 +1,139 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import java.sql.Connection
+import java.time.LocalDateTime
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+/**
+ * Deletes tombstoned rows from a metastore table, and puts them back.
+ *
+ * Standalone by design: it shares no code with `Graph`, `JdbcHashLabel` or anything else that
+ * serves the metastore. It opens a connection, reads columns, and reads two fields out of the
+ * encoded ones. Deleting rows out from under the running metastore is not an ability the serving
+ * path should grow, and a tool that dies with JDBC should not be entangled with what is being
+ * retired around it.
+ */
+class MetastorePurge(
+    val target: MetastoreTarget,
+    connections: () -> Connection,
+) {
+    private val table = PurgeTable(target.table)
+
+    // Opening a Database does not open a connection - Exposed asks for one per transaction - so
+    // this is safe to build at startup for a metastore that may be unreachable.
+    private val database: Database = Database.connect(getNewConnection = connections)
+
+    /**
+     * Walks the table by primary key and collects rows of [service] that are inactive and settled
+     * before [updatedBefore].
+     *
+     * Two limits, because there are two costs. [maxRows] caps what comes back, and [maxScan] caps
+     * how far the walk goes when tombstones are sparse - without it a table of live rows would be
+     * read end to end to fill one page. Either limit leaves a `nextCursor` to resume from, and a
+     * null one means the table ran out.
+     *
+     * The age filter is a `WHERE` clause on an indexed column, so rows too young to purge are never
+     * read. Being inactive is not, which is the whole problem this tool exists for.
+     */
+    fun scan(
+        service: String,
+        updatedBefore: LocalDateTime,
+        maxRows: Int,
+        maxScan: Int,
+        cursor: Long = 0,
+    ): PurgeScan {
+        require(maxRows > 0) { "maxRows must be positive, got $maxRows" }
+        require(maxScan >= maxRows) { "maxScan ($maxScan) must be at least maxRows ($maxRows)" }
+
+        val found = mutableListOf<PurgeRow>()
+        val undecodable = mutableListOf<UndecodableKey>()
+        var scanned = 0
+        var cursorNow = cursor
+        var exhausted = false
+
+        transaction(database) {
+            while (found.size < maxRows && scanned < maxScan && !exhausted) {
+                val page = page(cursorNow, updatedBefore, minOf(PAGE_SIZE, maxScan - scanned))
+                exhausted = page.isEmpty()
+                // Stops on the row that fills the page rather than draining it, so the cursor is
+                // the last row actually accounted for. Advancing past rows that were fetched but
+                // never returned would skip them on resume.
+                for ((id, row) in page) {
+                    cursorNow = id
+                    scanned++
+                    when (val verdict = verdict(row, service)) {
+                        Verdict.Purge -> found += row
+                        Verdict.Keep -> Unit
+                        is Verdict.Unreadable -> undecodable += UndecodableKey(row.k, verdict.reason)
+                    }
+                    if (found.size >= maxRows) break
+                }
+            }
+        }
+
+        return PurgeScan(
+            rows = found,
+            undecodable = undecodable,
+            scanned = scanned,
+            nextCursor = cursorNow.takeUnless { exhausted },
+        )
+    }
+
+    private fun page(
+        after: Long,
+        updatedBefore: LocalDateTime,
+        limit: Int,
+    ): List<Pair<Long, PurgeRow>> =
+        table
+            .select { (table.id greater after) and (table.updateTs less updatedBefore) }
+            .orderBy(table.id to SortOrder.ASC)
+            .limit(limit)
+            .map { it[table.id] to it.toPurgeRow() }
+
+    /**
+     * A row that cannot be read is reported, never purged. The purge does not remove what it could
+     * not understand, and an operator who sees the key can decide what it was.
+     */
+    private fun verdict(
+        row: PurgeRow,
+        service: String,
+    ): Verdict =
+        runCatching {
+            when {
+                PurgeFields.isActive(row.v) -> Verdict.Keep
+                PurgeFields.serviceOf(row.k) != service -> Verdict.Keep
+                else -> Verdict.Purge
+            }
+        }.getOrElse { Verdict.Unreadable(it.message ?: it::class.java.simpleName) }
+
+    private fun ResultRow.toPurgeRow() =
+        PurgeRow(
+            k = this[table.k],
+            v = this[table.v],
+            createdAt = this[table.createdAt],
+            createdBy = this[table.createdBy],
+            modifiedAt = this[table.modifiedAt],
+            modifiedBy = this[table.modifiedBy],
+            updateTs = this[table.updateTs],
+        )
+
+    private sealed interface Verdict {
+        data object Purge : Verdict
+
+        data object Keep : Verdict
+
+        data class Unreadable(
+            val reason: String,
+        ) : Verdict
+    }
+
+    private companion object {
+        const val PAGE_SIZE = 1_000
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastoreTarget.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastoreTarget.kt
@@ -1,0 +1,32 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+/**
+ * A metastore table the purge may open.
+ *
+ * Credentials are deliberately absent: this travels in request and response bodies and lands in
+ * logs, so it carries only what identifies the table.
+ *
+ * The purge is a standalone tool, not a label. It shares no code with `Graph`, `JdbcHashLabel` or
+ * the metastore's serving path - it opens a connection, reads rows, and decodes values with
+ * codec-java. Deleting rows out from under the running metastore is not something the serving path
+ * should grow the ability to do, and a tool that dies with JDBC should not be entangled with the
+ * code being retired around it.
+ */
+data class MetastoreTarget(
+    /** The configured name, which is how a caller asks for it. */
+    val name: String,
+    val url: String,
+    val table: String,
+) {
+    init {
+        require(name.isNotBlank()) { "metastore name is blank" }
+        require(url.startsWith("jdbc:")) { "metastore '$name': url must be a jdbc url, got '$url'" }
+        // The table name is interpolated into every statement the purge runs, so it is checked
+        // here rather than at the call sites - a data class cannot be built around the check.
+        require(IDENTIFIER.matches(table)) { "metastore '$name': table '$table' is not a plain sql identifier" }
+    }
+
+    private companion object {
+        val IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeFields.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeFields.kt
@@ -1,0 +1,45 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import com.kakao.actionbase.v2.core.code.hbase.OrderedBytes
+import com.kakao.actionbase.v2.core.code.hbase.SimplePositionedMutableByteRange
+import com.kakao.actionbase.v2.core.code.hbase.ValueUtils
+
+import java.util.Base64
+
+/**
+ * Reads the two fields the purge needs out of a stored row, and nothing else.
+ *
+ * The metastore's own decoders build an edge: they walk every property, resolve names through a
+ * schema, and hand back a model object. None of that is wanted here. The purge asks whether a row
+ * is inactive and which service it belongs to, so it reads the front of each encoding and stops.
+ * That keeps the tool off the data model entirely - only the byte-level primitives below it.
+ *
+ * How old a tombstone is comes from the `update_ts` column instead of the encoded `delete_ts`,
+ * because reaching that property means walking the whole property list. For a row that is currently
+ * inactive the last write was the one that deactivated it, so the column says the same thing, and
+ * it says it in a `WHERE` clause against an index rather than after the row was read.
+ */
+internal object PurgeFields {
+    private val decoder: Base64.Decoder = Base64.getUrlDecoder()
+
+    /** `1` is the only active code; `0` and the retired `2` both mean inactive. */
+    private const val ACTIVE_CODE: Byte = 1
+
+    /**
+     * The value opens with the active flag, so decoding stops after one field. Everything past it
+     * is the timestamp and the property list, which the purge has no use for.
+     */
+    fun isActive(v: String): Boolean = OrderedBytes.decodeInt8(SimplePositionedMutableByteRange(decoder.decode(v))) == ACTIVE_CODE
+
+    /**
+     * The key opens with a hash of the source, then the source itself. A metastore row's source is
+     * the service it belongs to, which is what scopes a purge.
+     *
+     * The field suffix after `:` is not read - the source sits before it.
+     */
+    fun serviceOf(k: String): String {
+        val range = SimplePositionedMutableByteRange(decoder.decode(k.substringBefore(':')))
+        range.getInt() // the source hash, which the source itself follows
+        return ValueUtils.deserialize<Any>(range).toString()
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeOutcome.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeOutcome.kt
@@ -1,0 +1,31 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+/** Why a row named in a request was not acted on. */
+enum class SkipReason {
+    /** The key is there but holds different bytes: the row came back to life since it was listed. */
+    CHANGED,
+
+    /** The key is gone, which is what a repeated `execute` sees. */
+    ABSENT,
+
+    /** A restore found the key already occupied, and will not write over what is there now. */
+    PRESENT,
+}
+
+data class SkippedRow(
+    val k: String,
+    val reason: SkipReason,
+)
+
+/**
+ * What a delete or a restore actually did.
+ *
+ * [requested] and [applied] differ exactly when rows were skipped, and every skipped row says why -
+ * an operator facing a partial result needs to know whether something changed underneath them or
+ * whether they are looking at a retry that had nothing left to do.
+ */
+data class PurgeOutcome(
+    val requested: Int,
+    val applied: Int,
+    val skipped: List<SkippedRow>,
+)

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeRow.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeRow.kt
@@ -1,0 +1,42 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import java.time.LocalDateTime
+
+/**
+ * One metastore row, as it sits in the table.
+ *
+ * A row is its `k` and `v`. The audit columns ride along because a restore has to write the row
+ * back as it was, not as it would be if inserted today. There is no primary key here on purpose:
+ * the id is a cursor for paging a scan, not part of what identifies a row to delete.
+ */
+data class PurgeRow(
+    val k: String,
+    val v: String,
+    val createdAt: LocalDateTime,
+    val createdBy: String,
+    val modifiedAt: LocalDateTime,
+    val modifiedBy: String,
+    val updateTs: LocalDateTime,
+)
+
+/**
+ * A row the scan refused to read. It is reported rather than skipped silently, and it is never
+ * deleted - the purge does not remove what it could not understand.
+ */
+data class UndecodableKey(
+    val k: String,
+    val reason: String,
+)
+
+/**
+ * One page of a scan.
+ *
+ * [scanned] is how many rows were walked to find [rows], which is what tells an operator how dense
+ * the tombstones are. [nextCursor] is null once the table is exhausted.
+ */
+data class PurgeScan(
+    val rows: List<PurgeRow>,
+    val undecodable: List<UndecodableKey>,
+    val scanned: Int,
+    val nextCursor: Long?,
+)

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeTable.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeTable.kt
@@ -14,7 +14,9 @@ import org.jetbrains.exposed.sql.javatime.datetime
 internal class PurgeTable(
     name: String,
 ) : Table(name) {
-    val id = long("id")
+    // Declared as generated because it is: a restore must not supply one, and a batch insert
+    // refuses to run at all unless every column it omits is known to have a value without it.
+    val id = long("id").autoIncrement()
     val k = varchar("k", 512)
     val v = text("v")
     val createdAt = datetime("created_at")

--- a/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeTable.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/PurgeTable.kt
@@ -1,0 +1,25 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.datetime
+
+/**
+ * The metastore table, as the purge needs to see it.
+ *
+ * Deliberately not `MetadataTable`. That one is the serving path's definition and carries the index
+ * declarations its DDL creation needs; this one only ever reads, deletes and inserts, and naming
+ * the columns separately keeps a change on either side from reaching the other. The table name
+ * comes from configuration and is checked as an identifier by `MetastoreTarget`.
+ */
+internal class PurgeTable(
+    name: String,
+) : Table(name) {
+    val id = long("id")
+    val k = varchar("k", 512)
+    val v = text("v")
+    val createdAt = datetime("created_at")
+    val createdBy = varchar("created_by", 256)
+    val modifiedAt = datetime("modified_at")
+    val modifiedBy = varchar("modified_by", 256)
+    val updateTs = datetime("update_ts")
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurgeApplyTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurgeApplyTest.kt
@@ -1,0 +1,201 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import com.kakao.actionbase.v2.core.code.HashEdgeValue
+import com.kakao.actionbase.v2.core.code.StringKeyFieldValueEdgeEncoder
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.Active
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.LocalDateTime
+import java.util.UUID
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Delete and restore, against a real table. */
+class MetastorePurgeApplyTest {
+    private val encoder = StringKeyFieldValueEdgeEncoder()
+    private val table = "kc_graph_metadata"
+    private val old = LocalDateTime.of(2026, 1, 1, 0, 0)
+    private val cutoff = LocalDateTime.of(2026, 6, 1, 0, 0)
+
+    private lateinit var connections: () -> Connection
+    private lateinit var purge: MetastorePurge
+
+    @BeforeEach
+    fun setUp() {
+        val url = "jdbc:h2:mem:purge-${UUID.randomUUID()};DB_CLOSE_DELAY=-1;MODE=MYSQL"
+        connections = { DriverManager.getConnection(url, "", "") }
+        connections().use { connection ->
+            connection.createStatement().use {
+                it.execute(
+                    """
+                    CREATE TABLE $table (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        k VARCHAR(512) NOT NULL UNIQUE,
+                        v TEXT NOT NULL,
+                        created_at DATETIME(6) NOT NULL,
+                        created_by VARCHAR(256) NOT NULL,
+                        modified_at DATETIME(6) NOT NULL,
+                        modified_by VARCHAR(256) NOT NULL,
+                        update_ts DATETIME(6) NOT NULL
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+        purge = MetastorePurge(MetastoreTarget("test", url, table), connections)
+    }
+
+    private fun keyOf(name: String): String {
+        val encoded = encoder.encodeHashEdgeKey(Edge(0L, SERVICE, name), LABEL_ID)
+        return encoded.field?.let { "${encoded.key}:$it" } ?: encoded.key
+    }
+
+    private fun valueOf(
+        active: Active,
+        ts: Long = 1L,
+    ) = encoder.encodeHashEdgeValue(HashEdgeValue.from(active, ts, emptyMap(), null, null))
+
+    private fun write(
+        k: String,
+        v: String,
+    ) {
+        connections().use { connection ->
+            connection
+                .prepareStatement(
+                    "INSERT INTO $table (k, v, created_at, created_by, modified_at, modified_by, update_ts) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ).use {
+                    it.setString(1, k)
+                    it.setString(2, v)
+                    it.setObject(3, old)
+                    it.setString(4, "writer")
+                    it.setObject(5, old)
+                    it.setString(6, "writer")
+                    it.setObject(7, old)
+                    it.executeUpdate()
+                }
+        }
+    }
+
+    private fun replaceValue(
+        k: String,
+        v: String,
+    ) {
+        connections().use { connection ->
+            connection.prepareStatement("UPDATE $table SET v = ? WHERE k = ?").use {
+                it.setString(1, v)
+                it.setString(2, k)
+                it.executeUpdate()
+            }
+        }
+    }
+
+    private fun rowCount(): Int =
+        connections().use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT COUNT(*) FROM $table").use {
+                    it.next()
+                    it.getInt(1)
+                }
+            }
+        }
+
+    private fun candidates() = purge.scan(SERVICE, cutoff, maxRows = 100, maxScan = 1_000).rows
+
+    @Test
+    fun `delete removes exactly the rows it was given`() {
+        write(keyOf("gone"), valueOf(Active.INACTIVE))
+        write(keyOf("also-gone"), valueOf(Active.INACTIVE))
+        write(keyOf("live"), valueOf(Active.ACTIVE))
+
+        val outcome = purge.delete(candidates())
+
+        assertEquals(2, outcome.requested)
+        assertEquals(2, outcome.applied)
+        assertEquals(emptyList<SkippedRow>(), outcome.skipped)
+        assertEquals(1, rowCount())
+    }
+
+    @Test
+    fun `a tombstone that came back to life since it was listed survives`() {
+        val k = keyOf("resurrected")
+        write(k, valueOf(Active.INACTIVE))
+        val listed = candidates()
+
+        replaceValue(k, valueOf(Active.ACTIVE))
+        val outcome = purge.delete(listed)
+
+        assertEquals(0, outcome.applied)
+        assertEquals(listOf(SkippedRow(k, SkipReason.CHANGED)), outcome.skipped)
+        assertEquals(1, rowCount())
+    }
+
+    @Test
+    fun `repeating a delete after a lost response changes nothing`() {
+        write(keyOf("gone"), valueOf(Active.INACTIVE))
+        val listed = candidates()
+        purge.delete(listed)
+
+        val again = purge.delete(listed)
+
+        assertEquals(0, again.applied)
+        assertEquals(listOf(SkipReason.ABSENT), again.skipped.map { it.reason })
+        assertEquals(0, rowCount())
+    }
+
+    @Test
+    fun `restore writes the rows back as they were`() {
+        val k = keyOf("gone")
+        write(k, valueOf(Active.INACTIVE))
+        val listed = candidates()
+        purge.delete(listed)
+
+        val outcome = purge.restore(listed)
+
+        assertEquals(1, outcome.applied)
+        assertEquals(emptyList<SkippedRow>(), outcome.skipped)
+
+        val restored = candidates().single()
+        assertEquals(listed.single(), restored)
+    }
+
+    @Test
+    fun `restore will not write over a key taken since the purge`() {
+        val k = keyOf("gone")
+        write(k, valueOf(Active.INACTIVE))
+        val listed = candidates()
+        purge.delete(listed)
+        write(k, valueOf(Active.ACTIVE, ts = 99L))
+
+        val outcome = purge.restore(listed)
+
+        assertEquals(0, outcome.applied)
+        assertEquals(listOf(SkippedRow(k, SkipReason.PRESENT)), outcome.skipped)
+        assertEquals(emptyList<PurgeRow>(), candidates(), "the live row is still live")
+    }
+
+    @Test
+    fun `a partial restore reports both sides`() {
+        val taken = keyOf("taken")
+        val free = keyOf("free")
+        write(taken, valueOf(Active.INACTIVE))
+        write(free, valueOf(Active.INACTIVE))
+        val listed = candidates()
+        purge.delete(listed)
+        write(taken, valueOf(Active.ACTIVE, ts = 99L))
+
+        val outcome = purge.restore(listed)
+
+        assertEquals(2, outcome.requested)
+        assertEquals(1, outcome.applied)
+        assertEquals(listOf(SkippedRow(taken, SkipReason.PRESENT)), outcome.skipped)
+    }
+
+    private companion object {
+        const val SERVICE = "prod:wish"
+        const val LABEL_ID = 7
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurgeScanTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/metastore/purge/MetastorePurgeScanTest.kt
@@ -1,0 +1,202 @@
+package com.kakao.actionbase.v2.engine.metastore.purge
+
+import com.kakao.actionbase.v2.core.code.HashEdgeValue
+import com.kakao.actionbase.v2.core.code.StringKeyFieldValueEdgeEncoder
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.Active
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.LocalDateTime
+import java.util.UUID
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Drives the scan against a real table rather than a mock. Rows are written with the encoder the
+ * metastore itself uses, so the test also pins that the purge reads what production writes - which
+ * is the claim worth holding onto, given it reads only the front of each encoding.
+ */
+class MetastorePurgeScanTest {
+    private val encoder = StringKeyFieldValueEdgeEncoder()
+    private val table = "kc_graph_metadata"
+    private lateinit var url: String
+    private lateinit var connections: () -> Connection
+    private lateinit var purge: MetastorePurge
+
+    private val old = LocalDateTime.of(2026, 1, 1, 0, 0)
+    private val recent = LocalDateTime.of(2026, 8, 1, 0, 0)
+    private val cutoff = LocalDateTime.of(2026, 6, 1, 0, 0)
+
+    @BeforeEach
+    fun setUp() {
+        url = "jdbc:h2:mem:purge-${UUID.randomUUID()};DB_CLOSE_DELAY=-1;MODE=MYSQL"
+        connections = { DriverManager.getConnection(url, "", "") }
+        connections().use { connection ->
+            connection.createStatement().use {
+                it.execute(
+                    """
+                    CREATE TABLE $table (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        k VARCHAR(512) NOT NULL UNIQUE,
+                        v TEXT NOT NULL,
+                        created_at DATETIME(6) NOT NULL,
+                        created_by VARCHAR(256) NOT NULL,
+                        modified_at DATETIME(6) NOT NULL,
+                        modified_by VARCHAR(256) NOT NULL,
+                        update_ts DATETIME(6) NOT NULL
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+        purge = MetastorePurge(MetastoreTarget("test", url, table), connections)
+    }
+
+    /** Mirrors how `JdbcHashLabel` stores a row: `key` alone, or `key:field` when there is a field. */
+    private fun write(
+        service: String,
+        name: String,
+        active: Active,
+        updateTs: LocalDateTime = old,
+    ) {
+        val edge = Edge(0L, service, name)
+        val encodedKey = encoder.encodeHashEdgeKey(edge, LABEL_ID)
+        val k = encodedKey.field?.let { "${encodedKey.key}:$it" } ?: encodedKey.key
+        val v = encoder.encodeHashEdgeValue(HashEdgeValue.from(active, 1L, emptyMap(), null, null))
+        insert(k, v, updateTs)
+    }
+
+    private fun insert(
+        k: String,
+        v: String,
+        updateTs: LocalDateTime,
+    ) {
+        connections().use { connection ->
+            connection
+                .prepareStatement(
+                    "INSERT INTO $table (k, v, created_at, created_by, modified_at, modified_by, update_ts) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ).use {
+                    it.setString(1, k)
+                    it.setString(2, v)
+                    it.setObject(3, old)
+                    it.setString(4, "test")
+                    it.setObject(5, updateTs)
+                    it.setString(6, "test")
+                    it.setObject(7, updateTs)
+                    it.executeUpdate()
+                }
+        }
+    }
+
+    private fun scan(
+        service: String = SERVICE,
+        maxRows: Int = 100,
+        maxScan: Int = 1_000,
+        cursor: Long = 0,
+    ) = purge.scan(service, cutoff, maxRows, maxScan, cursor)
+
+    @Test
+    fun `an inactive row of the requested service is a candidate`() {
+        write(SERVICE, "gone", Active.INACTIVE)
+
+        val scan = scan()
+
+        assertEquals(1, scan.rows.size)
+        assertEquals(emptyList<UndecodableKey>(), scan.undecodable)
+    }
+
+    @Test
+    fun `an active row is left alone, which is the whole point`() {
+        write(SERVICE, "live", Active.ACTIVE)
+
+        assertEquals(emptyList<PurgeRow>(), scan().rows)
+    }
+
+    @Test
+    fun `another service's tombstone is out of scope`() {
+        write("other-service", "gone", Active.INACTIVE)
+
+        assertEquals(emptyList<PurgeRow>(), scan().rows)
+    }
+
+    @Test
+    fun `a tombstone settled after the cutoff is too young to purge`() {
+        write(SERVICE, "just-deleted", Active.INACTIVE, updateTs = recent)
+
+        assertEquals(emptyList<PurgeRow>(), scan().rows)
+    }
+
+    @Test
+    fun `a row that cannot be read is reported and never purged`() {
+        insert("this-is-not-an-encoded-key", "neither-is-this", old)
+
+        val scan = scan()
+
+        assertEquals(emptyList<PurgeRow>(), scan.rows)
+        assertEquals(1, scan.undecodable.size)
+        assertEquals("this-is-not-an-encoded-key", scan.undecodable.first().k)
+    }
+
+    @Test
+    fun `the audit columns come back so a restore can write the row as it was`() {
+        write(SERVICE, "gone", Active.INACTIVE)
+
+        val row = scan().rows.single()
+
+        assertEquals("test", row.createdBy)
+        assertEquals(old, row.createdAt)
+        assertEquals(old, row.updateTs)
+    }
+
+    @Test
+    fun `maxRows caps the page and leaves a cursor to resume from`() {
+        repeat(5) { write(SERVICE, "gone-$it", Active.INACTIVE) }
+
+        val first = scan(maxRows = 2)
+
+        assertEquals(2, first.rows.size)
+        assertTrue(first.nextCursor != null)
+
+        val second = scan(maxRows = 10, cursor = first.nextCursor!!)
+        assertEquals(3, second.rows.size)
+    }
+
+    @Test
+    fun `an exhausted table reports no cursor`() {
+        write(SERVICE, "gone", Active.INACTIVE)
+
+        assertNull(scan().nextCursor)
+    }
+
+    @Test
+    fun `maxScan stops the walk when tombstones are sparse`() {
+        repeat(10) { write(SERVICE, "live-$it", Active.ACTIVE) }
+
+        val scan = scan(maxRows = 5, maxScan = 5)
+
+        assertEquals(emptyList<PurgeRow>(), scan.rows)
+        assertEquals(5, scan.scanned)
+        assertTrue(scan.nextCursor != null, "a capped walk has to say where to resume")
+    }
+
+    @Test
+    fun `scanned reports how far the walk went, which is what shows tombstone density`() {
+        repeat(3) { write(SERVICE, "live-$it", Active.ACTIVE) }
+        write(SERVICE, "gone", Active.INACTIVE)
+
+        val scan = scan()
+
+        assertEquals(4, scan.scanned)
+        assertEquals(1, scan.rows.size)
+    }
+
+    private companion object {
+        const val SERVICE = "prod:wish"
+        const val LABEL_ID = 7
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeController.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeController.kt
@@ -1,0 +1,44 @@
+package com.kakao.actionbase.server.api.control.metastore
+
+import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+import com.kakao.actionbase.server.control.metastore.MetastorePurgeService
+import com.kakao.actionbase.server.control.metastore.PurgeQuery
+import com.kakao.actionbase.server.control.metastore.PurgeResult
+import com.kakao.actionbase.server.control.metastore.PurgeSet
+
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+import reactor.core.publisher.Mono
+
+/**
+ * Purging tombstoned rows from a metastore table, in three steps an operator drives.
+ *
+ * `candidates` hands back what it would delete, contents and all. `execute` deletes exactly those
+ * rows. `restore` puts them back. All three exchange the same document, so committing a purge is
+ * the operator keeping the file and reverting one is posting it to `restore`.
+ *
+ * This is temporary. It exists because a metadata `DELETE` only tombstones and nothing removes the
+ * rows, and it goes away with the JDBC metastore.
+ */
+@RestController
+@ConditionalOnControlRole
+class ControlPurgeController(
+    private val purgeService: MetastorePurgeService,
+) {
+    @PostMapping("/control/metastore/purge/candidates")
+    fun candidates(
+        @RequestBody query: PurgeQuery,
+    ): Mono<PurgeSet> = purgeService.candidates(query)
+
+    @PostMapping("/control/metastore/purge/execute")
+    fun execute(
+        @RequestBody set: PurgeSet,
+    ): Mono<PurgeResult> = purgeService.execute(set)
+
+    @PostMapping("/control/metastore/purge/restore")
+    fun restore(
+        @RequestBody set: PurgeSet,
+    ): Mono<PurgeResult> = purgeService.restore(set)
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreConfiguration.kt
@@ -1,0 +1,15 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.server.configuration.ConditionalOnControlRole
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnControlRole
+@EnableConfigurationProperties(MetastoreProperties::class)
+class MetastoreConfiguration {
+    @Bean
+    fun metastoreRegistry(properties: MetastoreProperties): MetastoreRegistry = properties.toRegistry()
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreConfiguration.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreConfiguration.kt
@@ -12,4 +12,7 @@ import org.springframework.context.annotation.Configuration
 class MetastoreConfiguration {
     @Bean
     fun metastoreRegistry(properties: MetastoreProperties): MetastoreRegistry = properties.toRegistry()
+
+    @Bean
+    fun metastorePurgeService(registry: MetastoreRegistry): MetastorePurgeService = MetastorePurgeService(registry)
 }

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreProperties.kt
@@ -31,7 +31,12 @@ data class MetastoreProperties(
         val user: String = "",
         val password: String = "",
         val table: String = DEFAULT_TABLE,
-    )
+    ) {
+        // A generated toString puts the password in whatever logs or reports this object. Actuator
+        // masks it by key name, but nothing masks a data class printed into a log line or an
+        // exception message, and this type is one careless interpolation away from that.
+        override fun toString(): String = "Metastore(url=$url, user=$user, table=$table, password=****)"
+    }
 
     /**
      * Resolves every entry up front. A malformed url or a duplicated coordinate is a deployment

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreProperties.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreProperties.kt
@@ -1,0 +1,63 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.v2.engine.metastore.purge.MetastoreTarget
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * The metastore tables a control instance may open for a purge.
+ *
+ * ```yaml
+ * actionbase:
+ *   role: CONTROL
+ *   control:
+ *     metastores:
+ *       alpha:
+ *         url: jdbc:mysql://ab-alpha-meta.example.net:3306/graph
+ *         user: ${METASTORE_USER_ALPHA}
+ *         password: ${METASTORE_PASSWORD_ALPHA}
+ *         table: kc_graph_metadata   # optional, this is the default
+ * ```
+ *
+ * This is an allowlist, not a convenience. Without it the purge would open whatever database a
+ * request body named, so a target absent from here is refused rather than resolved.
+ */
+@ConfigurationProperties(prefix = "actionbase.control")
+data class MetastoreProperties(
+    val metastores: Map<String, Metastore> = emptyMap(),
+) {
+    data class Metastore(
+        val url: String,
+        val user: String = "",
+        val password: String = "",
+        val table: String = DEFAULT_TABLE,
+    )
+
+    /**
+     * Resolves every entry up front. A malformed url or a duplicated coordinate is a deployment
+     * mistake, and finding it at boot beats finding it when an operator is midway through a purge.
+     */
+    fun toRegistry(): MetastoreRegistry {
+        val entries =
+            metastores.map { (name, metastore) ->
+                MetastoreRegistry.Entry(
+                    target = MetastoreTarget(name = name, url = metastore.url, table = metastore.table),
+                    user = metastore.user,
+                    password = metastore.password,
+                )
+            }
+
+        val duplicates = entries.groupBy { it.target.url to it.target.table }.filterValues { it.size > 1 }
+        require(duplicates.isEmpty()) {
+            val named = duplicates.values.flatten().joinToString(", ") { it.target.name }
+            "actionbase.control.metastores: $named point at the same url and table, " +
+                "so a purge set cannot be resolved back to one of them"
+        }
+
+        return MetastoreRegistry(entries)
+    }
+
+    companion object {
+        const val DEFAULT_TABLE = "kc_graph_metadata"
+    }
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
@@ -1,7 +1,6 @@
 package com.kakao.actionbase.server.control.metastore
 
 import com.kakao.actionbase.v2.engine.metastore.purge.MetastorePurge
-import com.kakao.actionbase.v2.engine.metastore.purge.MetastoreTarget
 import com.kakao.actionbase.v2.engine.metastore.purge.PurgeOutcome
 
 import java.time.Clock
@@ -60,7 +59,10 @@ class MetastorePurgeService(
         blocking {
             // Resolved from the document's own coordinates, so a file taken from one metastore
             // cannot be applied to another and a target this instance does not serve is refused.
-            val target = resolve(set)
+            // A document with no rows is not an error - it applies nothing and reports
+            // `requested=0`, which is what lets a misaimed file be refused for naming a database
+            // this instance does not serve rather than answered with an empty result.
+            val target = registry.target(set.metastore, set.table)
             val outcome = action(registry.purge(target))
             PurgeResult(
                 metastore = target.url,
@@ -71,10 +73,6 @@ class MetastorePurgeService(
                 skipped = outcome.skipped,
             )
         }
-
-    // Which metastore is checked before whether there is anything to do, so a document aimed at a
-    // database this instance does not serve says so rather than reporting an empty one.
-    private fun resolve(set: PurgeSet): MetastoreTarget = registry.target(set.metastore, set.table)
 
     /**
      * JDBC blocks, and this runs on an event loop. The work is a handful of statements per request

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
@@ -24,19 +24,23 @@ class MetastorePurgeService(
 ) {
     fun candidates(query: PurgeQuery): Mono<PurgeSet> =
         blocking {
-            val target = registry.target(query.metastore)
+            val bounded = query.bounded()
+            val target = registry.target(bounded.metastore)
             val scan =
                 registry.purge(target).scan(
-                    service = query.service,
-                    updatedBefore = LocalDateTime.now(clock).minusDays(query.olderThanDays),
-                    maxRows = query.maxRows,
-                    maxScan = query.maxScan,
-                    cursor = query.cursor,
+                    service = bounded.service,
+                    // The cutoff is compared against `update_ts`, which the database writes in its
+                    // own zone. A control instance in a different zone shifts the window by the
+                    // offset, which only matters at the edge of the grace period.
+                    updatedBefore = LocalDateTime.now(clock).minusDays(bounded.olderThanDays),
+                    maxRows = bounded.maxRows,
+                    maxScan = bounded.maxScan,
+                    cursor = bounded.cursor,
                 )
             PurgeSet(
                 metastore = target.url,
                 table = target.table,
-                service = query.service,
+                service = bounded.service,
                 generatedAt = Instant.now(clock),
                 scanned = scan.scanned,
                 nextCursor = scan.nextCursor,
@@ -68,10 +72,9 @@ class MetastorePurgeService(
             )
         }
 
-    private fun resolve(set: PurgeSet): MetastoreTarget {
-        require(set.rows.isNotEmpty()) { "purge set has no rows: nothing to apply" }
-        return registry.target(set.metastore, set.table)
-    }
+    // Which metastore is checked before whether there is anything to do, so a document aimed at a
+    // database this instance does not serve says so rather than reporting an empty one.
+    private fun resolve(set: PurgeSet): MetastoreTarget = registry.target(set.metastore, set.table)
 
     /**
      * JDBC blocks, and this runs on an event loop. The work is a handful of statements per request

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePurgeService.kt
@@ -1,0 +1,82 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.v2.engine.metastore.purge.MetastorePurge
+import com.kakao.actionbase.v2.engine.metastore.purge.MetastoreTarget
+import com.kakao.actionbase.v2.engine.metastore.purge.PurgeOutcome
+
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+
+/**
+ * Runs a purge against one configured metastore.
+ *
+ * Stateless: nothing is remembered between calls. That is what forces the rows to reach the client
+ * before anything is deleted, which in turn is what makes the document a client holds a usable
+ * backup - there is no window where rows are gone and the only copy was lost in a dropped response.
+ */
+class MetastorePurgeService(
+    private val registry: MetastoreRegistry,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    fun candidates(query: PurgeQuery): Mono<PurgeSet> =
+        blocking {
+            val target = registry.target(query.metastore)
+            val scan =
+                registry.purge(target).scan(
+                    service = query.service,
+                    updatedBefore = LocalDateTime.now(clock).minusDays(query.olderThanDays),
+                    maxRows = query.maxRows,
+                    maxScan = query.maxScan,
+                    cursor = query.cursor,
+                )
+            PurgeSet(
+                metastore = target.url,
+                table = target.table,
+                service = query.service,
+                generatedAt = Instant.now(clock),
+                scanned = scan.scanned,
+                nextCursor = scan.nextCursor,
+                rows = scan.rows,
+                undecodable = scan.undecodable,
+            )
+        }
+
+    fun execute(set: PurgeSet): Mono<PurgeResult> = apply(set) { purge -> purge.delete(set.rows) }
+
+    fun restore(set: PurgeSet): Mono<PurgeResult> = apply(set) { purge -> purge.restore(set.rows) }
+
+    private fun apply(
+        set: PurgeSet,
+        action: (MetastorePurge) -> PurgeOutcome,
+    ): Mono<PurgeResult> =
+        blocking {
+            // Resolved from the document's own coordinates, so a file taken from one metastore
+            // cannot be applied to another and a target this instance does not serve is refused.
+            val target = resolve(set)
+            val outcome = action(registry.purge(target))
+            PurgeResult(
+                metastore = target.url,
+                table = target.table,
+                service = set.service,
+                requested = outcome.requested,
+                applied = outcome.applied,
+                skipped = outcome.skipped,
+            )
+        }
+
+    private fun resolve(set: PurgeSet): MetastoreTarget {
+        require(set.rows.isNotEmpty()) { "purge set has no rows: nothing to apply" }
+        return registry.target(set.metastore, set.table)
+    }
+
+    /**
+     * JDBC blocks, and this runs on an event loop. The work is a handful of statements per request
+     * against an operator-facing endpoint, so it belongs on the elastic pool rather than anywhere
+     * it could stall request handling.
+     */
+    private fun <T : Any> blocking(work: () -> T): Mono<T> = Mono.fromCallable(work).subscribeOn(Schedulers.boundedElastic())
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreRegistry.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreRegistry.kt
@@ -1,5 +1,6 @@
 package com.kakao.actionbase.server.control.metastore
 
+import com.kakao.actionbase.v2.engine.metastore.purge.MetastorePurge
 import com.kakao.actionbase.v2.engine.metastore.purge.MetastoreTarget
 
 import java.sql.Connection
@@ -37,13 +38,18 @@ class MetastoreRegistry(
         byCoordinate[url to table]?.target
             ?: throw IllegalArgumentException("metastore '$url' table '$table' is not configured on this instance")
 
-    /** Hands the purge a way to open connections without handing it the credentials. */
-    fun connections(target: MetastoreTarget): () -> Connection {
-        val entry =
-            byName[target.name]?.takeIf { it.target == target }
-                ?: throw IllegalArgumentException("metastore '${target.name}' is not configured on this instance")
-        return { DriverManager.getConnection(entry.target.url, entry.user, entry.password) }
-    }
+    // One purge per configured metastore, built up front. Credentials are captured in the
+    // connection lambda and go no further, so nothing outside this class can read them back.
+    private val purges: Map<String, MetastorePurge> =
+        entries.associate { entry ->
+            entry.target.name to MetastorePurge(entry.target) { open(entry) }
+        }
+
+    fun purge(target: MetastoreTarget): MetastorePurge =
+        purges[target.name]
+            ?: throw IllegalArgumentException("metastore '${target.name}' is not configured on this instance")
+
+    private fun open(entry: Entry): Connection = DriverManager.getConnection(entry.target.url, entry.user, entry.password)
 
     class Entry(
         val target: MetastoreTarget,

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreRegistry.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/MetastoreRegistry.kt
@@ -1,0 +1,53 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.v2.engine.metastore.purge.MetastoreTarget
+
+import java.sql.Connection
+import java.sql.DriverManager
+
+/**
+ * The metastores a purge may open, and the only place their credentials live.
+ *
+ * Connections are opened per use rather than pooled at startup. A purge runs a handful of
+ * statements per request against a database the data plane is still serving from, so a pool would
+ * only add ways to hold its connections open; and a metastore that is down should fail the request
+ * that wanted it, not the boot of a control instance that has other work to do.
+ */
+class MetastoreRegistry(
+    entries: List<Entry>,
+) {
+    private val byName: Map<String, Entry> = entries.associateBy { it.target.name }
+    private val byCoordinate: Map<Pair<String, String>, Entry> = entries.associateBy { it.target.url to it.target.table }
+
+    val targets: List<MetastoreTarget> get() = byName.values.map { it.target }
+
+    /** Resolves the name a caller asked for. */
+    fun target(name: String): MetastoreTarget =
+        byName[name]?.target
+            ?: throw IllegalArgumentException("unknown metastore '$name': configured are ${byName.keys.sorted()}")
+
+    /**
+     * Resolves the coordinate carried by a purge set, which is how a file saved earlier is checked
+     * against what this instance is allowed to open.
+     */
+    fun target(
+        url: String,
+        table: String,
+    ): MetastoreTarget =
+        byCoordinate[url to table]?.target
+            ?: throw IllegalArgumentException("metastore '$url' table '$table' is not configured on this instance")
+
+    /** Hands the purge a way to open connections without handing it the credentials. */
+    fun connections(target: MetastoreTarget): () -> Connection {
+        val entry =
+            byName[target.name]?.takeIf { it.target == target }
+                ?: throw IllegalArgumentException("metastore '${target.name}' is not configured on this instance")
+        return { DriverManager.getConnection(entry.target.url, entry.user, entry.password) }
+    }
+
+    class Entry(
+        val target: MetastoreTarget,
+        val user: String,
+        val password: String,
+    )
+}

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/PurgeSet.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/PurgeSet.kt
@@ -1,0 +1,58 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.v2.engine.metastore.purge.PurgeRow
+import com.kakao.actionbase.v2.engine.metastore.purge.SkippedRow
+import com.kakao.actionbase.v2.engine.metastore.purge.UndecodableKey
+
+import java.time.Instant
+
+/** What `candidates` was asked for. `metastore` is a configured name, not a url. */
+data class PurgeQuery(
+    val metastore: String,
+    val service: String,
+    val olderThanDays: Long = DEFAULT_OLDER_THAN_DAYS,
+    val maxRows: Int = DEFAULT_MAX_ROWS,
+    val maxScan: Int = DEFAULT_MAX_SCAN,
+    val cursor: Long = 0,
+) {
+    companion object {
+        const val DEFAULT_OLDER_THAN_DAYS = 30L
+        const val DEFAULT_MAX_ROWS = 500
+        const val DEFAULT_MAX_SCAN = 50_000
+    }
+}
+
+/**
+ * One page of a purge, and the only document the three endpoints exchange.
+ *
+ * `candidates` returns this, and `execute` and `restore` accept it back unchanged. There is no
+ * reduced projection for either, so a client saves a response and later posts it as it stands - and
+ * because the rows reach the client before anything is deleted, the saved document is the backup.
+ *
+ * `metastore` and `table` are resolved coordinates rather than the name that was asked for: a file
+ * read months later should say which database it came from, and both are checked against the
+ * configured list before anything is opened.
+ *
+ * `scanned`, `nextCursor` and `undecodable` are informational coming back in. They travel with the
+ * document so an operator's record of what was skipped survives next to the backup.
+ */
+data class PurgeSet(
+    val metastore: String,
+    val table: String,
+    val service: String,
+    val generatedAt: Instant,
+    val scanned: Int,
+    val nextCursor: Long?,
+    val rows: List<PurgeRow>,
+    val undecodable: List<UndecodableKey>,
+)
+
+/** What `execute` or `restore` did. */
+data class PurgeResult(
+    val metastore: String,
+    val table: String,
+    val service: String,
+    val requested: Int,
+    val applied: Int,
+    val skipped: List<SkippedRow>,
+)

--- a/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/PurgeSet.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/control/metastore/PurgeSet.kt
@@ -15,10 +15,27 @@ data class PurgeQuery(
     val maxScan: Int = DEFAULT_MAX_SCAN,
     val cursor: Long = 0,
 ) {
+    /**
+     * Both limits are clamped rather than trusted.
+     *
+     * They exist to bound a response and a walk, and a caller that sets them to something enormous
+     * would undo that - a page of a million rows is held whole in memory before it is serialised.
+     * `/control` has no authorization yet, so the ceiling has to be here rather than in the client.
+     */
+    fun bounded(): PurgeQuery =
+        copy(
+            olderThanDays = olderThanDays.coerceAtLeast(0),
+            maxRows = maxRows.coerceIn(1, MAX_ROWS_CEILING),
+            maxScan = maxScan.coerceIn(1, MAX_SCAN_CEILING).coerceAtLeast(maxRows.coerceIn(1, MAX_ROWS_CEILING)),
+            cursor = cursor.coerceAtLeast(0),
+        )
+
     companion object {
         const val DEFAULT_OLDER_THAN_DAYS = 30L
         const val DEFAULT_MAX_ROWS = 500
         const val DEFAULT_MAX_SCAN = 50_000
+        const val MAX_ROWS_CEILING = 5_000
+        const val MAX_SCAN_CEILING = 1_000_000
     }
 }
 

--- a/server/src/main/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilter.kt
+++ b/server/src/main/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilter.kt
@@ -22,6 +22,9 @@ class ReadOnlyRequestFilter : WebFilter {
             "/edges/get",
             "/multi-edges/ids",
             "/query",
+            // Listing what a purge would delete touches nothing, so a read-only instance answers
+            // it. `execute` and `restore` sit under the same prefix and are refused like any write.
+            "/metastore/purge/candidates",
         )
 
     init {

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeE2ETest.kt
@@ -1,0 +1,234 @@
+package com.kakao.actionbase.server.api.control.metastore
+
+import com.kakao.actionbase.server.test.E2ETestBase
+import com.kakao.actionbase.v2.core.code.HashEdgeValue
+import com.kakao.actionbase.v2.core.code.StringKeyFieldValueEdgeEncoder
+import com.kakao.actionbase.v2.core.edge.Edge
+import com.kakao.actionbase.v2.core.metadata.Active
+
+import java.sql.DriverManager
+import java.time.LocalDateTime
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+
+/**
+ * The purge over http, against a real metastore table.
+ *
+ * The point being pinned is that the document round-trips: whatever `candidates` returns is posted
+ * back to `execute` and `restore` byte for byte, with no client-side reshaping. If that ever stops
+ * holding, the file an operator saved stops being usable as a backup.
+ */
+@SpringBootTest(
+    properties = [
+        "actionbase.role=CONTROL",
+        "actionbase.control.tenants.alpha.env=prod",
+        "actionbase.control.tenants.alpha.namespace=ab_alpha",
+        "actionbase.control.tenants.alpha.active-url=http://127.0.0.1:1",
+        "actionbase.control.metastores.alpha.url=$METASTORE_URL",
+        "actionbase.control.metastores.alpha.table=kc_graph_metadata",
+    ],
+)
+class ControlPurgeE2ETest : E2ETestBase() {
+    private val encoder = StringKeyFieldValueEdgeEncoder()
+    private val old: LocalDateTime = LocalDateTime.now().minusYears(1)
+
+    @BeforeEach
+    fun resetTable() {
+        DriverManager.getConnection(METASTORE_URL, "", "").use { connection ->
+            connection.createStatement().use {
+                it.execute("DROP TABLE IF EXISTS kc_graph_metadata")
+                it.execute(
+                    """
+                    CREATE TABLE kc_graph_metadata (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        k VARCHAR(512) NOT NULL UNIQUE,
+                        v TEXT NOT NULL,
+                        created_at DATETIME(6) NOT NULL,
+                        created_by VARCHAR(256) NOT NULL,
+                        modified_at DATETIME(6) NOT NULL,
+                        modified_by VARCHAR(256) NOT NULL,
+                        update_ts DATETIME(6) NOT NULL
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+    }
+
+    private fun write(
+        name: String,
+        active: Active,
+    ) {
+        val encoded = encoder.encodeHashEdgeKey(Edge(0L, SERVICE, name), LABEL_ID)
+        val k = encoded.field?.let { "${encoded.key}:$it" } ?: encoded.key
+        val v = encoder.encodeHashEdgeValue(HashEdgeValue.from(active, 1L, emptyMap(), null, null))
+        DriverManager.getConnection(METASTORE_URL, "", "").use { connection ->
+            connection
+                .prepareStatement(
+                    "INSERT INTO kc_graph_metadata (k, v, created_at, created_by, modified_at, modified_by, update_ts) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ).use {
+                    it.setString(1, k)
+                    it.setString(2, v)
+                    it.setObject(3, old)
+                    it.setString(4, "writer")
+                    it.setObject(5, old)
+                    it.setString(6, "writer")
+                    it.setObject(7, old)
+                    it.executeUpdate()
+                }
+        }
+    }
+
+    private fun rowCount(): Int =
+        DriverManager.getConnection(METASTORE_URL, "", "").use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT COUNT(*) FROM kc_graph_metadata").use {
+                    it.next()
+                    it.getInt(1)
+                }
+            }
+        }
+
+    /** The response body as it came off the wire, which is what gets posted back. */
+    private fun candidates(): String =
+        client
+            .post()
+            .uri("/control/metastore/purge/candidates")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"metastore":"alpha","service":"$SERVICE"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+    private fun post(
+        path: String,
+        body: String,
+    ) = client
+        .post()
+        .uri(path)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .exchange()
+
+    @Test
+    fun `candidates lists the tombstones with their contents and leaves the table alone`() {
+        write("gone", Active.INACTIVE)
+        write("live", Active.ACTIVE)
+
+        post("/control/metastore/purge/candidates", """{"metastore":"alpha","service":"$SERVICE"}""")
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.rows.length()")
+            .isEqualTo(1)
+            .jsonPath("$.rows[0].v")
+            .exists()
+            .jsonPath("$.table")
+            .isEqualTo("kc_graph_metadata")
+            .jsonPath("$.metastore")
+            .value<String> { assertTrue(it.startsWith("jdbc:h2:"), it) }
+
+        assertEquals(2, rowCount())
+    }
+
+    @Test
+    fun `the candidates document is posted back verbatim to delete and to restore`() {
+        write("gone", Active.INACTIVE)
+        write("live", Active.ACTIVE)
+        val document = candidates()
+
+        post("/control/metastore/purge/execute", document)
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.applied")
+            .isEqualTo(1)
+            .jsonPath("$.skipped.length()")
+            .isEqualTo(0)
+        assertEquals(1, rowCount(), "only the tombstone went")
+
+        post("/control/metastore/purge/restore", document)
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.applied")
+            .isEqualTo(1)
+        assertEquals(2, rowCount(), "the same document put it back")
+    }
+
+    @Test
+    fun `repeating execute after a lost response changes nothing`() {
+        write("gone", Active.INACTIVE)
+        val document = candidates()
+        post("/control/metastore/purge/execute", document).expectStatus().isOk
+
+        post("/control/metastore/purge/execute", document)
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.applied")
+            .isEqualTo(0)
+            .jsonPath("$.skipped[0].reason")
+            .isEqualTo("ABSENT")
+        assertEquals(0, rowCount())
+    }
+
+    @Test
+    fun `a row that cannot be read is reported and never deleted`() {
+        DriverManager.getConnection(METASTORE_URL, "", "").use { connection ->
+            connection
+                .prepareStatement(
+                    "INSERT INTO kc_graph_metadata (k, v, created_at, created_by, modified_at, modified_by, update_ts) " +
+                        "VALUES ('not-an-encoded-key', 'nor-this', ?, 'writer', ?, 'writer', ?)",
+                ).use {
+                    it.setObject(1, old)
+                    it.setObject(2, old)
+                    it.setObject(3, old)
+                    it.executeUpdate()
+                }
+        }
+
+        post("/control/metastore/purge/candidates", """{"metastore":"alpha","service":"$SERVICE"}""")
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.rows.length()")
+            .isEqualTo(0)
+            .jsonPath("$.undecodable[0].k")
+            .isEqualTo("not-an-encoded-key")
+
+        assertEquals(1, rowCount())
+    }
+
+    @Test
+    fun `an unconfigured metastore name is refused`() {
+        post("/control/metastore/purge/candidates", """{"metastore":"nope","service":"$SERVICE"}""")
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `a document naming a metastore this instance does not serve is refused`() {
+        write("gone", Active.INACTIVE)
+        val document = candidates().replace(METASTORE_URL, "jdbc:mysql://somewhere-else.example.net:3306/graph")
+
+        post("/control/metastore/purge/execute", document).expectStatus().isBadRequest
+        assertEquals(1, rowCount(), "nothing was touched")
+    }
+
+    private companion object {
+        const val SERVICE = "prod:wish"
+        const val LABEL_ID = 7
+    }
+}
+
+private const val METASTORE_URL = "jdbc:h2:mem:purge-e2e;DB_CLOSE_DELAY=-1;MODE=MySQL"

--- a/server/src/test/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeE2ETest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/api/control/metastore/ControlPurgeE2ETest.kt
@@ -217,6 +217,29 @@ class ControlPurgeE2ETest : E2ETestBase() {
     }
 
     @Test
+    fun `a document with no rows applies nothing rather than failing`() {
+        write("live", Active.ACTIVE)
+        val document = candidates()
+
+        post("/control/metastore/purge/execute", document)
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.requested")
+            .isEqualTo(0)
+            .jsonPath("$.applied")
+            .isEqualTo(0)
+        assertEquals(1, rowCount())
+    }
+
+    @Test
+    fun `an empty document still has to name a metastore this instance serves`() {
+        val document = candidates().replace(METASTORE_URL, "jdbc:mysql://somewhere-else.example.net:3306/graph")
+
+        post("/control/metastore/purge/execute", document).expectStatus().isBadRequest
+    }
+
+    @Test
     fun `a document naming a metastore this instance does not serve is refused`() {
         write("gone", Active.INACTIVE)
         val document = candidates().replace(METASTORE_URL, "jdbc:mysql://somewhere-else.example.net:3306/graph")

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePropertiesTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePropertiesTest.kt
@@ -1,6 +1,7 @@
 package com.kakao.actionbase.server.control.metastore
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -72,6 +73,22 @@ class MetastorePropertiesTest {
                 props("alpha" to metastore(), "alpha-copy" to metastore()).toRegistry()
             }
         assertTrue(thrown.message!!.contains("same url and table"), thrown.message)
+    }
+
+    @Test
+    fun `the password is not printed, since a generated toString would carry it into any log line`() {
+        val printed = metastore().toString()
+
+        assertFalse(printed.contains("secret"), printed)
+        assertTrue(printed.contains("jdbc:mysql://ab-alpha-meta.example.net:3306/graph"), printed)
+        assertTrue(printed.contains("purge"), printed)
+    }
+
+    @Test
+    fun `the enclosing properties object does not print it either, which is the object that gets logged`() {
+        val printed = props("alpha" to metastore()).toString()
+
+        assertFalse(printed.contains("secret"), printed)
     }
 
     @Test

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePropertiesTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/MetastorePropertiesTest.kt
@@ -1,0 +1,81 @@
+package com.kakao.actionbase.server.control.metastore
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetastorePropertiesTest {
+    private fun metastore(
+        url: String = "jdbc:mysql://ab-alpha-meta.example.net:3306/graph",
+        table: String = MetastoreProperties.DEFAULT_TABLE,
+    ) = MetastoreProperties.Metastore(url = url, user = "purge", password = "secret", table = table)
+
+    private fun props(vararg entries: Pair<String, MetastoreProperties.Metastore>) = MetastoreProperties(entries.toMap())
+
+    @Test
+    fun `a configured metastore resolves by name`() {
+        val registry = props("alpha" to metastore()).toRegistry()
+
+        val target = registry.target("alpha")
+
+        assertEquals("jdbc:mysql://ab-alpha-meta.example.net:3306/graph", target.url)
+        assertEquals(MetastoreProperties.DEFAULT_TABLE, target.table)
+    }
+
+    @Test
+    fun `a purge set is resolved back by url and table`() {
+        val registry = props("alpha" to metastore()).toRegistry()
+
+        assertEquals("alpha", registry.target("jdbc:mysql://ab-alpha-meta.example.net:3306/graph", "kc_graph_metadata").name)
+    }
+
+    @Test
+    fun `a target absent from the configuration is refused rather than opened`() {
+        val registry = props("alpha" to metastore()).toRegistry()
+
+        val thrown =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.target("jdbc:mysql://somewhere-else.example.net:3306/graph", "kc_graph_metadata")
+            }
+        assertTrue(thrown.message!!.contains("not configured"), thrown.message)
+    }
+
+    @Test
+    fun `an unknown name names the ones that exist`() {
+        val registry = props("alpha" to metastore()).toRegistry()
+
+        val thrown = assertThrows(IllegalArgumentException::class.java) { registry.target("beta") }
+        assertTrue(thrown.message!!.contains("alpha"), thrown.message)
+    }
+
+    @Test
+    fun `a url that is not jdbc fails at startup rather than at the first request`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            props("alpha" to metastore(url = "ab-alpha-meta.example.net:3306")).toRegistry()
+        }
+    }
+
+    @Test
+    fun `a table name that is not a plain identifier is rejected`() {
+        val thrown =
+            assertThrows(IllegalArgumentException::class.java) {
+                props("alpha" to metastore(table = "kc_graph_metadata; drop table users")).toRegistry()
+            }
+        assertTrue(thrown.message!!.contains("identifier"), thrown.message)
+    }
+
+    @Test
+    fun `two names pointing at the same table fail at startup, since a purge set could not resolve back to one`() {
+        val thrown =
+            assertThrows(IllegalArgumentException::class.java) {
+                props("alpha" to metastore(), "alpha-copy" to metastore()).toRegistry()
+            }
+        assertTrue(thrown.message!!.contains("same url and table"), thrown.message)
+    }
+
+    @Test
+    fun `no metastores configured is allowed, since a control instance need not host a purge`() {
+        assertEquals(emptyList<Any>(), MetastoreProperties().toRegistry().targets)
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/PurgeQueryTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/control/metastore/PurgeQueryTest.kt
@@ -1,0 +1,123 @@
+package com.kakao.actionbase.server.control.metastore
+
+import com.kakao.actionbase.test.documentations.params.ObjectSourceParameterizedTest
+import com.kakao.actionbase.test.documentations.params.TableSource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The ceilings a request body cannot talk its way past.
+ *
+ * `/control` has no authorization yet, so these are the only thing standing between a caller and a
+ * page held whole in memory. They are asserted here rather than through the endpoint because the
+ * clamp has to hold for every caller, not just the one the E2E test writes.
+ */
+class PurgeQueryTest {
+    private fun query(
+        olderThanDays: Long = PurgeQuery.DEFAULT_OLDER_THAN_DAYS,
+        maxRows: Int = PurgeQuery.DEFAULT_MAX_ROWS,
+        maxScan: Int = PurgeQuery.DEFAULT_MAX_SCAN,
+        cursor: Long = 0,
+    ) = PurgeQuery(
+        metastore = "alpha",
+        service = "prod:wish",
+        olderThanDays = olderThanDays,
+        maxRows = maxRows,
+        maxScan = maxScan,
+        cursor = cursor,
+    )
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        - -1      | 1
+        - 0       | 1
+        - 500     | 500
+        - 5000    | 5000
+        - 5001    | 5000
+        - 1000000 | 5000
+        """,
+    )
+    fun `maxRows is clamped to the ceiling`(
+        requested: Int,
+        expected: Int,
+    ) {
+        assertThat(query(maxRows = requested).bounded().maxRows).isEqualTo(expected)
+    }
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        - 50000    | 50000
+        - 1000000  | 1000000
+        - 1000001  | 1000000
+        - 99999999 | 1000000
+        """,
+    )
+    fun `maxScan is clamped to the ceiling`(
+        requested: Int,
+        expected: Int,
+    ) {
+        assertThat(query(maxScan = requested).bounded().maxScan).isEqualTo(expected)
+    }
+
+    @Test
+    fun `maxScan below maxRows is raised to it, since a walk that short cannot fill the page it was asked for`() {
+        val bounded = query(maxRows = 2000, maxScan = 10).bounded()
+
+        assertThat(bounded.maxScan).isEqualTo(2000)
+    }
+
+    @Test
+    fun `maxScan is raised to the clamped maxRows, not the requested one`() {
+        val bounded = query(maxRows = 1000000, maxScan = 1).bounded()
+
+        assertThat(bounded.maxScan).isEqualTo(PurgeQuery.MAX_ROWS_CEILING)
+    }
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        - -1 | 0
+        - 0  | 0
+        - 30 | 30
+        """,
+    )
+    fun `a negative age would reach past now, so it floors at zero`(
+        requested: Long,
+        expected: Long,
+    ) {
+        assertThat(query(olderThanDays = requested).bounded().olderThanDays).isEqualTo(expected)
+    }
+
+    @ObjectSourceParameterizedTest
+    @TableSource(
+        """
+        - -1  | 0
+        - 0   | 0
+        - 900 | 900
+        """,
+    )
+    fun `a negative cursor floors at zero`(
+        requested: Long,
+        expected: Long,
+    ) {
+        assertThat(query(cursor = requested).bounded().cursor).isEqualTo(expected)
+    }
+
+    @Test
+    fun `a query inside the bounds comes back as it was`() {
+        val original = query()
+
+        assertThat(original.bounded()).isEqualTo(original)
+    }
+
+    @Test
+    fun `clamping leaves the target alone`() {
+        val bounded = query(maxRows = 1000000).bounded()
+
+        assertThat(bounded.metastore).isEqualTo("alpha")
+        assertThat(bounded.service).isEqualTo("prod:wish")
+    }
+}

--- a/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
+++ b/server/src/test/kotlin/com/kakao/actionbase/server/filter/ReadOnlyRequestFilterTest.kt
@@ -261,6 +261,7 @@ class ReadOnlyRequestFilterTest {
                 "GET /control/topology/{tenant}",
                 "GET /control/tenants/{tenant}/datastore/tables",
                 "GET /control/htables",
+                "POST /control/metastore/purge/candidates",
             )
 
         // Operational writes: refused by a read-only instance like any other write, but served by a
@@ -268,6 +269,8 @@ class ReadOnlyRequestFilterTest {
         val CONTROL_WRITE_ENDPOINTS =
             setOf(
                 "POST /control/jobs",
+                "POST /control/metastore/purge/execute",
+                "POST /control/metastore/purge/restore",
             )
 
         val NON_GRAPH_ENDPOINTS =


### PR DESCRIPTION
## Summary

The metastore keeps every row it was ever told to delete. A metadata `DELETE` writes the row back with `Active.INACTIVE`, and `JdbcHashLabel.scanStorage` applies `LIMIT` before the active filter, so tombstones spend the budget a live scan needs. Past 1000 of them under one service, `DatastoreTableReferences.whole()` refuses and the control plane's own cleanup endpoints stop answering.

This adds a purge that reads a metastore table directly, hands back what it would delete, deletes exactly that, and can put it back. Stateless: `candidates` returns a `PurgeSet`, and `execute` and `restore` accept the same document unchanged, so the file an operator holds is both the plan and the backup.

Temporary. It targets a table the data plane is already abandoning and goes away with JDBC in Phase 4 of #347.

Closes #485

## Plan

Created by **claude code (opus 5)**

- [x] 1. `actionbase.control.metastores.*` config — the JDBC URI and table pairs the purge may open, credentials from the environment, resolved at startup
- [x] 2. PK-cursor scanner — decode `active` and `deleteTs` with an empty field-name map, filter by service, report undecodable keys
- [x] 3. `PurgeSet` as one type, serving as the `candidates` response and the request body of the other two
- [x] 4. The three endpoints, rejecting a `PurgeSet` whose target is not in the configured list
- [x] 5. Endpoint classification in `ReadOnlyRequestFilter` — `execute` and `restore` are writes
- [x] 6. `purge plan` / `show` / `apply` / `restore` in the Go CLI
- [x] 7. E2E test posting the `candidates` response back verbatim — resurrected tombstone, undecodable row, repeated `execute`, restore over a live key

## Progress

<!-- Append only. Never remove another agent's entry. -->
- [x] 1 — **claude code (opus 5)** (commit 5cfebd5)
- [x] 2 — **claude code (opus 5)** (commit 8fe7c64)
- [x] 3–7 — **claude code (opus 5)** (commit a02730f)
- [x] Review round 1 fixes — **claude code (opus 5)** (commit db3c10d)
- [x] Tests for the round 1 fixes, and the `resolve` comment corrected — **claude code (opus 5)** (commit 0fcd65f)

## Changes

**engine** — `metastore/purge/`, standalone. `MetastorePurge` walks `WHERE id > :cursor ORDER BY id`, decodes two fields, and deletes on `k` and `v` together. `PurgeFields` reads the active flag off the front of the encoded value and the service off the front of the encoded key. `PurgeTable` is its own Exposed definition.

**server** — `control/metastore/` holds the allowlist, the credentials and the service; `api/control/metastore/` holds the three endpoints. `candidates` joins the read-only filter's allowed suffixes, `execute` and `restore` join `CONTROL_WRITE_ENDPOINTS`.

**cli** — `purge plan | show | apply | restore`, driving the endpoints over a file. `apply` and `restore` need `--yes`.

## Three things worth naming

**Nothing from the data model.** The purge reads `active` and the service straight off the encodings with `OrderedBytes` and `ValueUtils`. No `HashEdgeValue`, no `DecodedEdge`, no `EdgeSchema`, no `Graph`. A tool that dies with JDBC should not be entangled with what is being retired around it, and it means no new dependency in `server` at all.

**How old a tombstone is comes from `update_ts`, not the encoded `delete_ts`.** Reaching that property means walking the whole property list, while the column says the same thing for a row that is currently inactive — the last write was the one that deactivated it — and says it in a `WHERE` clause against an index.

**One document, three endpoints.** `candidates` returns it and the other two take it back unchanged, so the CLI never reshapes anything. The rows therefore reach the client before anything is deleted, which is what makes the saved file a backup rather than a convenience. Committing a purge is keeping the file; reverting one is posting it to `restore`.

## How to Test

```
./gradlew :engine:test --tests "*MetastorePurge*"
./gradlew :server:test --tests "*Metastore*" --tests "*ControlPurge*" --tests "*RequestFilterTest*"
cd cli && go test ./...
```

`ControlPurgeE2ETest` runs against a real table and posts the `candidates` response back byte for byte, which is the claim that has to keep holding.

## Not touched

`JdbcHashLabel.cad` is broken — its `deleteWhere` lambda has `k eq ...` and `v eq ...` as separate statements, so Exposed takes the last as the predicate and the delete matches on value alone, ignoring the key. `deleteOnLock` is the caller. Out of scope here and it needs its own issue.

The root cause outlives this PR: `scanStorage` still cannot filter on `active` in SQL. An `active` column with an index would fix it properly, at the cost of a schema change and a backfill.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)

