### PR TITLE
Reshape a query's results with SQL, in process (Step 1 of #490)

### DIFF
--- a/conventions/src/main/kotlin/actionbase/JibConventionsPlugin.kt
+++ b/conventions/src/main/kotlin/actionbase/JibConventionsPlugin.kt
@@ -24,7 +24,7 @@ class JibConventionsPlugin : Plugin<Project> {
                 "--add-opens",
                 "java.base/java.nio=ALL-UNNAMED",
                 "--add-exports",
-                "java.security.jgss/sun.security.krb5=ALL-UNNAMED",
+                "java.security.jgss/sun.security.krb5=ALL-UNNAMED"
             )
         project.extensions.extraProperties["jvmArgs"] = jvmArgs
 

--- a/conventions/src/main/kotlin/actionbase/JibConventionsPlugin.kt
+++ b/conventions/src/main/kotlin/actionbase/JibConventionsPlugin.kt
@@ -1,8 +1,9 @@
 package actionbase
 
-import com.google.cloud.tools.jib.gradle.JibExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+
+import com.google.cloud.tools.jib.gradle.JibExtension
 
 class JibConventionsPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -19,10 +20,11 @@ class JibConventionsPlugin : Plugin<Project> {
                 "-Dsun.net.inetaddr.ttl=0",
                 "-Dnetworkaddress.cache.ttl=0",
                 "-Dnetworkaddress.cache.negative.ttl=0",
+                "-Dcalcite.bindable.cache.maxSize=1000",
                 "--add-opens",
                 "java.base/java.nio=ALL-UNNAMED",
                 "--add-exports",
-                "java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+                "java.security.jgss/sun.security.krb5=ALL-UNNAMED",
             )
         project.extensions.extraProperties["jvmArgs"] = jvmArgs
 
@@ -42,4 +44,3 @@ class JibConventionsPlugin : Plugin<Project> {
         }
     }
 }
-

