### PR TITLE
docs: pair codec-java 0.6.0 with the 0.5.x server line

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -127,6 +127,7 @@ Each module releases independently.
 
 | codec-java | Actionbase (server) |
 | ---------- | ------------------- |
+| 0.6.0      | 0.5.x               |
 | 0.3.0      | 0.4.x               |
 | 0.2.0      | 0.3.x               |
 


### PR DESCRIPTION
## Summary

I'm getting ready to release `0.5.0` and the compatibility table has no row for it. It stops at codec-java `0.3.0` against the `0.4.x` server.

The pairing is unambiguous from the trees. `v0.4.7` carries codec-java at `0.3.0-SNAPSHOT`, so the existing `0.3.0` row is right. Every codec-java release since — `0.4.0`, `0.5.0`, `0.6.0` — was cut from a tree where the server read `0.5.0-SNAPSHOT`, so they all belong to the `0.5.x` line, and `0.6.0` is the latest of them. `main` is on `0.7.0-SNAPSHOT` now, which is the next line's row to write when it ships.

## Changes

- Add `0.6.0 | 0.5.x` to the compatibility table in `RELEASES.md`.

## How to Test

Read the table. Nothing builds from it.

## AI Assistance

- [x] This PR was written largely with AI assistance.
  - Tool / model: Claude Code (Opus 5)