--- a/conventions/src/main/kotlin/actionbase/dependencies/Dependencies.kt
+++ b/conventions/src/main/kotlin/actionbase/dependencies/Dependencies.kt
@@ -37,6 +37,7 @@ object Versions {
     const val RELOAD4J = "1.2.25"
     const val JACKSON_SPARK = "2.12.3"
     const val JUNIT_JUPITER_OLD = "5.9.2"
+    const val CALCITE = "1.40.0"
 }
 
 object Dependencies {
@@ -152,6 +153,10 @@ object Dependencies {
 
     object DatabasePool {
         const val HIKARICP = "com.zaxxer:HikariCP:${Versions.HIKARICP}"
+    }
+
+    object Calcite {
+        const val CORE = "org.apache.calcite:calcite-core:${Versions.CALCITE}"
     }
 
     object Exposed {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     // kafka
     implementation(Dependencies.Kafka.CLIENTS)
 
+    // SQL
+    implementation(Dependencies.Calcite.CORE)
+
     // RDB
     implementation(Dependencies.DatabasePool.HIKARICP)
     implementation(Dependencies.Exposed.CORE)
@@ -95,4 +98,6 @@ tasks.withType<Test>().all {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
         jvmArgs("-XX:+AllowRedefinitionToAddDeleteMethods")
     }
+
+    systemProperty("calcite.bindable.cache.maxSize", System.getProperty("calcite.bindable.cache.maxSize") ?: "1000")
 }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 data class ActionbaseQuery(
     val fetch: List<Item>,
+    val transform: List<Transform> = emptyList(),
     val stats: Set<StatKey> = emptySet(),
 ) {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -112,6 +113,20 @@ data class ActionbaseQuery(
             override val post: List<PostProcessor> = emptyList(),
             override val aggregators: List<Aggregator> = emptyList(),
         ) : Item()
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = Transform.Sql::class, name = "SQL"),
+    )
+    sealed class Transform {
+        abstract val name: String
+
+        data class Sql(
+            override val name: String,
+            val sql: String,
+            val arguments: List<String> = emptyList(),
+        ) : Transform()
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQuery.kt
@@ -17,6 +17,13 @@ data class ActionbaseQuery(
     val transform: List<Transform> = emptyList(),
     val stats: Set<StatKey> = emptySet(),
 ) {
+    init {
+        val taken = fetch.mapTo(mutableSetOf()) { it.name }
+        transform.forEach { step ->
+            require(taken.add(step.name)) { "`${step.name}` already names a fetch step or an earlier transform." }
+        }
+    }
+
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
     @JsonSubTypes(
         JsonSubTypes.Type(value = Item.Self::class, name = "SELF"),

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
@@ -9,6 +9,7 @@ import com.kakao.actionbase.engine.binding.TableBinding
 import com.kakao.actionbase.engine.service.RankScan
 import com.kakao.actionbase.engine.sql.DataFrame
 import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.sql.calcite.SqlTransform
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
@@ -30,6 +31,7 @@ import reactor.core.publisher.Mono
  */
 class ActionbaseQueryExecutor(
     private val engine: QueryEngine,
+    private val transforms: SqlTransform = SqlTransform(),
 ) {
     private val objectMapper = jacksonObjectMapper()
 
@@ -51,7 +53,12 @@ class ActionbaseQueryExecutor(
                     .map { df -> df.getColumn(vertex.field).filterNotNull().toSet() }
         }
 
-    fun query(actionBaseQuery: ActionbaseQuery): Mono<Map<String, DataFrame>> {
+    fun query(actionBaseQuery: ActionbaseQuery): Mono<Map<String, DataFrame>> = query(actionBaseQuery, emptyList())
+
+    private fun query(
+        actionBaseQuery: ActionbaseQuery,
+        transformArguments: List<List<Any?>>,
+    ): Mono<Map<String, DataFrame>> {
         val computed: Mono<Map<String, DataFrame>> =
             actionBaseQuery.fetch.fold(Mono.just(emptyMap())) { acc, queryItem ->
                 acc.flatMap { context ->
@@ -61,8 +68,36 @@ class ActionbaseQueryExecutor(
             }
         val returnNames = actionBaseQuery.fetch.filter { it.include }.map { it.name }
 
-        return computed.map { context -> returnNames.associateWith { context.getValue(it) } }
+        // Transforms read the whole context, `include = false` steps and all: a step can exist only to
+        // be subtracted from a later one. What the caller gets back is filtered afterwards.
+        return computed
+            .flatMap { context -> applyTransforms(context, actionBaseQuery.transform, transformArguments) }
+            .map { context ->
+                returnNames.associateWith { context.getValue(it) } +
+                    actionBaseQuery.transform.associate { it.name to context.getValue(it.name) }
+            }
     }
+
+    private fun applyTransforms(
+        context: Map<String, DataFrame>,
+        transforms: List<ActionbaseQuery.Transform>,
+        arguments: List<List<Any?>>,
+    ): Mono<Map<String, DataFrame>> =
+        transforms.withIndex().fold(Mono.just(context)) { acc, (index, transform) ->
+            acc.flatMap { carried ->
+                applyTransform(carried, transform, arguments.getOrElse(index) { emptyList() })
+                    .map { carried + (transform.name to it) }
+            }
+        }
+
+    private fun applyTransform(
+        context: Map<String, DataFrame>,
+        transform: ActionbaseQuery.Transform,
+        arguments: List<Any?>,
+    ): Mono<DataFrame> =
+        when (transform) {
+            is ActionbaseQuery.Transform.Sql -> Mono.fromCallable { transforms.run(context, transform.sql, arguments) }
+        }
 
     private fun processQuery(
         queryItem: ActionbaseQuery.Item,

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/query/ActionbaseQueryExecutor.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 
 /**
  * @see ActionbaseQuery
@@ -96,7 +97,10 @@ class ActionbaseQueryExecutor(
         arguments: List<Any?>,
     ): Mono<DataFrame> =
         when (transform) {
-            is ActionbaseQuery.Transform.Sql -> Mono.fromCallable { transforms.run(context, transform.sql, arguments) }
+            is ActionbaseQuery.Transform.Sql ->
+                Mono
+                    .fromCallable { transforms.run(context, transform.sql, arguments) }
+                    .subscribeOn(Schedulers.boundedElastic())
         }
 
     private fun processQuery(

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/CalciteTypes.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/CalciteTypes.kt
@@ -1,0 +1,62 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+
+import java.sql.ResultSetMetaData
+import java.sql.Types
+
+import org.apache.calcite.rel.type.RelDataType
+import org.apache.calcite.rel.type.RelDataTypeFactory
+import org.apache.calcite.sql.type.SqlTypeName
+
+internal fun StructType.toRelDataType(typeFactory: RelDataTypeFactory): RelDataType =
+    typeFactory
+        .builder()
+        .also { builder ->
+            fields.forEach { field ->
+                builder.add(field.name, typeFactory.createTypeWithNullability(typeFactory.createSqlType(field.type.toSqlTypeName()), field.nullable))
+            }
+        }.build()
+
+/** The output schema of a prepared statement, which Calcite knows before the statement is executed. */
+internal fun ResultSetMetaData.toStructType(): StructType =
+    StructType(
+        (1..columnCount).map { column ->
+            StructField(
+                name = getColumnLabel(column),
+                type = getColumnType(column).toPrimitiveType(),
+                comment = "",
+                nullable = isNullable(column) != ResultSetMetaData.columnNoNulls,
+            )
+        },
+    )
+
+private fun PrimitiveType.toSqlTypeName(): SqlTypeName =
+    when (this) {
+        PrimitiveType.BOOLEAN -> SqlTypeName.BOOLEAN
+        PrimitiveType.BYTE -> SqlTypeName.TINYINT
+        PrimitiveType.SHORT -> SqlTypeName.SMALLINT
+        PrimitiveType.INT -> SqlTypeName.INTEGER
+        PrimitiveType.LONG -> SqlTypeName.BIGINT
+        PrimitiveType.FLOAT -> SqlTypeName.REAL
+        PrimitiveType.DOUBLE -> SqlTypeName.DOUBLE
+        // A JSON node has no SQL type. It is carried as text, so `JSON_VALUE` and friends can reach
+        // into it and a projection can hand it back unchanged.
+        PrimitiveType.STRING, PrimitiveType.OBJECT -> SqlTypeName.VARCHAR
+    }
+
+private fun Int.toPrimitiveType(): PrimitiveType =
+    when (this) {
+        Types.BOOLEAN -> PrimitiveType.BOOLEAN
+        Types.TINYINT -> PrimitiveType.BYTE
+        Types.SMALLINT -> PrimitiveType.SHORT
+        Types.INTEGER -> PrimitiveType.INT
+        Types.BIGINT -> PrimitiveType.LONG
+        Types.REAL -> PrimitiveType.FLOAT
+        // Calcite's FLOAT is eight bytes wide, the same as DOUBLE.
+        Types.FLOAT, Types.DOUBLE, Types.DECIMAL, Types.NUMERIC -> PrimitiveType.DOUBLE
+        Types.CHAR, Types.VARCHAR -> PrimitiveType.STRING
+        else -> throw IllegalArgumentException("A transform cannot return JDBC type $this; a DataFrame has no matching type.")
+    }

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/PreparedTransform.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/PreparedTransform.kt
@@ -1,0 +1,69 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.engine.sql.DataFrame
+
+/**
+ * A transform already parsed, planned and compiled into a JDBC `PreparedStatement`. Executing it is
+ * the only work left per request. Close it to give the statement back.
+ *
+ * Safe to share across threads; a statement is not, so each execution leases a session for its
+ * duration. The lease stays inside one synchronous call — never hand a `ResultSet` to a reactive
+ * chain, or the session outlives the thread that took it. From a chain, wrap the call in
+ * `Mono.fromCallable`.
+ */
+class PreparedTransform internal constructor(
+    private val sessions: TransformSessionPool,
+    /** The frames this transform reads, and the columns each was prepared for. */
+    private val inputSchemas: Map<String, StructType>,
+) : AutoCloseable {
+    /** The fetch names this transform reads. An execution has to supply a frame for each. */
+    val inputs: Set<String> get() = inputSchemas.keys
+
+    /** The columns the SQL returns, known without executing it. */
+    val schema: StructType get() = sessions.schema
+
+    /** How many `?` placeholders the SQL carries, so a caller can check its arguments up front. */
+    val parameterCount: Int get() = sessions.parameterCount
+
+    /** Sessions currently open, which is the concurrency this transform can actually serve. */
+    val sessionCount: Int get() = sessions.sessionCount
+
+    fun execute(
+        frames: Map<String, DataFrame>,
+        arguments: List<Any?> = emptyList(),
+    ): DataFrame {
+        val missing = inputs - frames.keys
+        require(missing.isEmpty()) { "This transform reads ${inputs.joinToString()}; the execution is missing ${missing.joinToString()}." }
+        require(arguments.size == parameterCount) { "This transform takes $parameterCount arguments, got ${arguments.size}." }
+        // Left to the statement this surfaces as a SQLException from inside Calcite, after taking a session.
+        inputSchemas.forEach { (name, schema) ->
+            val given = frames.getValue(name).schema
+            require(given == schema) {
+                "`$name` was prepared for ${schema.fields.map { it.name }} but was given ${given.fields.map { it.name }}."
+            }
+        }
+
+        return sessions.lease { session -> session.execute(frames, arguments) }
+    }
+
+    /** Opens sessions up front. Required before serving traffic: opening one reads from disk. */
+    fun warmUp(sessions: Int = DEFAULT_MAXIMUM_SESSIONS) {
+        this.sessions.warmUp(sessions)
+    }
+
+    override fun close() {
+        sessions.close()
+    }
+
+    companion object {
+        fun compile(
+            schemas: Map<String, StructType>,
+            sql: String,
+            maximumSessions: Int = DEFAULT_MAXIMUM_SESSIONS,
+        ): PreparedTransform = PreparedTransform(TransformSessionPool(sql, schemas, maximumSessions), schemas)
+
+        /** One per event loop, so no event-loop thread ever waits for a session. */
+        val DEFAULT_MAXIMUM_SESSIONS: Int = Runtime.getRuntime().availableProcessors()
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/SqlTransform.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/SqlTransform.kt
@@ -1,0 +1,63 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.engine.sql.DataFrame
+
+import com.github.benmanes.caffeine.cache.Caffeine
+
+/**
+ * Holds the prepared statement behind each SQL transform, keyed by the statement and the columns of
+ * the frames it reads. Calcite's driver caches no plan between statements, so without this every
+ * request re-parses, re-plans and re-compiles the same SQL.
+ *
+ * [prepare] pays that cost up front and fills the session pool; [prepared] answers only if it has
+ * already been paid, so a caller can keep it off a thread that must not block. Close it to release
+ * every statement it holds.
+ */
+class SqlTransform(
+    private val maximumSessionsPerTransform: Int = PreparedTransform.DEFAULT_MAXIMUM_SESSIONS,
+    maximumTransforms: Long = DEFAULT_MAXIMUM_TRANSFORMS,
+) : AutoCloseable {
+    private val transforms =
+        Caffeine
+            .newBuilder()
+            .maximumSize(maximumTransforms)
+            .evictionListener<PlanKey, PreparedTransform> { _, transform, _ -> transform?.close() }
+            .build<PlanKey, PreparedTransform>()
+
+    /** Transforms held, for a cache-hit metric to sit on. */
+    val transformCount: Long get() = transforms.estimatedSize()
+
+    fun run(
+        frames: Map<String, DataFrame>,
+        sql: String,
+        arguments: List<Any?> = emptyList(),
+    ): DataFrame = prepare(frames.mapValues { (_, frame) -> frame.schema }, sql).execute(frames, arguments)
+
+    fun prepare(
+        schemas: Map<String, StructType>,
+        sql: String,
+    ): PreparedTransform =
+        transforms.get(PlanKey(sql, schemas)) { key ->
+            PreparedTransform.compile(key.schemas, key.sql, maximumSessionsPerTransform).also { it.warmUp() }
+        }
+
+    fun prepared(
+        schemas: Map<String, StructType>,
+        sql: String,
+    ): PreparedTransform? = transforms.getIfPresent(PlanKey(sql, schemas))
+
+    override fun close() {
+        transforms.asMap().values.forEach { it.close() }
+        transforms.invalidateAll()
+    }
+
+    private data class PlanKey(
+        val sql: String,
+        val schemas: Map<String, StructType>,
+    )
+
+    companion object {
+        const val DEFAULT_MAXIMUM_TRANSFORMS = 1_000L
+    }
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/TransformSession.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/TransformSession.kt
@@ -1,0 +1,115 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.Properties
+
+import org.apache.calcite.DataContext
+import org.apache.calcite.jdbc.CalciteConnection
+import org.apache.calcite.linq4j.Enumerable
+import org.apache.calcite.linq4j.Linq4j
+import org.apache.calcite.rel.type.RelDataType
+import org.apache.calcite.rel.type.RelDataTypeFactory
+import org.apache.calcite.schema.ScannableTable
+import org.apache.calcite.schema.impl.AbstractTable
+
+/**
+ * One connection, its frame slots, and the [PreparedStatement] the transform was prepared into.
+ *
+ * Leased for one execution and never shared, which is what makes writing a request's frames into the
+ * slots safe.
+ */
+internal class TransformSession(
+    sql: String,
+    schemas: Map<String, StructType>,
+) : AutoCloseable {
+    private val connection: Connection = DriverManager.getConnection("jdbc:calcite:", CONNECTION_PROPERTIES)
+    private val slots: Map<String, FrameSlot> = schemas.mapValues { (_, schema) -> FrameSlot(schema) }
+    private val statement: PreparedStatement
+
+    /** The columns the statement returns, taken from its metadata rather than from a first execution. */
+    val schema: StructType
+
+    /** How many `?` placeholders the SQL carries. */
+    val parameterCount: Int
+
+    init {
+        val rootSchema = connection.unwrap(CalciteConnection::class.java).rootSchema
+        slots.forEach { (name, slot) -> rootSchema.add(name, slot) }
+
+        statement = connection.prepareStatement(sql)
+        schema = statement.metaData.toStructType()
+        parameterCount = statement.parameterMetaData.parameterCount
+    }
+
+    fun execute(
+        frames: Map<String, DataFrame>,
+        arguments: List<Any?>,
+    ): DataFrame =
+        try {
+            slots.forEach { (name, slot) -> slot.frame = frames.getValue(name) }
+            arguments.forEachIndexed { index, argument -> statement.setObject(index + 1, argument) }
+            statement.executeQuery().use { it.toDataFrame(schema) }
+        } finally {
+            // Slots outlive the execution; holding the frames would keep a request's rows reachable.
+            slots.forEach { (_, slot) -> slot.frame = null }
+        }
+
+    override fun close() {
+        statement.close()
+        connection.close()
+    }
+
+    private companion object {
+        val CONNECTION_PROPERTIES =
+            Properties().apply {
+                // Keeps unquoted identifiers as written, so `hop1.paidAt` is not `PAIDAT`.
+                setProperty("lex", "JAVA")
+                // The standard operator table has no `IFNULL`; the dialect libraries do.
+                setProperty("fun", "all")
+            }
+    }
+}
+
+/** Columns fixed at prepare time, rows written just before each execution by the lease holder alone. */
+private class FrameSlot(
+    private val schema: StructType,
+) : AbstractTable(),
+    ScannableTable {
+    var frame: DataFrame? = null
+
+    override fun getRowType(typeFactory: RelDataTypeFactory): RelDataType = schema.toRelDataType(typeFactory)
+
+    override fun scan(root: DataContext): Enumerable<Array<Any?>> {
+        val frame = checkNotNull(frame) { "A transform was executed without rows for one of its inputs." }
+        require(frame.schema == schema) {
+            "This transform was prepared for ${schema.fields.map { it.name }} but was given ${frame.schema.fields.map { it.name }}."
+        }
+
+        val fields = schema.fields
+        return Linq4j.asEnumerable(
+            frame.rows.map { row ->
+                Array<Any?>(fields.size) { column ->
+                    val value = row.data[fields[column].name]
+                    if (fields[column].type == PrimitiveType.OBJECT) value?.toString() else value
+                }
+            },
+        )
+    }
+}
+
+private fun ResultSet.toDataFrame(schema: StructType): DataFrame {
+    val fields = schema.fields
+    val rows = mutableListOf<Row>()
+    while (next()) {
+        rows += Row(fields.mapIndexed { index, field -> field.name to getObject(index + 1)?.let { field.type.cast(it) } }.toMap(), schema)
+    }
+    return DataFrame(rows, schema, total = rows.size.toLong())
+}

--- a/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/TransformSessionPool.kt
+++ b/engine/src/main/kotlin/com/kakao/actionbase/engine/sql/calcite/TransformSessionPool.kt
@@ -1,0 +1,95 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructType
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The sessions one prepared transform can execute on. Concurrency comes from holding several rather
+ * than sharing one, since a statement takes a single thread.
+ *
+ * Each session carries its own copy of the plan and costs milliseconds to open, so the pool stops at
+ * [maximumSessions] and a request that finds them all busy waits instead of opening another.
+ */
+internal class TransformSessionPool(
+    private val sql: String,
+    private val schemas: Map<String, StructType>,
+    private val maximumSessions: Int = DEFAULT_MAXIMUM_SESSIONS,
+) : AutoCloseable {
+    private val idle = ArrayBlockingQueue<TransformSession>(maximumSessions)
+    private val opened = AtomicInteger()
+    private val closed = AtomicBoolean()
+
+    /** Opened here, not on the first request. Its metadata is immutable, so reading it while leased is safe. */
+    private val first: TransformSession = open().also { idle.offer(it) }
+
+    val schema: StructType get() = first.schema
+
+    val parameterCount: Int get() = first.parameterCount
+
+    val sessionCount: Int get() = opened.get()
+
+    fun <T> lease(block: (TransformSession) -> T): T {
+        check(!closed.get()) { "This transform has been closed." }
+
+        val session = borrow()
+        return try {
+            block(session)
+        } finally {
+            release(session)
+        }
+    }
+
+    /** Opens sessions up front so no request pays for one. */
+    fun warmUp(sessions: Int) {
+        while (opened.get() < minOf(sessions, maximumSessions)) {
+            idle.offer(openIfUnderCap() ?: return)
+        }
+    }
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            generateSequence { idle.poll() }.forEach { it.close() }
+        }
+    }
+
+    private fun borrow(): TransformSession =
+        idle.poll()
+            ?: openIfUnderCap()
+            ?: idle.poll(LEASE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            ?: throw IllegalStateException("All $maximumSessions transform sessions were busy for $LEASE_TIMEOUT_MILLIS ms.")
+
+    private fun release(session: TransformSession) {
+        if (closed.get() || !idle.offer(session)) {
+            session.close()
+            opened.decrementAndGet()
+        }
+    }
+
+    private fun open(): TransformSession = openIfUnderCap() ?: throw IllegalStateException("The pool is already holding $maximumSessions sessions.")
+
+    /** Claims a slot before opening, so the cap holds even when several threads arrive at once. */
+    private fun openIfUnderCap(): TransformSession? {
+        while (true) {
+            val current = opened.get()
+            if (current >= maximumSessions) {
+                return null
+            }
+            if (opened.compareAndSet(current, current + 1)) {
+                return runCatching { TransformSession(sql, schemas) }
+                    .getOrElse { failure ->
+                        opened.decrementAndGet()
+                        throw failure
+                    }
+            }
+        }
+    }
+
+    private companion object {
+        val DEFAULT_MAXIMUM_SESSIONS = Runtime.getRuntime().availableProcessors()
+        const val LEASE_TIMEOUT_MILLIS = 1_000L
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/CalciteLatencyProbe.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/CalciteLatencyProbe.kt
@@ -1,0 +1,305 @@
+package com.kakao.actionbase.engine.experiments.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.sql.calcite.SqlTransform
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.Properties
+
+import org.apache.calcite.DataContext
+import org.apache.calcite.jdbc.CalciteConnection
+import org.apache.calcite.linq4j.Enumerable
+import org.apache.calcite.linq4j.Linq4j
+import org.apache.calcite.rel.type.RelDataType
+import org.apache.calcite.rel.type.RelDataTypeFactory
+import org.apache.calcite.schema.ScannableTable
+import org.apache.calcite.schema.impl.AbstractTable
+import org.apache.calcite.sql.type.SqlTypeName
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+/**
+ * Measures where the time goes when a `transform` step is a SQL string: connection setup, parse,
+ * validate, plan, code generation, and only then the row work.
+ *
+ * Numbers from a 14-core M-series laptop, JDK 17, Calcite 1.40, with
+ * `calcite.bindable.cache.maxSize=1000` as this module sets it:
+ *
+ * ```
+ *                                             100 x 70    1000 x 700
+ * A. first query ever (cold JVM)             631,760 us     7,015 us
+ * B. new connection + executeQuery per call    6,739 us     4,174 us
+ * C. shared connection, executeQuery per call  3,623 us     2,965 us
+ * D. prepared once, frames swapped per call       77 us       598 us
+ * E. SqlTransform.run (first call, prepares)   7,099 us     5,108 us
+ * F. SqlTransform.run (statement cached)          84 us       679 us
+ * G. PreparedTransform.execute                    67 us       667 us
+ * H. hand-written join + project + sort           14 us       113 us
+ * ```
+ *
+ * B and C barely differ from each other, and neither moves when the frames grow tenfold: what repeats
+ * per request is parse, validate and plan, not row work, and the JDBC driver caches no plan between
+ * statements. With `calcite.bindable.cache.maxSize` left at Calcite's default of 0, both are roughly
+ * 4 ms slower still, because every execution recompiles the generated class with Janino.
+ *
+ * E is what the first request for an unseen statement pays, and the reason a registered query should
+ * prepare and warm up when it is registered rather than when it is first asked for.
+ *
+ * G is the shipped path. It costs about five times H, the same join written out as one pass — 53 us
+ * more at the 100 rows a `TOPK` step returns, against a 5 ms query budget. The multiple holds as the
+ * frames grow, so a transform over thousands of rows is where this stops being free.
+ */
+@Disabled("Measures Calcite's own planning cost rather than actionbase logic; run it by hand when the numbers matter.")
+class CalciteLatencyProbe {
+    @Test
+    fun `where the milliseconds go`() {
+        listOf(100, 1_000).forEach { rowCount ->
+            val hop1 = ranked(rowCount)
+            val hop2 = paid(rowCount * 7 / 10)
+            println("\n##### hop1=${hop1.rows.size} rows, hop2=${hop2.rows.size} rows #####")
+
+            // A. The very first query this JVM runs: driver load, schema build, parse, plan, Janino.
+            val cold = timeOnce { runSql(mapOf("hop1" to hop1, "hop2" to hop2), SQL) }
+            report("A. first query ever (cold JVM)", listOf(cold))
+
+            // B. What a naive request path costs: a connection per request, so nothing is reused.
+            report(
+                "B. new connection + executeQuery per call",
+                measure(30) { runSql(mapOf("hop1" to hop1, "hop2" to hop2), SQL) },
+            )
+
+            // C. Connection reused, statement not. Does Calcite remember the plan for this SQL?
+            connection().use { connection ->
+                register(connection, hop1, hop2)
+                report("C. shared connection, executeQuery per call", measure(30) { drain(connection.createStatement().executeQuery(SQL)) })
+            }
+
+            // D. Plan built once, data swapped per call: what a prepared transform would cost.
+            connection().use { connection ->
+                val tables = register(connection, hop1, hop2)
+                val statement = connection.prepareStatement(SQL)
+                report("D. prepared once, frames swapped per call", measure(200) { execute(statement, tables, hop1, hop2) })
+            }
+
+            // E. What the engine actually ships: SqlTransform, plan cached, frames per execution.
+            val transform = SqlTransform()
+            report("E. SqlTransform.run (first call, plans)", listOf(timeOnce { transform.run(mapOf("hop1" to hop1, "hop2" to hop2), SQL) }))
+            report("F. SqlTransform.run (plan cached)", measure(200) { transform.run(mapOf("hop1" to hop1, "hop2" to hop2), SQL) })
+
+            val prepared = transform.prepare(mapOf("hop1" to hop1.schema, "hop2" to hop2.schema), SQL)
+            prepared.warmUp(2)
+            report("G. PreparedTransform.execute", measure(200) { prepared.execute(mapOf("hop1" to hop1, "hop2" to hop2)) })
+            transform.close()
+
+            // H. The same left join, projection and sort written by hand, for scale.
+            report("H. hand-written join + project + sort", measure(200) { byHand(hop1, hop2).rows.size })
+            // The baseline has to answer the same thing the SQL does, or the comparison is empty.
+            val fromSql = SqlTransform().use { it.run(mapOf("hop1" to hop1, "hop2" to hop2), SQL) }
+            val expected = byHand(hop1, hop2)
+            check(fromSql.rows.map { it.data } == expected.rows.map { it.data } && fromSql.schema == expected.schema) {
+                "baseline disagrees with SQL:\n${fromSql.schema}\n${expected.schema}\n${fromSql.rows.take(3).map { it.data }}\n${expected.rows.take(3).map { it.data }}"
+            }
+        }
+    }
+
+    @Test
+    fun `a statement prepared once sees the frames that replaced the ones it was planned against`() {
+        connection().use { connection ->
+            val tables = register(connection, ranked(3), paid(2))
+            val statement = connection.prepareStatement(SQL)
+
+            val first = execute(statement, tables, ranked(3), paid(2))
+            val second = execute(statement, tables, ranked(7), paid(5))
+
+            println("prepared once: $first rows, then $second rows after swapping frames")
+            check(first == 3 && second == 7) { "The plan is serving stale rows: got $first then $second." }
+        }
+    }
+
+    /**
+     * The baseline the SQL path is measured against: the same left join, projection and sort as [SQL],
+     * written out. `DataFrame` carries no join operator on this branch, so it is spelled here rather
+     * than borrowed.
+     *
+     * It builds the same `DataFrame` the SQL path returns, rows and schema included. A version that
+     * stops at arrays measures an eighth of the time and answers a different question.
+     */
+    private fun byHand(
+        hop1: DataFrame,
+        hop2: DataFrame,
+    ): DataFrame {
+        val paidByKey = hop2.rows.associateBy({ it.data["source"] to it.data["target"] }, { it.data["paidAt"] })
+        val rows =
+            hop1.rows
+                .map { row ->
+                    val paidAt = paidByKey[row.data["source"] to row.data["target"]] ?: -1L
+                    Row(mapOf("productGroupId" to row.data["target"], "metric" to row.data["metric"], "paidAt" to paidAt), joinedSchema)
+                }.sortedWith(compareByDescending { it.data["metric"] as Long })
+
+        return DataFrame(rows, joinedSchema, total = rows.size.toLong())
+    }
+
+    /** The naive path: a connection and a statement per call, nothing reused. */
+    private fun runSql(
+        frames: Map<String, DataFrame>,
+        sql: String,
+    ): Int =
+        connection().use { connection ->
+            val rootSchema = connection.unwrap(CalciteConnection::class.java).rootSchema
+            frames.forEach { (name, frame) -> rootSchema.add(name, SwappableTable(frame)) }
+
+            connection.createStatement().use { statement -> drain(statement.executeQuery(sql)) }
+        }
+
+    private fun register(
+        connection: Connection,
+        hop1: DataFrame,
+        hop2: DataFrame,
+    ): List<SwappableTable> {
+        val tables = listOf(SwappableTable(hop1), SwappableTable(hop2))
+        val rootSchema = connection.unwrap(CalciteConnection::class.java).rootSchema
+        rootSchema.add("hop1", tables[0])
+        rootSchema.add("hop2", tables[1])
+        return tables
+    }
+
+    private fun execute(
+        statement: PreparedStatement,
+        tables: List<SwappableTable>,
+        hop1: DataFrame,
+        hop2: DataFrame,
+    ): Int {
+        tables[0].frame = hop1
+        tables[1].frame = hop2
+        return drain(statement.executeQuery())
+    }
+
+    private fun drain(resultSet: ResultSet): Int {
+        var rows = 0
+        resultSet.use {
+            while (it.next()) {
+                it.getObject(1)
+                rows++
+            }
+        }
+        return rows
+    }
+
+    private fun measure(
+        iterations: Int,
+        block: () -> Any?,
+    ): List<Long> {
+        repeat(iterations / 3) { block() }
+        return (1..iterations).map { timeOnce(block) }
+    }
+
+    private fun timeOnce(block: () -> Any?): Long {
+        val start = System.nanoTime()
+        block()
+        return System.nanoTime() - start
+    }
+
+    private fun report(
+        label: String,
+        samples: List<Long>,
+    ) {
+        val sorted = samples.sorted()
+        val micros = { nanos: Long -> "%,.0f".format(nanos / 1_000.0) }
+        println(
+            "%-44s p50=%9s us  min=%9s us  max=%9s us  (n=%d)".format(
+                label,
+                micros(sorted[sorted.size / 2]),
+                micros(sorted.first()),
+                micros(sorted.last()),
+                samples.size,
+            ),
+        )
+    }
+
+    /** A table whose schema is fixed but whose rows are replaced between executions. */
+    private class SwappableTable(
+        var frame: DataFrame,
+    ) : AbstractTable(),
+        ScannableTable {
+        private val fields = frame.schema.fields
+
+        override fun getRowType(typeFactory: RelDataTypeFactory): RelDataType =
+            typeFactory
+                .builder()
+                .also { builder ->
+                    fields.forEach { field ->
+                        val sqlType = if (field.type == PrimitiveType.STRING) SqlTypeName.VARCHAR else SqlTypeName.BIGINT
+                        builder.add(field.name, typeFactory.createTypeWithNullability(typeFactory.createSqlType(sqlType), field.nullable))
+                    }
+                }.build()
+
+        override fun scan(root: DataContext): Enumerable<Array<Any?>> = Linq4j.asEnumerable(frame.rows.map { row -> Array<Any?>(fields.size) { i -> row.data[fields[i].name] } })
+    }
+
+    private companion object {
+        val SQL =
+            """
+            SELECT hop1.target AS productGroupId, hop1.metric AS metric, IFNULL(hop2.paidAt, -1) AS paidAt
+            FROM      hop1
+            LEFT JOIN hop2 ON hop1.source = hop2.source AND hop1.target = hop2.target
+            ORDER BY  metric DESC, paidAt DESC
+            """.trimIndent()
+
+        val joinedSchema =
+            StructType(
+                listOf(
+                    StructField("productGroupId", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", false),
+                    StructField("paidAt", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        val rankedSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        val paidSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("paidAt", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        fun ranked(rowCount: Int): DataFrame =
+            DataFrame(
+                (1..rowCount).map { i -> Row(mapOf("source" to "U1", "target" to "PG$i", "metric" to (rowCount - i).toLong()), rankedSchema) },
+                rankedSchema,
+                total = rowCount.toLong(),
+            )
+
+        fun paid(rowCount: Int): DataFrame =
+            DataFrame(
+                (1..rowCount).map { i -> Row(mapOf("source" to "U1", "target" to "PG$i", "paidAt" to 1_700_000_000L - i), paidSchema) },
+                paidSchema,
+                total = rowCount.toLong(),
+            )
+
+        fun connection(): Connection =
+            DriverManager.getConnection(
+                "jdbc:calcite:",
+                Properties().apply {
+                    setProperty("lex", "JAVA")
+                    setProperty("fun", "all")
+                },
+            )
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/DataFrameSqlTransformTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/DataFrameSqlTransformTest.kt
@@ -1,0 +1,167 @@
+package com.kakao.actionbase.engine.experiments.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.sql.calcite.SqlTransform
+import com.kakao.actionbase.engine.sql.show
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+import io.kotest.matchers.shouldBe
+
+/**
+ * Onboarding walkthrough for running a `transform` step as SQL.
+ *
+ * The `fetch` half is faked: each hop is a hand-built [DataFrame], the same flat shape a `TOPK` or
+ * `GET` step hands back today (`source`, `target`, then the edge properties). Only the `transform`
+ * half is real — the frames are registered as Calcite tables under their fetch names and a SQL
+ * string is executed against them.
+ *
+ * The query being modelled, for entity `U1`:
+ *
+ * ```
+ * fetch  hop1: TOPK market_order_collection_v1 / top_product_groups_1y  -> ranked product groups
+ * fetch  hop2: GET  market_order_product_group_v1                      -> when each was last paid
+ * transform result: SQL
+ * ```
+ *
+ * Note the property namespace. The design sketch writes `hop1.properties.metric`, but a fetched
+ * frame is flat today, so the SQL below says `hop1.metric`. Adding a nested row form to
+ * [DataFrame] is what would make the dotted form work.
+ */
+class DataFrameSqlTransformTest {
+    private val transform = SqlTransform()
+
+    @AfterEach
+    fun close() {
+        transform.close()
+    }
+
+    @Test
+    fun `left join with a null fallback keeps a ranked group that was never paid for`() {
+        val sql =
+            """
+            SELECT hop1.target             AS productGroupId,
+                   hop1.metric             AS metric,
+                   IFNULL(hop2.paidAt, -1) AS paidAt
+            FROM      hop1
+            LEFT JOIN hop2 ON hop1.source = hop2.source AND hop1.target = hop2.target
+            ORDER BY  metric DESC, paidAt DESC
+            """.trimIndent()
+
+        val result = runAndShow(mapOf("hop1" to hop1, "hop2" to hop2), sql)
+
+        result.schema.fields.map { it.name } shouldBe listOf("productGroupId", "metric", "paidAt")
+        result.schema.getField("metric").type shouldBe PrimitiveType.LONG
+        // PG2 is ranked but never paid for, so it survives the join and falls back to -1.
+        result.rows.map { listOf(it.data["productGroupId"], it.data["metric"], it.data["paidAt"]) } shouldBe
+            listOf(
+                listOf("PG1", 30L, 1_700_000_000L),
+                listOf("PG2", 20L, -1L),
+                listOf("PG3", 10L, 1_600_000_000L),
+            )
+    }
+
+    @Test
+    fun `an inner join loses that group, which is why the join has to be a left join`() {
+        val sql =
+            """
+            SELECT hop1.target AS productGroupId
+            FROM hop1 JOIN hop2 ON hop1.source = hop2.source AND hop1.target = hop2.target
+            ORDER BY hop1.metric DESC
+            """.trimIndent()
+
+        runAndShow(mapOf("hop1" to hop1, "hop2" to hop2), sql).getColumn("productGroupId") shouldBe listOf("PG1", "PG3")
+    }
+
+    @Test
+    fun `an anti-join excludes what an earlier step already returned`() {
+        // The third step of "what I saw -> who else saw it -> what they saw" has to drop step one's
+        // rows from its own. Every step is in memory, so the exclusion is just a NOT EXISTS.
+        val sql =
+            """
+            SELECT hop1.target AS productGroupId
+            FROM hop1
+            WHERE NOT EXISTS (SELECT 1 FROM hop0 WHERE hop0.target = hop1.target)
+            ORDER BY hop1.metric DESC
+            """.trimIndent()
+
+        val alreadySeen = ranked("U1" to "PG1" to 99L)
+
+        runAndShow(mapOf("hop0" to alreadySeen, "hop1" to hop1), sql).getColumn("productGroupId") shouldBe listOf("PG2", "PG3")
+    }
+
+    @Test
+    fun `sorting and limiting happen in SQL rather than in an aggregator`() {
+        val sql =
+            """
+            SELECT hop1.target AS productGroupId, hop1.metric AS metric
+            FROM hop1
+            ORDER BY hop1.metric ASC
+            LIMIT 2
+            """.trimIndent()
+
+        runAndShow(mapOf("hop1" to hop1), sql).rows.map { it.data["productGroupId"] } shouldBe listOf("PG3", "PG2")
+    }
+
+    /**
+     * Prints what goes in, the SQL, and what comes back. The result is a [DataFrame] again, so the
+     * input frames and the output frame render through the same `show`.
+     */
+    private fun runAndShow(
+        frames: Map<String, DataFrame>,
+        sql: String,
+    ): DataFrame {
+        frames.forEach { (name, frame) -> frame.show("in: $name") }
+        println("--- transform SQL ---\n$sql\n")
+        return transform.run(frames, sql).show("out: result")
+    }
+
+    private companion object {
+        /** What a `TOPK` fetch returns: one row per ranked product group, carrying its rank metric. */
+        val rankedSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        /** What the `GET` fetch returns: the last payment time, for the pairs that have one. */
+        val paidSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("paidAt", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        fun ranked(vararg entries: Pair<Pair<String, String>, Long>): DataFrame = frame(rankedSchema, "metric", *entries)
+
+        fun paid(vararg entries: Pair<Pair<String, String>, Long>): DataFrame = frame(paidSchema, "paidAt", *entries)
+
+        private fun frame(
+            schema: StructType,
+            valueField: String,
+            vararg entries: Pair<Pair<String, String>, Long>,
+        ): DataFrame =
+            DataFrame(
+                entries.map { (key, value) ->
+                    Row(mapOf("source" to key.first, "target" to key.second, valueField to value), schema)
+                },
+                schema,
+                total = entries.size.toLong(),
+            )
+
+        val hop1: DataFrame = ranked("U1" to "PG1" to 30L, "U1" to "PG2" to 20L, "U1" to "PG3" to 10L)
+
+        // PG2 is missing on purpose: a product group can be bought often and yet have no recent order.
+        val hop2: DataFrame = paid("U1" to "PG1" to 1_700_000_000L, "U1" to "PG3" to 1_600_000_000L)
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/TransformSchedulerProbe.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/experiments/calcite/TransformSchedulerProbe.kt
@@ -1,0 +1,74 @@
+package com.kakao.actionbase.engine.experiments.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.sql.calcite.SqlTransform
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+import reactor.blockhound.BlockHound
+import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
+
+/**
+ * Asks BlockHound what a transform does to a non-blocking scheduler — the question that decides how a
+ * WebFlux request path may call one.
+ *
+ * On 14 cores, `Schedulers.parallel()`, 400 executions over a 100-row frame, pool capped at 14:
+ *
+ * ```
+ * parallelism=2   sessions=2   failures=1    BlockingOperationError: java.io.FileInputStream#readBytes
+ * parallelism=14  sessions=14  failures=0
+ * parallelism=64  sessions=14  failures=20   BlockingOperationError: jdk.internal.misc.Unsafe#park
+ * ```
+ *
+ * Executing a prepared transform is clean: at parallelism 14, where every execution finds a session
+ * already open, nothing blocks. The two failures are the edges around it. Opening a session reads from
+ * disk — the JDBC driver, the generated class — so a pool that grows on the request path blocks the
+ * event loop; that is why a transform has to be warmed up before it serves traffic. And once
+ * concurrency passes the pool size, waiting for a session parks the thread, so the pool has to cover
+ * the threads that can be inside `execute` at once, or the call belongs on `boundedElastic`.
+ *
+ * `BlockHound.install()` is JVM-wide, which is why this stays disabled rather than joining the suite.
+ */
+@Disabled("Installs BlockHound for the whole JVM; run it by hand when the scheduler contract is in question.")
+class TransformSchedulerProbe {
+    @Test
+    fun `what blocks when a transform runs on a non-blocking scheduler`() {
+        BlockHound.install()
+
+        listOf(2, Runtime.getRuntime().availableProcessors(), 64).forEach { parallelism ->
+            SqlTransform().use { transform ->
+                val prepared = transform.prepare(mapOf("hop1" to schema), "SELECT hop1.target AS t FROM hop1 ORDER BY hop1.metric DESC")
+                val failures =
+                    Flux
+                        .range(1, 400)
+                        .parallel(parallelism)
+                        .runOn(Schedulers.parallel())
+                        .map { runCatching { prepared.execute(mapOf("hop1" to frame)).rows.size }.exceptionOrNull()?.toString() ?: "" }
+                        .sequential()
+                        .filter { it.isNotEmpty() }
+                        .collectList()
+                        .block()!!
+
+                println("parallelism=$parallelism sessions=${prepared.sessionCount} failures=${failures.size} ${failures.firstOrNull()?.take(120) ?: ""}")
+            }
+        }
+    }
+
+    private companion object {
+        val schema =
+            StructType(
+                listOf(
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        val frame = DataFrame((1..100).map { Row(mapOf("target" to "PG$it", "metric" to it.toLong()), schema) }, schema, total = 100L)
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/DataFrameShow.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/DataFrameShow.kt
@@ -1,0 +1,54 @@
+package com.kakao.actionbase.engine.sql
+
+import com.kakao.actionbase.core.types.PrimitiveType
+
+/**
+ * Renders a [DataFrame] as a bordered table, the way `spark-shell` shows one. Types sit under the
+ * column names — a `?` marks a nullable field — because a transform that changes a column's type is
+ * as interesting as one that changes its values.
+ *
+ * Test-scope on purpose. Move it next to [DataFrame] once something in main wants it.
+ */
+fun DataFrame.show(name: String): DataFrame {
+    println(render(name))
+    return this
+}
+
+fun DataFrame.render(name: String): String {
+    val header = "=== $name === ${describe()}"
+    if (schema.fields.isEmpty()) {
+        return "$header\n(no columns)\n"
+    }
+
+    val names = schema.fields.map { it.name }
+    val types = schema.fields.map { field -> field.type.name + if (field.nullable) "?" else "" }
+    val cells = rows.map { row -> schema.fields.map { field -> row.data[field.name].toCell() } }
+    val widths = names.indices.map { column -> (cells.map { it[column].length } + names[column].length + types[column].length).max() }
+    val alignRight = schema.fields.map { it.type.isNumeric() }
+    val border = widths.joinToString(separator = "+", prefix = "+", postfix = "+") { "-".repeat(it + 2) }
+
+    return (
+        listOf(header, border, names.toLine(widths, alignRight), types.toLine(widths, alignRight), border) +
+            cells.map { it.toLine(widths, alignRight) } +
+            border
+    ).joinToString(separator = "\n", postfix = "\n")
+}
+
+private fun DataFrame.describe(): String =
+    listOfNotNull(
+        "$count of $total rows",
+        offset?.let { "offset=$it" },
+        "hasNext=$hasNext".takeIf { hasNext },
+    ).joinToString()
+
+private fun List<String>.toLine(
+    widths: List<Int>,
+    alignRight: List<Boolean>,
+): String =
+    mapIndexed { column, cell ->
+        if (alignRight[column]) cell.padStart(widths[column]) else cell.padEnd(widths[column])
+    }.joinToString(separator = " | ", prefix = "| ", postfix = " |")
+
+private fun Any?.toCell(): String = this?.toString() ?: "NULL"
+
+private fun PrimitiveType.isNumeric(): Boolean = this in setOf(PrimitiveType.BYTE, PrimitiveType.SHORT, PrimitiveType.INT, PrimitiveType.LONG, PrimitiveType.FLOAT, PrimitiveType.DOUBLE)

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/DataFrameShowTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/DataFrameShowTest.kt
@@ -1,0 +1,59 @@
+package com.kakao.actionbase.engine.sql
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+
+import org.junit.jupiter.api.Test
+
+import io.kotest.matchers.shouldBe
+
+class DataFrameShowTest {
+    @Test
+    fun `renders types under the column names and right-aligns numbers`() {
+        val frame =
+            DataFrame(
+                listOf(
+                    Row(mapOf("target" to "PG1", "metric" to 30L), schema),
+                    Row(mapOf("target" to "PRODUCT_GROUP_2", "metric" to 1_700L), schema),
+                ),
+                schema,
+                total = 2L,
+            )
+
+        frame.render("hop1") shouldBe
+            """
+            === hop1 === 2 of 2 rows
+            +-----------------+--------+
+            | target          | metric |
+            | STRING          |  LONG? |
+            +-----------------+--------+
+            | PG1             |     30 |
+            | PRODUCT_GROUP_2 |   1700 |
+            +-----------------+--------+
+
+            """.trimIndent()
+    }
+
+    @Test
+    fun `renders a missing value as NULL, aligned the way its column is`() {
+        val frame = DataFrame(listOf(Row(mapOf("target" to "PG1"), schema)), schema, total = 1L)
+
+        frame.render("hop1").lines()[5] shouldBe "| PG1    |   NULL |"
+    }
+
+    @Test
+    fun `an empty frame has nothing to tabulate`() {
+        DataFrame.empty.render("hop1") shouldBe "=== hop1 === 0 of 0 rows\n(no columns)\n"
+    }
+
+    private companion object {
+        val schema =
+            StructType(
+                listOf(
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", true),
+                ),
+            )
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/calcite/SqlTransformTest.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/engine/sql/calcite/SqlTransformTest.kt
@@ -1,0 +1,225 @@
+package com.kakao.actionbase.engine.sql.calcite
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
+
+class SqlTransformTest {
+    private val transform = SqlTransform()
+
+    @AfterEach
+    fun close() {
+        transform.close()
+    }
+
+    @Test
+    fun `a left join with a null fallback keeps a ranked group that was never paid for`() {
+        val result = transform.run(mapOf("hop1" to hop1, "hop2" to hop2), LEFT_JOIN_SQL)
+
+        result.schema.fields.map { it.name } shouldBe listOf("productGroupId", "metric", "paidAt")
+        result.schema.getField("metric").type shouldBe PrimitiveType.LONG
+        result.rows.map { listOf(it.data["productGroupId"], it.data["metric"], it.data["paidAt"]) } shouldBe
+            listOf(
+                listOf("PG1", 30L, 1_700_000_000L),
+                listOf("PG2", 20L, -1L),
+                listOf("PG3", 10L, 1_600_000_000L),
+            )
+    }
+
+    @Test
+    fun `a single-column result comes back as a column`() {
+        val sql = "SELECT hop1.target AS productGroupId FROM hop1 ORDER BY hop1.metric DESC"
+
+        transform.run(mapOf("hop1" to hop1), sql).getColumn("productGroupId") shouldBe listOf("PG1", "PG2", "PG3")
+    }
+
+    @Test
+    fun `an anti-join excludes what an earlier step already returned`() {
+        val sql =
+            """
+            SELECT hop1.target AS productGroupId
+            FROM hop1
+            WHERE NOT EXISTS (SELECT 1 FROM hop0 WHERE hop0.target = hop1.target)
+            ORDER BY hop1.metric DESC
+            """.trimIndent()
+
+        transform.run(mapOf("hop0" to ranked("PG1" to 99L), "hop1" to hop1), sql).getColumn("productGroupId") shouldBe listOf("PG2", "PG3")
+    }
+
+    @Test
+    fun `the output schema is known before any row is read`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema, "hop2" to paidSchema), LEFT_JOIN_SQL)
+
+        prepared.inputs shouldBe setOf("hop1", "hop2")
+        prepared.parameterCount shouldBe 0
+        prepared.schema.fields.map { it.name to it.type } shouldBe
+            listOf("productGroupId" to PrimitiveType.STRING, "metric" to PrimitiveType.LONG, "paidAt" to PrimitiveType.LONG)
+    }
+
+    @Test
+    fun `a placeholder is bound per execution rather than baked into the plan`() {
+        val sql = "SELECT hop1.target AS productGroupId FROM hop1 WHERE hop1.metric >= ? ORDER BY hop1.metric DESC"
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), sql)
+
+        prepared.parameterCount shouldBe 1
+        prepared.execute(mapOf("hop1" to hop1), listOf(20L)).getColumn("productGroupId") shouldBe listOf("PG1", "PG2")
+        prepared.execute(mapOf("hop1" to hop1), listOf(30L)).getColumn("productGroupId") shouldBe listOf("PG1")
+        transform.transformCount shouldBe 1L
+    }
+
+    @Test
+    fun `the wrong number of arguments is refused before the statement runs`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), "SELECT hop1.target AS t FROM hop1 WHERE hop1.metric >= ?")
+
+        shouldThrow<IllegalArgumentException> { prepared.execute(mapOf("hop1" to hop1)) }
+            .message shouldBe "This transform takes 1 arguments, got 0."
+    }
+
+    @Test
+    fun `the same sql over the same schemas is prepared once`() {
+        transform.run(mapOf("hop1" to hop1, "hop2" to hop2), LEFT_JOIN_SQL)
+        transform.run(mapOf("hop1" to ranked("PG9" to 1L), "hop2" to paid("PG9" to 5L)), LEFT_JOIN_SQL)
+
+        transform.transformCount shouldBe 1L
+    }
+
+    @Test
+    fun `the same sql over different schemas is prepared separately`() {
+        val renamed = StructType(rankedSchema.fields.map { if (it.name == "metric") it.copy(name = "score") else it })
+        val sql = "SELECT hop1.target AS productGroupId FROM hop1"
+
+        transform.prepare(mapOf("hop1" to rankedSchema), sql)
+        transform.prepare(mapOf("hop1" to renamed), sql)
+
+        transform.transformCount shouldBe 2L
+    }
+
+    /**
+     * The shape a WebFlux request path has: many executions in flight at once, none of them pinned to
+     * the thread it started on. Each has to see its own rows.
+     *
+     * Warmed up first and run at exactly the pool size, which is the contract a non-blocking scheduler
+     * needs: no session is opened and none is waited for while a request is on the thread.
+     */
+    @Test
+    fun `concurrent executions of one prepared transform do not mix their frames`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), "SELECT hop1.target AS productGroupId FROM hop1 ORDER BY hop1.metric DESC")
+        prepared.sessionCount shouldBe PreparedTransform.DEFAULT_MAXIMUM_SESSIONS
+
+        val mixed =
+            Flux
+                .range(1, 400)
+                .parallel(PreparedTransform.DEFAULT_MAXIMUM_SESSIONS)
+                .runOn(Schedulers.parallel())
+                .map { task ->
+                    val frame = ranked(*(1..task % 7 + 1).map { "T$task-$it" to it.toLong() }.toTypedArray())
+                    prepared.execute(mapOf("hop1" to frame)).getColumn("productGroupId").toSet() != frame.getColumn("target").toSet()
+                }.sequential()
+                .filter { it }
+                .count()
+                .block()
+
+        mixed shouldBe 0L
+    }
+
+    @Test
+    fun `a transform executed with a frame it was not prepared for is refused`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), "SELECT hop1.target AS productGroupId FROM hop1")
+
+        shouldThrow<IllegalArgumentException> { prepared.execute(mapOf("hop1" to paid("PG1" to 1L))) }
+            .message shouldBe "`hop1` was prepared for [source, target, metric] but was given [source, target, paidAt]."
+    }
+
+    @Test
+    fun `executing without one of the prepared frames says which one is missing`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema, "hop2" to paidSchema), LEFT_JOIN_SQL)
+
+        shouldThrow<IllegalArgumentException> { prepared.execute(mapOf("hop1" to hop1)) }
+            .message shouldBe "This transform reads hop1, hop2; the execution is missing hop2."
+    }
+
+    @Test
+    fun `preparing fills the pool so no execution has to open a session`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), "SELECT hop1.target AS productGroupId FROM hop1")
+
+        prepared.sessionCount shouldBe PreparedTransform.DEFAULT_MAXIMUM_SESSIONS
+    }
+
+    @Test
+    fun `a transform not yet prepared is reported as absent rather than prepared on the spot`() {
+        val schemas = mapOf("hop1" to rankedSchema)
+        val sql = "SELECT hop1.target AS productGroupId FROM hop1"
+
+        transform.prepared(schemas, sql) shouldBe null
+        transform.transformCount shouldBe 0L
+
+        val prepared = transform.prepare(schemas, sql)
+
+        transform.prepared(schemas, sql) shouldBe prepared
+    }
+
+    @Test
+    fun `a closed transform refuses to execute`() {
+        val prepared = transform.prepare(mapOf("hop1" to rankedSchema), "SELECT hop1.target AS productGroupId FROM hop1")
+        transform.close()
+
+        shouldThrow<IllegalStateException> { prepared.execute(mapOf("hop1" to hop1)) }
+    }
+
+    private companion object {
+        val LEFT_JOIN_SQL =
+            """
+            SELECT hop1.target AS productGroupId, hop1.metric AS metric, IFNULL(hop2.paidAt, -1) AS paidAt
+            FROM      hop1
+            LEFT JOIN hop2 ON hop1.source = hop2.source AND hop1.target = hop2.target
+            ORDER BY  metric DESC, paidAt DESC
+            """.trimIndent()
+
+        val rankedSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("metric", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        val paidSchema =
+            StructType(
+                listOf(
+                    StructField("source", PrimitiveType.STRING, "", false),
+                    StructField("target", PrimitiveType.STRING, "", false),
+                    StructField("paidAt", PrimitiveType.LONG, "", false),
+                ),
+            )
+
+        fun ranked(vararg entries: Pair<String, Long>): DataFrame = frame(rankedSchema, "metric", *entries)
+
+        fun paid(vararg entries: Pair<String, Long>): DataFrame = frame(paidSchema, "paidAt", *entries)
+
+        private fun frame(
+            schema: StructType,
+            valueField: String,
+            vararg entries: Pair<String, Long>,
+        ): DataFrame =
+            DataFrame(
+                entries.map { (target, value) -> Row(mapOf("source" to "U1", "target" to target, valueField to value), schema) },
+                schema,
+                total = entries.size.toLong(),
+            )
+
+        val hop1: DataFrame = ranked("PG1" to 30L, "PG2" to 20L, "PG3" to 10L)
+
+        val hop2: DataFrame = paid("PG1" to 1_700_000_000L, "PG3" to 1_600_000_000L)
+    }
+}

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/query/ActionbaseQueryExecutorTransformSchedulerSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/query/ActionbaseQueryExecutorTransformSchedulerSpec.kt
@@ -1,0 +1,70 @@
+package com.kakao.actionbase.v2.engine.v3.query
+
+import com.kakao.actionbase.core.metadata.common.StructField
+import com.kakao.actionbase.core.metadata.common.StructType
+import com.kakao.actionbase.core.types.PrimitiveType
+import com.kakao.actionbase.engine.QueryEngine
+import com.kakao.actionbase.engine.binding.TableBinding
+import com.kakao.actionbase.engine.query.ActionbaseQuery
+import com.kakao.actionbase.engine.query.ActionbaseQueryExecutor
+import com.kakao.actionbase.engine.sql.DataFrame
+import com.kakao.actionbase.engine.sql.Row
+import com.kakao.actionbase.engine.sql.calcite.SqlTransform
+
+import java.util.concurrent.atomic.AtomicReference
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import reactor.test.StepVerifier
+
+/**
+ * A SQL transform blocks the thread it runs on: an unseen statement is parsed, planned and given its
+ * sessions on the spot, and a known one waits when every session is busy — both measured by
+ * `TransformSchedulerProbe`. On a WebFlux request that thread is an event loop, so the executor owes
+ * the work a scheduler that may block.
+ */
+class ActionbaseQueryExecutorTransformSchedulerSpec :
+    StringSpec({
+
+        val engine =
+            object : QueryEngine {
+                override fun getTableBinding(
+                    database: String,
+                    alias: String,
+                ): TableBinding = throw NotImplementedError()
+            }
+
+        val schema = StructType(listOf(StructField("target", PrimitiveType.STRING, "", false)))
+        val shaped = DataFrame(listOf(Row(mapOf("target" to "item1"), schema)), schema, total = 1L)
+
+        "a SQL transform runs off the thread that subscribed" {
+            val ranOn = AtomicReference<String>()
+            val transforms =
+                mockk<SqlTransform> {
+                    every { run(any(), any(), any()) } answers {
+                        ranOn.set(Thread.currentThread().name)
+                        shaped
+                    }
+                }
+
+            val query =
+                ActionbaseQuery(
+                    fetch = emptyList(),
+                    transform = listOf(ActionbaseQuery.Transform.Sql(name = "shaped", sql = "SELECT 1")),
+                )
+
+            val subscriber = Thread.currentThread().name
+
+            StepVerifier
+                .create(ActionbaseQueryExecutor(engine, transforms).query(query))
+                .assertNext { it.keys shouldBe setOf("shaped") }
+                .verifyComplete()
+
+            ranOn.get() shouldNotBe subscriber
+            ranOn.get() shouldContain "boundedElastic"
+        }
+    })

--- a/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/query/ActionbaseQueryTransformNameSpec.kt
+++ b/engine/src/test/kotlin/com/kakao/actionbase/v2/engine/v3/query/ActionbaseQueryTransformNameSpec.kt
@@ -1,0 +1,52 @@
+package com.kakao.actionbase.v2.engine.v3.query
+
+import com.kakao.actionbase.engine.query.ActionbaseQuery
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * A transform's frame is added to the fetch context under the transform's name, and the response is
+ * keyed the same way. Nothing downstream can tell a reused name from an intended one, so the query
+ * refuses it rather than letting one frame quietly stand in for another.
+ */
+class ActionbaseQueryTransformNameSpec :
+    StringSpec({
+
+        fun fetch(name: String) =
+            ActionbaseQuery.Item.Self(
+                name = name,
+                database = "commerce",
+                table = "orders",
+                source = ActionbaseQuery.Vertex.Value(listOf("user1")),
+                include = true,
+            )
+
+        fun transform(name: String) = ActionbaseQuery.Transform.Sql(name = name, sql = "SELECT 1")
+
+        "a transform cannot take the name of a fetch step" {
+            shouldThrow<IllegalArgumentException> {
+                ActionbaseQuery(fetch = listOf(fetch("hop1")), transform = listOf(transform("hop1")))
+            }.message shouldContain "`hop1` already names a fetch step"
+        }
+
+        "two transforms cannot share a name" {
+            shouldThrow<IllegalArgumentException> {
+                ActionbaseQuery(fetch = listOf(fetch("hop1")), transform = listOf(transform("shaped"), transform("shaped")))
+            }.message shouldContain "`shaped` already names a fetch step or an earlier transform"
+        }
+
+        "a transform keeps its own name" {
+            ActionbaseQuery(fetch = listOf(fetch("hop1")), transform = listOf(transform("shaped"), transform("ranked")))
+        }
+
+        "a fetch step that is not returned still holds its name" {
+            shouldThrow<IllegalArgumentException> {
+                ActionbaseQuery(
+                    fetch = listOf(fetch("hop1").copy(include = false)),
+                    transform = listOf(transform("hop1")),
+                )
+            }
+        }
+    })


### PR DESCRIPTION
## Summary

A multi-hop query returns one frame per step and nothing more. Joining two hops, ranking their rows or projecting a subset all happens on the caller. This lets a query name SQL that runs over the frames it just fetched, in process, before the response goes out.

```json
{
  "fetch": [
    { "type": "SCAN", "name": "follows", "database": "graph", "table": "follows", "index": "created_at", "source": { "type": "VALUE", "value": "user1" } },
    { "type": "TOPK", "name": "ranked", "database": "graph", "table": "orders", "topk": "top_product_groups_1y", "entity": { "type": "REF", "ref": "follows", "field": "tgt" }, "limit": 100 }
  ],
  "transform": [
    {
      "type": "SQL",
      "name": "top_items",
      "sql": "SELECT ranked.tgt, SUM(ranked.metric) AS metric FROM ranked GROUP BY ranked.tgt ORDER BY metric DESC LIMIT ?",
      "arguments": ["10"]
    }
  ]
}
```

Each step's frame is a table named after the step, so SQL addresses `ranked.metric` directly. Transforms run in order and each one's output joins the context under its `name`, so a later transform can read an earlier one. They see the whole context including `include = false` steps — a step can exist only to be subtracted from a later one —
and what the caller gets back is filtered afterwards.

Calcite is the engine, over a JDBC connection whose root schema holds one slot per frame. Most of the design here is about not paying its planning cost per request.

`SqlTransform` caches a `PreparedTransform` per `(sql, input columns)`. Calcite's driver keeps no plan between statements, so without this every request re-parses, re-plans and re-compiles the same SQL. Each prepared transform owns a pool of sessions rather than one shared session, because a `PreparedStatement` takes a single thread.
Sessions open at prepare time, not on the request path — opening one touches disk for the driver and the generated class. `prepare` pays that cost and `prepared` answers only if it was already paid, so a caller can keep it off a thread that must not block.

The pool is capped per transform, so a burst of concurrent requests on the same SQL queues instead of scaling out. I'd rather queue than open connections on the request path. If that queue shows up in latency, the cap is the knob.

Two smaller decisions. The connection sets `lex=JAVA` so identifiers stay as written and `hop1.paidAt` is not folded to `PAIDAT`, and `fun=all` so the dialect operator tables are available — the standard one has no `IFNULL`. And `calcite.bindable.cache.maxSize=1000` is set in three places: the Gradle test JVM, the Jib image, and as a
default in the pool. That cache is process-wide and its default is small enough that a handful of distinct transforms evict each other.

Nothing here bounds what a transform can ask for — no row cap on the result, no timeout, no check on the SQL beyond what Calcite refuses to plan. That needs to exist before this is reachable by an untrusted caller, and I'll do it in a follow-up.

The two probes are `@Disabled`, and that is deliberate. `TransformSchedulerProbe` installs BlockHound for the whole JVM, and `CalciteLatencyProbe` measures Calcite's planning cost rather than anything in this repo. They document how the numbers above were arrived at; run them by hand from the IDE when the numbers matter.

Stacked on #498 — that needs to land first.

Part of #490.

## Test plan

- `./gradlew :engine:test --tests '*SqlTransformTest*'` — plan cache, session pool, prepared-vs-prepare, argument binding, closing
- `./gradlew :engine:test --tests '*DataFrameSqlTransformTest*'` — SQL over frames: projection, join across steps, aggregation, ordering
- `./gradlew :engine:test --tests '*DataFrameShowTest*'` — the frame formatter the tests read failures through
- `./gradlew spotlessCheck build` — formatting and full build

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)